### PR TITLE
Quote-identify the column names in bulk update

### DIFF
--- a/packages/orm/src/EntityPersister.ts
+++ b/packages/orm/src/EntityPersister.ts
@@ -104,7 +104,7 @@ async function batchUpdate(knex: Knex, tx: Transaction, meta: EntityMetadata<any
       UPDATE ${meta.tableName}
       SET ${columns
         .filter((c) => c.columnName !== "id")
-        .map((c) => `"${c.columnName}" = data.${c.columnName}`)
+        .map((c) => `"${c.columnName}" = data."${c.columnName}"`)
         .join(", ")}
       FROM (select ${columns.map((c) => `unnest(?::${c.dbType}[]) as "${c.columnName}"`).join(", ")}) as data
       WHERE ${meta.tableName}.id = data.id


### PR DESCRIPTION
When the column names are not all lowercase, bulk update fails due to the alias being quote-identified in the `from` clause but not in the assignments in the `update` clause.

In practice, using the migration helpers will prevent this scenario from occurring, as they do a good job of forcing everything into the snake_case paradigm. This would only affect users who are using Joist to maintain existing tables (who will probably run into issues with `created_at` and `updated_at` anyway) or people like me who naively create "raw" node-pg-migrate migrations and define their columns in the JS-conventional camelCase.

Similarly, I couldn't figure out how to get an integration test written to cover this scenario without creating a lot of code that would otherwise feel out of place in the integration-tests project.