### PR TITLE
Run reactive validation rules on entity deletion.

### DIFF
--- a/packages/integration-tests/src/collections/ManyToManyCollection.test.ts
+++ b/packages/integration-tests/src/collections/ManyToManyCollection.test.ts
@@ -1,4 +1,5 @@
 import { EntityManager } from "joist-orm";
+import { zeroTo } from "../utils";
 import { knex, numberOfQueries, resetQueryCount } from "../setupDbTests";
 import { Author, Book, Tag } from "../entities";
 import { insertAuthor, insertBook, insertBookToTag, insertTag } from "../entities/factories";
@@ -268,7 +269,3 @@ describe("ManyToManyCollection", () => {
     expect(rows[1]).toEqual(expect.objectContaining({ book_id: 2, tag_id: 5 }));
   });
 });
-
-export function zeroTo(n: number): number[] {
-  return [...Array(n).keys()];
-}

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -1,5 +1,5 @@
 import { EntityManager, Loaded } from "joist-orm";
-import { AuthorCodegen, authorConfig, AuthorOpts, Book } from "./entities";
+import { AuthorCodegen, authorConfig, AuthorOpts } from "./entities";
 
 export class Author extends AuthorCodegen {
   public beforeFlushRan = false;
@@ -59,9 +59,17 @@ authorConfig.addRule((a) => {
   }
 });
 
+// Example of reactive rule being fired on Book change
 authorConfig.addRule("books", async (a) => {
   if (a.books.get.length > 0 && a.books.get.find((b) => b.title === a.firstName)) {
     return "A book title cannot be the author's firstName";
+  }
+});
+
+// Example of reactive rule being fired on Book insertion/deletion
+authorConfig.addRule("books", async (a) => {
+  if (a.books.get.length === 13) {
+    return "An author cannot have 13 books";
   }
 });
 

--- a/packages/integration-tests/src/utils.ts
+++ b/packages/integration-tests/src/utils.ts
@@ -1,4 +1,7 @@
-
 export function fail(message?: string): never {
   throw new Error(message || "Failed");
+}
+
+export function zeroTo(n: number): number[] {
+  return [...Array(n).keys()];
 }

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -867,7 +867,7 @@ async function addReactiveValidations(todos: Record<string, Todo>): Promise<void
     // Find each statically-declared reactive rule for the given entity type
     return todo.metadata.config.__data.reactiveRules.map(async (reverseHint) => {
       // Add the resulting "found" entities to the right todos to be validated
-      (await followReverseHint([...todo.inserts, ...todo.updates], reverseHint)).forEach((entity) => {
+      (await followReverseHint([...todo.inserts, ...todo.updates, ...todo.deletes], reverseHint)).forEach((entity) => {
         const todo = getTodo(todos, entity);
         if (!todo.inserts.includes(entity) && !todo.updates.includes(entity) && !entity.isDeletedEntity) {
           todo.validates.push(entity);

--- a/packages/orm/src/collections/ManyToManyCollection.ts
+++ b/packages/orm/src/collections/ManyToManyCollection.ts
@@ -28,7 +28,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity> extends Ab
   }
 
   async load(): Promise<ReadonlyArray<U>> {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.entity, { ignore: "pending" });
     if (this.loaded === undefined) {
       // TODO This key is basically a Reference, whenever we have that.
       // TODO Unsaved entities should never get here

--- a/packages/orm/src/collections/ManyToOneReference.ts
+++ b/packages/orm/src/collections/ManyToOneReference.ts
@@ -28,7 +28,7 @@ export class ManyToOneReference<T extends Entity, U extends Entity, N extends ne
   }
 
   async load(): Promise<U | N> {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.entity, { ignore: "pending" });
     const current = this.current();
     // Resolve the id to an entity
     if (!isEntity(current) && current !== undefined) {
@@ -130,7 +130,7 @@ export class ManyToOneReference<T extends Entity, U extends Entity, N extends ne
   }
 
   private returnUndefinedIfDeleted(e: U | N): U | N {
-    if (e !== undefined && e.isDeletedEntity) {
+    if (e !== undefined && e.isDeletedEntity && !e.isPendingDelete) {
       if (this.notNull) {
         throw new Error(`Referenced entity ${e} has been marked as deleted`);
       }


### PR DESCRIPTION
Just a first pass. Wondering if `ensureNotDeleted` should always allow pending-deletion entities/collections to be whitelisted.