### PR TITLE
Implement tagged ids

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -127,6 +127,10 @@ export class EntityDbMetadata {
       .map((r) => newManyToManyField(r));
     this.tableName = table.name;
   }
+
+  get name(): string {
+    return this.entity.name;
+  }
 }
 
 function isMultiColumnForeignKey(r: M2ORelation) {

--- a/packages/codegen/src/assignTags.ts
+++ b/packages/codegen/src/assignTags.ts
@@ -1,0 +1,43 @@
+import { snakeCase } from "change-case";
+import { DbMetadata } from "./index";
+import { Config } from "./config";
+
+/**
+ * Looks for any entities that don't have tags in `config` yet, and guesses at what a good tag would be.
+ *
+ * The current guess is `BookReview` -> `br`.
+ *
+ * We also mutate `config` by putting the guessed tag (assuming it's not already taken) on the entity's config.
+ *
+ * If a guessed tag name is already taken, we'll prompt the user to set their own tag in joist-codegen.json.
+ */
+export function assignTags(config: Config, dbMetadata: DbMetadata): { needsManuallyAssigned: string[] } {
+  const existingTags = Object.fromEntries(
+    Object.entries(config.entities).map(([name, conf]) => {
+      return [name, conf.tag];
+    }),
+  );
+
+  const needsManuallyAssigned: string[] = [];
+
+  dbMetadata.entities
+    .filter((e) => !existingTags[e.entity.name])
+    .forEach((e) => {
+      // Abbreviate BookReview -> book_review -> br
+      const potentialTag = snakeCase(e.entity.name)
+        .split("_")
+        .map((w) => w[0])
+        .join("");
+      if (Object.values(existingTags).includes(potentialTag)) {
+        needsManuallyAssigned.push(e.entity.name);
+      } else {
+        let oc = config.entities[e.entity.name];
+        if (!oc) {
+          oc = config.entities[e.entity.name] = { tag: potentialTag, fields: {} };
+        }
+        oc.tag = potentialTag;
+      }
+    });
+
+  return { needsManuallyAssigned };
+}

--- a/packages/codegen/src/assignTags.ts
+++ b/packages/codegen/src/assignTags.ts
@@ -26,7 +26,7 @@ export function assignTags(config: Config, dbMetadata: DbMetadata): void {
       const tagName = existingTagNames.includes(abbreviatedTag) ? camelCase(e.name) : abbreviatedTag;
       const oc = config.entities[e.name];
       if (!oc) {
-        config.entities[e.name] = { tag: tagName, fields: {} };
+        config.entities[e.name] = { tag: tagName };
       } else {
         oc.tag = tagName;
       }

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -10,7 +10,7 @@ export interface FieldConfig {
 
 export interface EntityConfig {
   tag: string;
-  fields: Record<string, FieldConfig>;
+  fields?: Record<string, FieldConfig>;
 }
 
 export interface Config {

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -50,7 +50,7 @@ export async function loadConfig(): Promise<Config> {
 }
 
 /**
- * Writes the potentially-updated config entry back to `joist-codegen.json.
+ * Writes the potentially-updated config entry back to `joist-codegen.json`.
  *
  * We format the output with prettier so it should both a) look nice and b) be deterministic,
  * such that no changes to the config show up as noops to the scm.

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -1,31 +1,63 @@
 import { Entity } from "EntityDbMetadata";
+import { promises as fs } from "fs";
+import prettier, { resolveConfig } from "prettier";
+import { trueIfResolved } from "./utils";
+
+export interface FieldConfig {
+  derived?: "sync" | "async";
+  protected?: boolean;
+}
+
+export interface EntityConfig {
+  tag: string;
+  fields: Record<string, FieldConfig>;
+}
 
 export interface Config {
   entitiesDirectory: string;
-  derivedFields: string[];
-  asyncDerivedFields: string[];
-  protectedFields: string[];
   codegenPlugins: string[];
+  entities: Record<string, EntityConfig>;
 }
 
 export const defaultConfig: Config = {
   entitiesDirectory: "./src/entities",
-  derivedFields: [],
-  asyncDerivedFields: [],
-  protectedFields: [],
   codegenPlugins: [],
+  entities: {},
 };
 
 export const ormMaintainedFields = ["createdAt", "updatedAt"];
 
 export function isDerived(config: Config, entity: Entity, fieldName: string): boolean {
-  return config.derivedFields.includes(`${entity.name}.${fieldName}`);
+  return config.entities[entity.name]?.fields?.[fieldName]?.derived === "sync";
 }
 
 export function isAsyncDerived(config: Config, entity: Entity, fieldName: string): boolean {
-  return config.asyncDerivedFields.includes(`${entity.name}.${fieldName}`);
+  return config.entities[entity.name]?.fields?.[fieldName]?.derived === "async";
 }
 
 export function isProtected(config: Config, entity: Entity, fieldName: string): boolean {
-  return config.protectedFields.includes(`${entity.name}.${fieldName}`);
+  return config.entities[entity.name]?.fields?.[fieldName]?.protected === true;
+}
+
+const configPath = "./joist-codegen.json";
+export async function loadConfig(): Promise<Config> {
+  const exists = await trueIfResolved(fs.access(configPath));
+  if (exists) {
+    const content = await fs.readFile(configPath);
+    return { ...defaultConfig, ...(JSON.parse(content.toString()) as Config) };
+  }
+  return defaultConfig;
+}
+
+/**
+ * Writes the potentially-updated config entry back to `joist-codegen.json.
+ *
+ * We format the output with prettier so it should both a) look nice and b) be deterministic,
+ * such that no changes to the config show up as noops to the scm.
+ */
+export async function writeConfig(config: Config): Promise<void> {
+  const prettierConfig = await resolveConfig("./");
+  const input = JSON.stringify(config);
+  const content = prettier.format(input.trim(), { parser: "json", ...prettierConfig });
+  await fs.writeFile(configPath, content);
 }

--- a/packages/codegen/src/generateMetadataFile.ts
+++ b/packages/codegen/src/generateMetadataFile.ts
@@ -1,7 +1,8 @@
+import { camelCase } from "change-case";
 import { code, Code, imp } from "ts-poet";
+import { Config } from "./config";
 import { EntityDbMetadata } from "./EntityDbMetadata";
 import { EntityMetadata, EnumFieldSerde, ForeignKeySerde, PrimaryKeySerde, SimpleSerde } from "./symbols";
-import { Config } from "./config";
 
 export function generateMetadataFile(config: Config, dbMetadata: EntityDbMetadata): Code {
   const { entity } = dbMetadata;
@@ -16,6 +17,7 @@ export function generateMetadataFile(config: Config, dbMetadata: EntityDbMetadat
     export const ${entity.metaName}: ${EntityMetadata}<${entity.type}> = {
       cstr: ${entity.type},
       type: "${entity.name}",
+      tagName: "${camelCase(entity.name)}",
       tableName: "${dbMetadata.tableName}",
       columns: [ ${primaryKey} ${enums} ${primitives} ${m2o} ],
       fields: [ ${primaryKeyField} ${enumFields} ${primitiveFields} ${m2oFields} ${o2mFields} ${m2mFields} ],
@@ -31,7 +33,7 @@ function generateColumns(
   dbMetadata: EntityDbMetadata,
 ): { primaryKey: Code; primitives: Code[]; enums: Code[]; m2o: Code[] } {
   const primaryKey = code`
-    { fieldName: "id", columnName: "id", dbType: "int", serde: new ${PrimaryKeySerde}("id", "id") },
+    { fieldName: "id", columnName: "id", dbType: "int", serde: new ${PrimaryKeySerde}(() => ${dbMetadata.entity.metaName}, "id", "id") },
   `;
 
   const primitives = dbMetadata.primitives.map((p) => {

--- a/packages/codegen/src/generateMetadataFile.ts
+++ b/packages/codegen/src/generateMetadataFile.ts
@@ -17,7 +17,7 @@ export function generateMetadataFile(config: Config, dbMetadata: EntityDbMetadat
     export const ${entity.metaName}: ${EntityMetadata}<${entity.type}> = {
       cstr: ${entity.type},
       type: "${entity.name}",
-      tagName: "${camelCase(entity.name)}",
+      tagName: "${config.entities[entity.name].tag}",
       tableName: "${dbMetadata.tableName}",
       columns: [ ${primaryKey} ${enums} ${primitives} ${m2o} ],
       fields: [ ${primaryKeyField} ${enumFields} ${primitiveFields} ${m2oFields} ${o2mFields} ${m2mFields} ],

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,8 +1,7 @@
 import { promises as fs } from "fs";
 import { newPgConnectionConfig } from "joist-utils";
 import { Client } from "pg";
-import pgStructure, { Db } from "pg-structure";
-import Table from "pg-structure/dist/pg-structure/entity/table";
+import pgStructure, { Db, Table } from "pg-structure";
 import { code, Code } from "ts-poet";
 import { assignTags } from "./assignTags";
 import { Config, loadConfig, writeConfig } from "./config";
@@ -141,12 +140,8 @@ if (require.main === module) {
     const entities = entityTables.map((table) => new EntityDbMetadata(config, table));
     const dbMetadata: DbMetadata = { entityTables, enumTables, entities, enumRows };
 
-    const { needsManuallyAssigned } = assignTags(config, dbMetadata);
+    assignTags(config, dbMetadata);
     await writeConfig(config);
-
-    if (needsManuallyAssigned.length > 0) {
-      throw new Error(`Please manually assign tags for ${needsManuallyAssigned.join(", ")} in joist-codegen.json`);
-    }
 
     await generateAndSaveFiles(config, dbMetadata);
   })().catch((err) => {

--- a/packages/integration-tests/joist-codegen.json
+++ b/packages/integration-tests/joist-codegen.json
@@ -1,6 +1,20 @@
 {
-  "derivedFields": ["Author.initials"],
-  "asyncDerivedFields": ["Author.numberOfBooks", "BookReview.isPublic"],
-  "protectedFields": ["Author.wasEverPopular"],
-  "codegenPlugins": ["joist-graphql-codegen"]
+  "entitiesDirectory": "./src/entities",
+  "codegenPlugins": ["joist-graphql-codegen"],
+  "entities": {
+    "Author": {
+      "fields": {
+        "initials": { "derived": "sync" },
+        "numberOfBooks": { "derived": "async" },
+        "wasEverPopular": { "protected": true }
+      },
+      "tag": "a"
+    },
+    "BookReview": { "fields": { "isPublic": { "derived": "async" } }, "tag": "br" },
+    "Book": { "tag": "b", "fields": {} },
+    "Image": { "tag": "i", "fields": {} },
+    "Publisher": { "tag": "p", "fields": {} },
+    "Tag": { "tag": "t", "fields": {} },
+    "BookAdvance": { "tag": "ba", "fields": {} }
+  }
 }

--- a/packages/integration-tests/joist-codegen.json
+++ b/packages/integration-tests/joist-codegen.json
@@ -11,10 +11,10 @@
       "tag": "a"
     },
     "BookReview": { "fields": { "isPublic": { "derived": "async" } }, "tag": "br" },
-    "Book": { "tag": "b", "fields": {} },
-    "Image": { "tag": "i", "fields": {} },
-    "Publisher": { "tag": "p", "fields": {} },
-    "Tag": { "tag": "t", "fields": {} },
-    "BookAdvance": { "tag": "ba", "fields": {} }
+    "Book": { "tag": "b" },
+    "Image": { "tag": "i" },
+    "Publisher": { "tag": "p" },
+    "Tag": { "tag": "t" },
+    "BookAdvance": { "tag": "ba" }
   }
 }

--- a/packages/integration-tests/src/EntityManager.lens.test.ts
+++ b/packages/integration-tests/src/EntityManager.lens.test.ts
@@ -96,6 +96,6 @@ describe("EntityManager.lens", () => {
     const em = new EntityManager(knex);
     const b1 = await em.load(Book, "1");
     const p1Id = await b1.load((b) => b.author.publisher.idOrFail);
-    expect(p1Id).toEqual("publisher:1");
+    expect(p1Id).toEqual("p:1");
   });
 });

--- a/packages/integration-tests/src/EntityManager.lens.test.ts
+++ b/packages/integration-tests/src/EntityManager.lens.test.ts
@@ -88,4 +88,14 @@ describe("EntityManager.lens", () => {
     const publisherName: string | undefined = await a1.load((a) => a.publisher.name);
     expect(publisherName).toEqual(undefined);
   });
+
+  it("can navigate into getters", async () => {
+    await insertPublisher({ name: "p1" });
+    await insertAuthor({ first_name: "a1", publisher_id: 1 });
+    await insertBook({ title: "b1", author_id: 1 });
+    const em = new EntityManager(knex);
+    const b1 = await em.load(Book, "1");
+    const p1Id = await b1.load((b) => b.author.publisher.idOrFail);
+    expect(p1Id).toEqual("publisher:1");
+  });
 });

--- a/packages/integration-tests/src/EntityManager.populate.test.ts
+++ b/packages/integration-tests/src/EntityManager.populate.test.ts
@@ -69,7 +69,7 @@ describe("EntityManager.populate", () => {
     expect(numberOfQueries).toEqual(2);
     expect(pub.authors.get.length).toEqual(2);
     expect(pub.authors.get[0].books.get.length).toEqual(2);
-    expect(pub.authors.get[0].publisher.get!.id).toEqual("1");
+    expect(pub.authors.get[0].publisher.get!.id).toEqual("publisher:1");
   });
 
   it("can populate via load", async () => {
@@ -139,7 +139,7 @@ describe("EntityManager.populate", () => {
     const em = new EntityManager(knex);
     const book = await em.load(Book, "1", "author");
     const authorId: string = book.author.id;
-    expect(authorId).toEqual("1");
+    expect(authorId).toEqual("author:1");
   });
 
   it("can populate two literals", async () => {

--- a/packages/integration-tests/src/EntityManager.populate.test.ts
+++ b/packages/integration-tests/src/EntityManager.populate.test.ts
@@ -69,7 +69,7 @@ describe("EntityManager.populate", () => {
     expect(numberOfQueries).toEqual(2);
     expect(pub.authors.get.length).toEqual(2);
     expect(pub.authors.get[0].books.get.length).toEqual(2);
-    expect(pub.authors.get[0].publisher.get!.id).toEqual("publisher:1");
+    expect(pub.authors.get[0].publisher.get!.id).toEqual("p:1");
   });
 
   it("can populate via load", async () => {
@@ -139,7 +139,7 @@ describe("EntityManager.populate", () => {
     const em = new EntityManager(knex);
     const book = await em.load(Book, "1", "author");
     const authorId: string = book.author.id;
-    expect(authorId).toEqual("author:1");
+    expect(authorId).toEqual("a:1");
   });
 
   it("can populate two literals", async () => {

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -214,6 +214,14 @@ describe("EntityManager.queries", () => {
     expect(pubs.length).toEqual(2);
   });
 
+  it("can find by tagged ids", async () => {
+    await insertPublisher({ name: "p1" });
+    await insertPublisher({ name: "p2" });
+    const em = new EntityManager(knex);
+    const pubs = await em.find(Publisher, { id: ["p:1", "p:2"] });
+    expect(pubs.length).toEqual(2);
+  });
+
   it("can find by enums", async () => {
     await insertPublisher({ name: "p1", size_id: 1 });
     await insertPublisher({ name: "p2", size_id: 2 });

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -148,7 +148,7 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ id: 2, first_name: "a1" });
     await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
     const em = new EntityManager(knex);
-    const publisherId: PublisherId = "publisher:1";
+    const publisherId: PublisherId = "p:1";
     const authors = await em.find(Author, { publisher: publisherId });
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
@@ -159,9 +159,9 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ id: 2, first_name: "a1" });
     await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
     const em = new EntityManager(knex);
-    const publisherId: PublisherId = "author:1";
+    const publisherId: PublisherId = "a:1";
     await expect(em.find(Author, { publisher: publisherId })).rejects.toThrow(
-      "Invalid tagged id, expected tag publisher, got author:1",
+      "Invalid tagged id, expected tag p, got a:1",
     );
   });
 

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -143,6 +143,28 @@ describe("EntityManager.queries", () => {
     expect(authors[0].firstName).toEqual("a2");
   });
 
+  it("can find by foreign key is tagged flavor", async () => {
+    await insertPublisher({ id: 1, name: "p1" });
+    await insertAuthor({ id: 2, first_name: "a1" });
+    await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
+    const em = new EntityManager(knex);
+    const publisherId: PublisherId = "publisher:1";
+    const authors = await em.find(Author, { publisher: publisherId });
+    expect(authors.length).toEqual(1);
+    expect(authors[0].firstName).toEqual("a2");
+  });
+
+  it("fails find by foreign key is invalid tagged id", async () => {
+    await insertPublisher({ id: 1, name: "p1" });
+    await insertAuthor({ id: 2, first_name: "a1" });
+    await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
+    const em = new EntityManager(knex);
+    const publisherId: PublisherId = "author:1";
+    await expect(em.find(Author, { publisher: publisherId })).rejects.toThrow(
+      "Invalid tagged id, expected tag publisher, got author:1",
+    );
+  });
+
   it("can find by foreign key is not flavor", async () => {
     await insertPublisher({ id: 1, name: "p1" });
     await insertAuthor({ id: 2, first_name: "a1" });
@@ -332,7 +354,7 @@ describe("EntityManager.queries", () => {
     const em = new EntityManager(knex);
     await expect(em.findOneOrFail(Publisher, { name: "p" })).rejects.toThrow(TooManyError);
     await expect(em.findOneOrFail(Publisher, { name: "p" })).rejects.toThrow(
-      "Found more than one: Publisher#1, Publisher#2",
+      "Found more than one: Publisher:1, Publisher:2",
     );
   });
 

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -21,15 +21,15 @@ describe("EntityManager", () => {
   it("can load an entity by tagged id", async () => {
     await insertAuthor({ first_name: "f" });
     const em = new EntityManager(knex);
-    const author = await em.load(Author, "author:1");
+    const author = await em.load(Author, "a:1");
     expect(author.firstName).toEqual("f");
   });
 
   it("fails to load an entity by an invalid tagged id", async () => {
     await insertAuthor({ first_name: "f" });
     const em = new EntityManager(knex);
-    await expect(em.load(Author, "publisher:1")).rejects.toThrow(
-      "Invalid tagged id, expected tag author, got publisher:1",
+    await expect(em.load(Author, "p:1")).rejects.toThrow(
+      "Invalid tagged id, expected tag a, got p:1",
     );
   });
 
@@ -70,7 +70,7 @@ describe("EntityManager", () => {
 
     const rows = await knex.select("*").from("authors");
     expect(rows.length).toEqual(1);
-    expect(author.id).toEqual("author:1");
+    expect(author.id).toEqual("a:1");
   });
 
   it("inserts then updates new entity", async () => {
@@ -100,11 +100,11 @@ describe("EntityManager", () => {
     const em = new EntityManager(knex);
     const author = new Author(em, { firstName: "a1" });
     await em.flush();
-    expect(author.id).toEqual("author:1");
+    expect(author.id).toEqual("a:1");
 
     author.firstName = "a2";
     await em.flush();
-    expect(author.id).toEqual("author:1");
+    expect(author.id).toEqual("a:1");
 
     const row = (await knex.select("*").from("authors"))[0];
     expect(row["first_name"]).toEqual("a2");
@@ -407,7 +407,7 @@ describe("EntityManager", () => {
     await insertBook({ id: 2, title: "b1", author_id: 1 });
     const em = new EntityManager(knex);
     const b1 = await em.load(Book, "2");
-    expect(b1.author.id).toEqual("author:1");
+    expect(b1.author.id).toEqual("a:1");
   });
 
   it("can create and cast to nested m2o hints", async () => {
@@ -688,7 +688,7 @@ describe("EntityManager", () => {
     new Author(em, { firstName: "a1" });
     await em.flush();
     const a = await em.findOrCreate(Author, { firstName: "a1" }, {});
-    expect(a.id).toEqual("author:1");
+    expect(a.id).toEqual("a:1");
   });
 
   it("can find by optional field with findOrCreate", async () => {
@@ -696,7 +696,7 @@ describe("EntityManager", () => {
     new Author(em, { firstName: "a1", age: 20 });
     await em.flush();
     const a = await em.findOrCreate(Author, { age: 20 }, { firstName: "a2" });
-    expect(a.id).toEqual("author:1");
+    expect(a.id).toEqual("a:1");
     // we leave firstName alone since it was in the ifNew hash
     expect(a.firstName).toEqual("a1");
   });
@@ -716,7 +716,7 @@ describe("EntityManager", () => {
     new Author(em, { firstName: "a1" });
     await em.flush();
     const a = await em.findOrCreate(Author, { firstName: "a1" }, { age: 20 }, { lastName: "l" });
-    expect(a.id).toEqual("author:1");
+    expect(a.id).toEqual("a:1");
     expect(a.lastName).toEqual("l");
     expect(a.age).toBeUndefined();
   });
@@ -841,7 +841,7 @@ describe("EntityManager", () => {
     const a1 = await em.load(Author, "1");
     a1.publisher.set(em.create(Publisher, { name: "p1" }));
     expect(a1.toJSON()).toMatchObject({
-      id: "author:1",
+      id: "a:1",
       firstName: "a1",
       publisher: "Publisher:new",
     });

--- a/packages/integration-tests/src/EntityManager.unsafe.test.ts
+++ b/packages/integration-tests/src/EntityManager.unsafe.test.ts
@@ -82,7 +82,7 @@ describe("EntityManager", () => {
     await insertAuthor({ first_name: "m1" });
     const em = new EntityManager(knex);
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: await em.load(Author, "1") });
-    expect(a1.mentor.id).toEqual("1");
+    expect(a1.mentor.id).toEqual("author:1");
   });
 
   it("collections can refer to entities by id", async () => {

--- a/packages/integration-tests/src/EntityManager.unsafe.test.ts
+++ b/packages/integration-tests/src/EntityManager.unsafe.test.ts
@@ -82,7 +82,7 @@ describe("EntityManager", () => {
     await insertAuthor({ first_name: "m1" });
     const em = new EntityManager(knex);
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: await em.load(Author, "1") });
-    expect(a1.mentor.id).toEqual("author:1");
+    expect(a1.mentor.id).toEqual("a:1");
   });
 
   it("collections can refer to entities by id", async () => {

--- a/packages/integration-tests/src/collections/CustomReference.test.ts
+++ b/packages/integration-tests/src/collections/CustomReference.test.ts
@@ -1,6 +1,6 @@
+import { insertAuthor, insertBook, insertBookReview, insertImage } from "@src/entities/inserts";
 import { EntityManager } from "joist-orm";
 import { Author, Book, BookReview, Image, ImageType } from "../entities";
-import { insertAuthor, insertBook, insertBookReview, insertImage } from "@src/entities/inserts";
 import { knex } from "../setupDbTests";
 
 describe("CustomReference", () => {
@@ -82,7 +82,7 @@ describe("CustomReference", () => {
     const a2 = await em.load(Author, "2");
     const r1 = await em.load(BookReview, "1");
 
-    expect(() => r1.author.set(a2)).toThrow("BookReview#1.author was not loaded");
+    expect(() => r1.author.set(a2)).toThrow("BookReview:1.author was not loaded");
   });
 
   it("can load against a new entity", async () => {

--- a/packages/integration-tests/src/collections/ManyToManyCollection.test.ts
+++ b/packages/integration-tests/src/collections/ManyToManyCollection.test.ts
@@ -228,7 +228,7 @@ describe("ManyToManyCollection", () => {
     // And the book is deleted
     em.delete(b1);
     // Then we cannot add to the tags collection
-    expect(() => b1.tags.add(t1)).toThrow("Book#2 is marked as deleted");
+    expect(() => b1.tags.add(t1)).toThrow("Book:2 is marked as deleted");
   });
 
   it("cannot remove to a deleted entity's m2m", async () => {
@@ -243,7 +243,7 @@ describe("ManyToManyCollection", () => {
     em.delete(b1);
     await em.flush();
     // Then we cannot remove from the tags collection
-    expect(() => b1.tags.remove(t1)).toThrow("Book#2 is marked as deleted");
+    expect(() => b1.tags.remove(t1)).toThrow("Book:2 is marked as deleted");
   });
 
   it("can set to both add and remove", async () => {

--- a/packages/integration-tests/src/collections/OneToManyCollection.test.ts
+++ b/packages/integration-tests/src/collections/OneToManyCollection.test.ts
@@ -90,7 +90,7 @@ describe("OneToManyCollection", () => {
     // And the book association to a2 is persisted to the database.
     await em.flush();
     const rows = await knex.select("*").from("books");
-    expect(`author:${rows[0].author_id}`).toEqual(a2.id);
+    expect(`a:${rows[0].author_id}`).toEqual(a2.id);
   });
 
   it("can add to one collection and remove from other when already persisted", async () => {
@@ -121,7 +121,7 @@ describe("OneToManyCollection", () => {
     // And the book association to a2 is persisted to the database.
     await em2.flush();
     const rows = await knex.select("*").from("books");
-    expect(`author:${rows[0].author_id}`).toEqual(a2_2.id);
+    expect(`a:${rows[0].author_id}`).toEqual(a2_2.id);
   });
 
   it("can add to collection from the other side", async () => {
@@ -148,7 +148,7 @@ describe("OneToManyCollection", () => {
     // Then the collection has both books in it
     expect(books.length).toEqual(2);
     expect(books[0].id).toEqual(undefined);
-    expect(books[1].id).toEqual("book:1");
+    expect(books[1].id).toEqual("b:1");
   });
 
   it("combines both pre-loaded and post-loaded removed entities", async () => {

--- a/packages/integration-tests/src/collections/OneToManyCollection.test.ts
+++ b/packages/integration-tests/src/collections/OneToManyCollection.test.ts
@@ -1,8 +1,7 @@
-import { EntityManager } from "joist-orm";
-import { keyToNumber } from "joist-orm/build/serde";
-import { knex } from "../setupDbTests";
-import { Author, Book, BookOpts, Publisher, Tag } from "../entities";
 import { insertAuthor, insertBook, insertPublisher } from "@src/entities/inserts";
+import { EntityManager } from "joist-orm";
+import { Author, Book, BookOpts, Publisher } from "../entities";
+import { knex } from "../setupDbTests";
 
 describe("OneToManyCollection", () => {
   it("loads collections", async () => {
@@ -91,7 +90,7 @@ describe("OneToManyCollection", () => {
     // And the book association to a2 is persisted to the database.
     await em.flush();
     const rows = await knex.select("*").from("books");
-    expect(rows[0].author_id).toEqual(keyToNumber(a2.id));
+    expect(`author:${rows[0].author_id}`).toEqual(a2.id);
   });
 
   it("can add to one collection and remove from other when already persisted", async () => {
@@ -122,7 +121,7 @@ describe("OneToManyCollection", () => {
     // And the book association to a2 is persisted to the database.
     await em2.flush();
     const rows = await knex.select("*").from("books");
-    expect(rows[0].author_id).toEqual(keyToNumber(a2_2.id));
+    expect(`author:${rows[0].author_id}`).toEqual(a2_2.id);
   });
 
   it("can add to collection from the other side", async () => {
@@ -149,7 +148,7 @@ describe("OneToManyCollection", () => {
     // Then the collection has both books in it
     expect(books.length).toEqual(2);
     expect(books[0].id).toEqual(undefined);
-    expect(books[1].id).toEqual("1");
+    expect(books[1].id).toEqual("book:1");
   });
 
   it("combines both pre-loaded and post-loaded removed entities", async () => {

--- a/packages/integration-tests/src/collections/OneToOneReference.test.ts
+++ b/packages/integration-tests/src/collections/OneToOneReference.test.ts
@@ -105,7 +105,7 @@ describe("OneToOneReference", () => {
     await insertAuthor({ first_name: "a1" });
     const em = new EntityManager(knex);
     const a1 = await em.load(Author, "1");
-    expect(() => a1.image.id).toThrow("Author#1.image was not loaded");
+    expect(() => a1.image.id).toThrow("Author:1.image was not loaded");
     await a1.image.load();
     expect(a1.image.id).toBeUndefined();
   });

--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -284,7 +284,7 @@ describe("Author", () => {
       expect(a1.changes.publisher.originalValue).toBeUndefined();
       a1.publisher.set(await em.load(Publisher, "2"));
       expect(a1.changes.publisher.hasChanged).toBeTruthy();
-      expect(a1.changes.publisher.originalValue).toEqual("publisher:1");
+      expect(a1.changes.publisher.originalValue).toEqual("p:1");
     });
   });
 

--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -284,7 +284,7 @@ describe("Author", () => {
       expect(a1.changes.publisher.originalValue).toBeUndefined();
       a1.publisher.set(await em.load(Publisher, "2"));
       expect(a1.changes.publisher.hasChanged).toBeTruthy();
-      expect(a1.changes.publisher.originalValue).toEqual("1");
+      expect(a1.changes.publisher.originalValue).toEqual("publisher:1");
     });
   });
 

--- a/packages/integration-tests/src/entities/Image.test.ts
+++ b/packages/integration-tests/src/entities/Image.test.ts
@@ -9,7 +9,7 @@ describe("Image", () => {
     const a1 = em.create(Author, { firstName: "a1" });
     const i = em.create(Image, { type: ImageType.AuthorImage, author: a1, fileName: "f1" });
     await em.flush();
-    expect(i.idOrFail).toEqual("1");
+    expect(i.idOrFail).toEqual("image:1");
   });
 
   it("cannot have multiple owners", async () => {

--- a/packages/integration-tests/src/entities/Image.test.ts
+++ b/packages/integration-tests/src/entities/Image.test.ts
@@ -9,7 +9,7 @@ describe("Image", () => {
     const a1 = em.create(Author, { firstName: "a1" });
     const i = em.create(Image, { type: ImageType.AuthorImage, author: a1, fileName: "f1" });
     await em.flush();
-    expect(i.idOrFail).toEqual("image:1");
+    expect(i.idOrFail).toEqual("i:1");
   });
 
   it("cannot have multiple owners", async () => {

--- a/packages/integration-tests/src/entities/metadata.ts
+++ b/packages/integration-tests/src/entities/metadata.ts
@@ -36,7 +36,7 @@ import {
 export const authorMeta: EntityMetadata<Author> = {
   cstr: Author,
   type: "Author",
-  tagName: "author",
+  tagName: "a",
   tableName: "authors",
   columns: [
     { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => authorMeta, "id", "id") },
@@ -225,7 +225,7 @@ export const authorMeta: EntityMetadata<Author> = {
 export const bookMeta: EntityMetadata<Book> = {
   cstr: Book,
   type: "Book",
-  tagName: "book",
+  tagName: "b",
   tableName: "books",
   columns: [
     { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => bookMeta, "id", "id") },
@@ -337,7 +337,7 @@ export const bookMeta: EntityMetadata<Book> = {
 export const bookAdvanceMeta: EntityMetadata<BookAdvance> = {
   cstr: BookAdvance,
   type: "BookAdvance",
-  tagName: "bookAdvance",
+  tagName: "ba",
   tableName: "book_advances",
   columns: [
     { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => bookAdvanceMeta, "id", "id") },
@@ -426,7 +426,7 @@ export const bookAdvanceMeta: EntityMetadata<BookAdvance> = {
 export const bookReviewMeta: EntityMetadata<BookReview> = {
   cstr: BookReview,
   type: "BookReview",
-  tagName: "bookReview",
+  tagName: "br",
   tableName: "book_reviews",
   columns: [
     { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => bookReviewMeta, "id", "id") },
@@ -514,7 +514,7 @@ export const bookReviewMeta: EntityMetadata<BookReview> = {
 export const imageMeta: EntityMetadata<Image> = {
   cstr: Image,
   type: "Image",
-  tagName: "image",
+  tagName: "i",
   tableName: "images",
   columns: [
     { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => imageMeta, "id", "id") },
@@ -632,7 +632,7 @@ export const imageMeta: EntityMetadata<Image> = {
 export const publisherMeta: EntityMetadata<Publisher> = {
   cstr: Publisher,
   type: "Publisher",
-  tagName: "publisher",
+  tagName: "p",
   tableName: "publishers",
   columns: [
     { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => publisherMeta, "id", "id") },
@@ -722,7 +722,7 @@ export const publisherMeta: EntityMetadata<Publisher> = {
 export const tagMeta: EntityMetadata<Tag> = {
   cstr: Tag,
   type: "Tag",
-  tagName: "tag",
+  tagName: "t",
   tableName: "tags",
   columns: [
     { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => tagMeta, "id", "id") },

--- a/packages/integration-tests/src/entities/metadata.ts
+++ b/packages/integration-tests/src/entities/metadata.ts
@@ -36,9 +36,10 @@ import {
 export const authorMeta: EntityMetadata<Author> = {
   cstr: Author,
   type: "Author",
+  tagName: "author",
   tableName: "authors",
   columns: [
-    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde("id", "id") },
+    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => authorMeta, "id", "id") },
 
     {
       fieldName: "firstName",
@@ -224,9 +225,10 @@ export const authorMeta: EntityMetadata<Author> = {
 export const bookMeta: EntityMetadata<Book> = {
   cstr: Book,
   type: "Book",
+  tagName: "book",
   tableName: "books",
   columns: [
-    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde("id", "id") },
+    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => bookMeta, "id", "id") },
 
     {
       fieldName: "title",
@@ -335,9 +337,10 @@ export const bookMeta: EntityMetadata<Book> = {
 export const bookAdvanceMeta: EntityMetadata<BookAdvance> = {
   cstr: BookAdvance,
   type: "BookAdvance",
+  tagName: "bookAdvance",
   tableName: "book_advances",
   columns: [
-    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde("id", "id") },
+    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => bookAdvanceMeta, "id", "id") },
 
     {
       fieldName: "status",
@@ -423,9 +426,10 @@ export const bookAdvanceMeta: EntityMetadata<BookAdvance> = {
 export const bookReviewMeta: EntityMetadata<BookReview> = {
   cstr: BookReview,
   type: "BookReview",
+  tagName: "bookReview",
   tableName: "book_reviews",
   columns: [
-    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde("id", "id") },
+    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => bookReviewMeta, "id", "id") },
 
     {
       fieldName: "rating",
@@ -510,9 +514,10 @@ export const bookReviewMeta: EntityMetadata<BookReview> = {
 export const imageMeta: EntityMetadata<Image> = {
   cstr: Image,
   type: "Image",
+  tagName: "image",
   tableName: "images",
   columns: [
-    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde("id", "id") },
+    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => imageMeta, "id", "id") },
 
     {
       fieldName: "type",
@@ -627,9 +632,10 @@ export const imageMeta: EntityMetadata<Image> = {
 export const publisherMeta: EntityMetadata<Publisher> = {
   cstr: Publisher,
   type: "Publisher",
+  tagName: "publisher",
   tableName: "publishers",
   columns: [
-    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde("id", "id") },
+    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => publisherMeta, "id", "id") },
 
     {
       fieldName: "size",
@@ -716,9 +722,10 @@ export const publisherMeta: EntityMetadata<Publisher> = {
 export const tagMeta: EntityMetadata<Tag> = {
   cstr: Tag,
   type: "Tag",
+  tagName: "tag",
   tableName: "tags",
   columns: [
-    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde("id", "id") },
+    { fieldName: "id", columnName: "id", dbType: "int", serde: new PrimaryKeySerde(() => tagMeta, "id", "id") },
 
     {
       fieldName: "name",

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -33,6 +33,10 @@ export abstract class BaseEntity implements Entity {
     return undefined;
   }
 
+  get idUntaggedOrFail(): string {
+    return this.idUntagged || fail("Entity has no id yet");
+  }
+
   abstract set(values: Partial<OptsOf<this>>): void;
 
   /**

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -1,4 +1,5 @@
 import {
+  deTagIds,
   Entity,
   EntityManager,
   EntityOrmField,
@@ -23,6 +24,13 @@ export abstract class BaseEntity implements Entity {
   protected constructor(em: EntityManager, metadata: any, data?: Record<string, any>) {
     this.__orm = { em, metadata, data: data || {}, originalData: {} };
     em.register(this);
+  }
+
+  get idUntagged(): string | undefined {
+    if (this.id) {
+      return deTagIds(getMetadata(this), [this.id])[0];
+    }
+    return undefined;
   }
 
   abstract set(values: Partial<OptsOf<this>>): void;

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -1,5 +1,15 @@
-import { Entity, EntityManager, EntityOrmField, IdOf, isEntity, OptsOf } from "./EntityManager";
-import { fail, PartialOrNull } from "./index";
+import {
+  Entity,
+  EntityManager,
+  EntityOrmField,
+  fail,
+  getMetadata,
+  IdOf,
+  isEntity,
+  keyToNumber,
+  OptsOf,
+  PartialOrNull,
+} from "./index";
 
 /**
  * The base class for all entities.
@@ -48,7 +58,11 @@ export abstract class BaseEntity implements Entity {
   }
 
   toString(): string {
-    return `${this.__orm.metadata.type}#${this.id}`;
+    const meta = getMetadata(this);
+    // Strip the tag because we add back the entity prefix
+    const id = keyToNumber(meta, this.id) || "new";
+    // Returns `Author:1` instead of `author:1` to differentiate the instance's toString from the tagged id itself
+    return `${meta.type}:${id}`;
   }
 
   /**

--- a/packages/orm/src/collections/CustomReference.ts
+++ b/packages/orm/src/collections/CustomReference.ts
@@ -1,5 +1,5 @@
 import { Entity, IdOf } from "../EntityManager";
-import { ensureNotDeleted, fail, Reference } from "../index";
+import { deTagIds, ensureNotDeleted, fail, Reference, unsafeDeTagIds } from "../index";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 
 export type CustomReferenceOpts<T extends Entity, U extends Entity, N extends never | undefined> = {
@@ -75,6 +75,15 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
 
   get idOrFail(): IdOf<U> {
     return fail(`CustomReference cannot resolve 'idOrFail'`);
+  }
+
+  get idUntagged(): string | undefined {
+    // We don't know the meta here but that is probably a feature in case this is polymorphic
+    return this.id && unsafeDeTagIds([this.id])[0];
+  }
+
+  get idUntaggedOrFail(): string {
+    return this.idUntagged || fail("Reference is unset or assigned to a new entity");
   }
 
   get isSet(): boolean {

--- a/packages/orm/src/collections/ManyToOneReference.ts
+++ b/packages/orm/src/collections/ManyToOneReference.ts
@@ -1,5 +1,6 @@
 import { Entity, EntityConstructor, EntityMetadata, getMetadata, IdOf, isEntity } from "../EntityManager";
 import {
+  deTagIds,
   ensureNotDeleted,
   fail,
   getEm,
@@ -85,6 +86,14 @@ export class ManyToOneReference<T extends Entity, U extends Entity, N extends ne
   get idOrFail(): IdOf<U> {
     ensureNotDeleted(this.entity, { ignore: "pending" });
     return this.id || fail("Reference is unset or assigned to a new entity");
+  }
+
+  get idUntagged(): string | undefined {
+    return this.id && deTagIds(this.otherMeta, [this.id])[0];
+  }
+
+  get idUntaggedOrFail(): string {
+    return this.idUntagged || fail("Reference is unset or assigned to a new entity");
   }
 
   // private impl

--- a/packages/orm/src/collections/OneToOneReference.ts
+++ b/packages/orm/src/collections/OneToOneReference.ts
@@ -1,4 +1,4 @@
-import { ensureNotDeleted, fail, getEm, IdOf, Reference } from "../";
+import { deTagIds, ensureNotDeleted, fail, getEm, IdOf, Reference, unsafeDeTagIds } from "../";
 import { Entity, EntityMetadata, getMetadata } from "../EntityManager";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { ManyToOneReference } from "./ManyToOneReference";
@@ -46,6 +46,14 @@ export class OneToOneReference<T extends Entity, U extends Entity> extends Abstr
 
   get idOrFail(): IdOf<U> {
     return this.id || fail(`${this.entity}.${this.fieldName} has no id yet`);
+  }
+
+  get idUntagged(): string | undefined {
+    return this.id && deTagIds(this.otherMeta, [this.id])[0];
+  }
+
+  get idUntaggedOrFail(): string {
+    return this.idUntagged || fail("Reference is unset or assigned to a new entity");
   }
 
   get isSet(): boolean {

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -65,6 +65,10 @@ export interface Reference<T extends Entity, U extends Entity, N extends never |
   /** Returns the id of the current assigned entity or a runtime error if it's either a) unset or b) set to a new entity that doesn't have an `id` yet. */
   idOrFail: IdOf<U>;
 
+  idUntagged: string | undefined;
+
+  idUntaggedOrFail: string;
+
   load(opts?: { withDeleted: boolean }): Promise<U | N>;
 
   set(other: U | N): void;

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -19,8 +19,9 @@ import {
 } from "./EntityManager";
 import { reverseHint } from "./reverseHint";
 
-export * from "./EntityManager";
+export * from "./keys";
 export * from "./serde";
+export * from "./EntityManager";
 export { newPgConnectionConfig } from "joist-utils";
 export * from "./reverseHint";
 export * from "./changes";
@@ -211,7 +212,7 @@ export function setOpts<T extends Entity>(
 
 export function ensureNotDeleted(entity: Entity, opts: { ignore?: EntityOrmField["deleted"] } = {}): void {
   if (entity.isDeletedEntity && (opts.ignore === undefined || entity.__orm.deleted !== opts.ignore)) {
-    throw new Error(entity + " is marked as deleted");
+    throw new Error(`${entity} is marked as deleted`);
   }
 }
 

--- a/packages/orm/src/keys.ts
+++ b/packages/orm/src/keys.ts
@@ -57,3 +57,8 @@ export function tagIfNeeded(meta: HasTagName, id: string): string {
 export function deTagIds(meta: HasTagName, keys: readonly string[]): readonly string[] {
   return keys.map((k) => keyToNumber(meta, k)).map((n) => n.toString());
 }
+
+/** Removes the tag prefixes so we can use the keys for SQL operations. */
+export function unsafeDeTagIds(keys: readonly string[]): readonly string[] {
+  return keys.map((k) => k.split(tagDelimiter)).map((t) => (t.length === 0 ? t[0] : t[1]));
+}

--- a/packages/orm/src/keys.ts
+++ b/packages/orm/src/keys.ts
@@ -1,0 +1,59 @@
+const tagDelimiter = ":";
+
+// I'm not entirely sure this is still necessary, but use a small subset of EntityMetadata so
+// that this file doesn't have to import the type and potentially create import cycles.
+type HasTagName = { tagName: string };
+
+// Before a referred-to object is saved, we keep its instance in our data
+// map, and then assume it will be persisted before we're asked to persist
+export function maybeResolveReferenceToId(value: any): string | undefined {
+  return typeof value === "number" || typeof value === "string" ? value : value?.id;
+}
+
+/** Converts `value` to a number, i.e. for string ids, unless its undefined. */
+export function keyToNumber(meta: HasTagName, value: string): number;
+export function keyToNumber(meta: HasTagName, value: any): number | undefined;
+export function keyToNumber(meta: HasTagName, value: any): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  } else if (typeof value === "number") {
+    return value;
+  } else if (typeof value === "string") {
+    const [tag, id] = value.split(tagDelimiter);
+    if (id === undefined) {
+      return Number(value);
+    }
+    if (tag !== meta.tagName) {
+      throw new Error(`Invalid tagged id, expected tag ${meta.tagName}, got ${value}`);
+    }
+    return Number(id);
+  } else {
+    throw new Error(`Invalid key ${value}`);
+  }
+}
+
+/** Converts `value` to a number, i.e. for string ids, unles its undefined. */
+export function keyToString(meta: HasTagName, value: any): string | undefined {
+  return value === undefined || value === null ? undefined : `${meta.tagName}:${value}`;
+}
+
+/** Fails if any keys are tagged; used by internal functions b/c we still allow most direct API input to be untagged. */
+export function assertIdsAreTagged(keys: readonly string[]): void {
+  const invalidKeys = keys.filter((k) => k.indexOf(tagDelimiter) === -1);
+  if (invalidKeys.length > 0) {
+    throw new Error(`Some keys are missing tags ${invalidKeys}`);
+  }
+}
+
+/** Tags a potentially untagged id, while our API inputs still accept either tagged or untagged ids. */
+export function tagIfNeeded(meta: HasTagName, id: string): string {
+  if (id.includes(tagDelimiter)) {
+    return id;
+  }
+  return `${meta.tagName}${tagDelimiter}${id}`;
+}
+
+/** Removes the tag prefixes so we can use the keys for SQL operations. */
+export function deTagIds(meta: HasTagName, keys: readonly string[]): readonly string[] {
+  return keys.map((k) => keyToNumber(meta, k)).map((n) => n.toString());
+}

--- a/packages/orm/src/serde.ts
+++ b/packages/orm/src/serde.ts
@@ -47,7 +47,7 @@ export class PrimaryKeySerde implements ColumnSerde {
   }
 
   mapToDb(value: any) {
-    return value;
+    return keyToNumber(this.meta(), value);
   }
 }
 


### PR DESCRIPTION
Somewhat proof-of-concept but it seems to be working pretty well/somewhat tempted to go ahead with it. At least don't see a reason to rule it out so far.

Basically our entity `.id`s already "look like strings" (still ints in the db), i.e. "1" / "2" / "3", and this changes the strings to be `"author:1"`, `"author:2"`, etc., so that as we pass around the id to the client / back to the server, we "really really really" know what entity it's for, and can verify that we didn't pass around the wrong id.

Historically when discussing tagged ids with other/pre-Homebound teams (i.e. at Remind, where a few of the "fancy tech shops" like FB/LinkedIn use tagged ids), the con of "well, that'd be a lot of boilerplate to go back/forth from tagged string / int-in-the-db" was one of the largest cons/blockers.

With this PR, all of that mapping basically goes away; ids stay as primary key ints in the db, but Joist turns them into tagged ids for free, and de-tags the ids before any SQL operations like insert/select/update.

Currently each tag is just the entity name, i.e. `author:1`, `publisher:2`, etc. The `tagName` is stored in the codegen'd `metadata.ts`, so we can easily change it at codegen time, i.e. by config values in `joist-codegen.json`. (Not entirely sure we want that to be configurable, although I suppose this brings up, how to handle table renames? Would prior `oldEntityName:1` tagged ids have to continue to be respected and mapped to the new `newEntityName:1` tag/entity automatically by Joist? Probably, i.e. in case ids have been stored externally in vendor systems / something / something.) 

The existing logic/slice points for "change int primary key to string id" we were already doing for playing nicely in the GQL ecosystem (to match their `ID`) meant this was actually pretty simple to do; i.e. `keyToNumber` and `keyToString` were already called in all the right spots, they just needed to be taught how to tag and un-tag string ids going back/forth to numbers.

While doing this, besides just dropping the tag prefix, i.e. `author:1` --> `1`, the logic also ensures the tag was the expected tag, i.e. if the code thought this should be a `publisher:...` and it got an `author:...` id, then it will immediately fail.

This is essentially the runtime version of our strongly typed/flavor ids, but even more powerful since the checking is based on the id value, so will persist across "hops to strings/GQL results/GQL inputs/query parameters/cookies/whatever".

Note that we still accept un-tagged ids to `.load` and `.find`, so this is not a breaking change in terms of inputs (if for whatever reason code/tests continues to pass the untagged value). However, it is a breaking change in terms of outputs, i.e. `Entity.id` is now `author:1` instead of `1`.

At some point we could disallow passing untagged ids all together.