### PR TITLE
Removed the constructor from initial entity codegen file 

### DIFF
--- a/packages/codegen/src/generateInitialEntityFile.ts
+++ b/packages/codegen/src/generateInitialEntityFile.ts
@@ -6,12 +6,7 @@ import { EntityDbMetadata } from "./EntityDbMetadata";
 export function generateInitialEntityFile(meta: EntityDbMetadata): Code {
   const entityName = meta.entity.name;
   const codegenClass = imp(`${entityName}Codegen@./entities`);
-  const optsClass = imp(`${entityName}Opts@./entities`);
   return code`
-    export class ${entityName} extends ${codegenClass} {
-      constructor(em: ${EntityManager}, opts: ${optsClass}) {
-        super(em, opts);
-      }
-    }
+    export class ${entityName} extends ${codegenClass} {}
   `;
 }

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -1,15 +1,11 @@
-import { EntityManager, Loaded } from "joist-orm";
-import { AuthorCodegen, authorConfig, AuthorOpts } from "./entities";
+import { Loaded } from "joist-orm";
+import { AuthorCodegen, authorConfig } from "./entities";
 
 export class Author extends AuthorCodegen {
   public beforeFlushRan = false;
   public beforeDeleteRan = false;
   public afterCommitRan = false;
   public ageForBeforeFlush?: number;
-
-  constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, opts);
-  }
 
   /** Example of using populate within an entity on itself. */
   get withLoadedBooks(): Promise<Loaded<Author, "books">> {

--- a/packages/integration-tests/src/entities/Book.ts
+++ b/packages/integration-tests/src/entities/Book.ts
@@ -1,10 +1,5 @@
-import { EntityManager } from "joist-orm";
-import { BookCodegen, bookConfig, BookOpts } from "./entities";
+import { BookCodegen, bookConfig } from "./entities";
 
-export class Book extends BookCodegen {
-  constructor(em: EntityManager, opts: BookOpts) {
-    super(em, opts);
-  }
-}
+export class Book extends BookCodegen {}
 
 bookConfig.cascadeDelete("reviews");

--- a/packages/integration-tests/src/entities/BookReview.ts
+++ b/packages/integration-tests/src/entities/BookReview.ts
@@ -1,5 +1,5 @@
-import { Author, BookReviewCodegen, bookReviewConfig, BookReviewOpts } from "./entities";
-import { CustomReference, EntityManager, Reference } from "joist-orm";
+import { Author, BookReviewCodegen, bookReviewConfig } from "./entities";
+import { CustomReference, Reference } from "joist-orm";
 
 export class BookReview extends BookReviewCodegen {
   readonly author: Reference<BookReview, Author, never> = new CustomReference<
@@ -19,10 +19,6 @@ export class BookReview extends BookReviewCodegen {
       return review.book.isSet() && review.book.get.author.isSet();
     },
   });
-
-  constructor(em: EntityManager, opts: BookReviewOpts) {
-    super(em, opts);
-  }
 }
 
 // Reviews are only public if the author is over the age of 21

--- a/packages/integration-tests/src/entities/Publisher.ts
+++ b/packages/integration-tests/src/entities/Publisher.ts
@@ -1,11 +1,6 @@
-import { EntityManager } from "joist-orm";
-import { PublisherCodegen, publisherConfig, PublisherOpts } from "./entities";
+import { PublisherCodegen, publisherConfig } from "./entities";
 
-export class Publisher extends PublisherCodegen {
-  constructor(em: EntityManager, opts: PublisherOpts) {
-    super(em, opts);
-  }
-}
+export class Publisher extends PublisherCodegen {}
 
 publisherConfig.addRule("authors", (p) => {
   if (p.authors.get.length === 13) {

--- a/packages/integration-tests/src/entities/Tag.ts
+++ b/packages/integration-tests/src/entities/Tag.ts
@@ -1,8 +1,3 @@
-import { EntityManager } from "joist-orm";
-import { TagCodegen, TagOpts } from "./entities";
+import { TagCodegen } from "./entities";
 
-export class Tag extends TagCodegen {
-  constructor(em: EntityManager, opts: TagOpts) {
-    super(em, opts);
-  }
-}
+export class Tag extends TagCodegen {}


### PR DESCRIPTION
As we've discussed, having the constructor in the entity file is unnecessary and we don't intend for it to be modified anyways