### PR TITLE
Add a limit to the number of entities that can be loaded.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,3 @@
-
 ![npm](https://img.shields.io/npm/v/joist-orm)
 [![CircleCI](https://circleci.com/gh/stephenh/joist-ts.svg?style=svg)](https://circleci.com/gh/stephenh/joist-ts)
 
@@ -49,13 +48,13 @@ After checkout:
 ### Todo
 
 In general priority/itch order:
- 
+
 - Open source a `joist-graphql-utils` with the `entityResolver` logic in it
 - Fix reactive rules not catching "middle-references" changing (fixed?)
-- Support `documentId`-style props in unsafe methods
+- Support `documentId`-style props in partial methods
 - Optionally move `begin` to the start of Unit of Work
 - `readonly asyncValue` that integrations into `populate`
-- Codegen'd test builders 
+- Codegen'd test builders
 - Add Collection.load(loadHint) (see branch, potential tsc 3.9 issue)
 - Support user-defined types
 - LargeCollection support
@@ -64,6 +63,8 @@ In general priority/itch order:
 - First-class support for soft deletion?
 - Op locks/`version` column?
 - An in-memory backend
+- `hasOneThrough` that can be used as `find`/SQL filters
+  - Need to declare in codegen to a) add to FilterType + b) verify once traverses relations
 
 ### History / Inspiration
 
@@ -76,5 +77,3 @@ The `EntityManager.find` syntax is heavily inspired from [MikroORM](https://mikr
 ### License
 
 MIT
-
-

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -1,6 +1,15 @@
 import Knex, { QueryBuilder } from "knex";
 import { fail } from "./utils";
-import { Entity, EntityConstructor, EntityMetadata, getMetadata, isEntity, FilterOf, OrderOf } from "./EntityManager";
+import {
+  Entity,
+  EntityConstructor,
+  EntityMetadata,
+  getMetadata,
+  isEntity,
+  FilterOf,
+  OrderOf,
+  entityLimit,
+} from "./EntityManager";
 import { ForeignKeySerde } from "./serde";
 
 export type OrderBy = "ASC" | "DESC";
@@ -216,9 +225,7 @@ export function buildQuery<T extends Entity>(
   if (!orderBy) {
     query = query.orderBy(`${alias}.id`);
   }
-  if (limit) {
-    query = query.limit(limit);
-  }
+  query = query.limit(limit || entityLimit);
   if (offset) {
     query = query.offset(offset);
   }


### PR DESCRIPTION
This copies the joist-java value of 10,000 being "yeah something is probably wrong" but still allowing "large-ish" UoWs. It's not based on any actual performance/profiling/etc. numbers.

(Specifically we had a WIP query in dev OOM the graphql service by "load all the tasks in the db".)

We also add a `LIMIT 10,000` to all of our `find` queries, and then if a row set comes back with 10,000 rows, similarly throw of "sorry you made a `find` call that was too big, try something else". Doing this in theory protects the database from a "return 1 million rows by accident" query. 