### PR TITLE
Update partial methods to upsert collections.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -223,7 +223,7 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
 
       constructor(em: ${EntityManager}, opts: ${entityName}Opts) {
         ${hasDefaultValues ? code`super(em, ${metadata}, {...${defaultValuesName}})` : code`super(em, ${metadata})`};
-        this.set(opts as ${entityName}Opts, { calledFromConstructor: true } as any);
+        ${setOpts}(this as any as ${entityName}, opts, { calledFromConstructor: true });
       }
 
       get id(): ${entityName}Id | undefined {
@@ -231,13 +231,13 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
       }
 
       ${primitives}
-      
-      set(values: Partial<${entityName}Opts>, opts: { ignoreUndefined?: boolean } = {}): void {
-        ${setOpts}(this, values as ${OptsOf}<this>, opts);
+
+      set(opts: Partial<${entityName}Opts>): void {
+        ${setOpts}(this as any as ${entityName}, opts);
       }
 
-      setPartial(values: ${PartialOrNull}<${entityName}Opts>, opts: { ignoreUndefined?: boolean } = {}): void {
-        ${setOpts}(this, values as ${OptsOf}<this>, { ignoreUndefined: true, ...opts });
+      setPartial(opts: ${PartialOrNull}<${entityName}Opts>): void {
+        ${setOpts}(this as any as ${entityName}, opts as ${OptsOf}<${entityName}>, { partial: true });
       }
 
       get changes(): ${Changes}<${entityName}> {

--- a/packages/integration-tests/src/collections/OneToManyCollection.test.ts
+++ b/packages/integration-tests/src/collections/OneToManyCollection.test.ts
@@ -147,8 +147,8 @@ describe("OneToManyCollection", () => {
 
     // Then the collection has both books in it
     expect(books.length).toEqual(2);
-    expect(books[0].id).toEqual(undefined);
-    expect(books[1].id).toEqual("b:1");
+    expect(books[0].id).toEqual("b:1");
+    expect(books[1].id).toEqual(undefined);
   });
 
   it("combines both pre-loaded and post-loaded removed entities", async () => {

--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -333,7 +333,7 @@ describe("Author", () => {
   it("set can treat undefined as leave", () => {
     const em = new EntityManager(knex);
     const author = new Author(em, { firstName: "a1" });
-    author.set({ firstName: undefined }, { ignoreUndefined: true });
+    author.setPartial({ firstName: undefined });
     expect(author.firstName).toEqual("a1");
   });
 

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -7,8 +7,8 @@ import {
   BaseEntity,
   EntityManager,
   setOpts,
-  OptsOf,
   PartialOrNull,
+  OptsOf,
   Changes,
   newChangesProxy,
   Lens,
@@ -133,7 +133,7 @@ export abstract class AuthorCodegen extends BaseEntity {
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta);
-    this.set(opts as AuthorOpts, { calledFromConstructor: true } as any);
+    setOpts((this as any) as Author, opts, { calledFromConstructor: true });
   }
 
   get id(): AuthorId | undefined {
@@ -197,12 +197,12 @@ export abstract class AuthorCodegen extends BaseEntity {
     return this.__orm.data["updatedAt"];
   }
 
-  set(values: Partial<AuthorOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, opts);
+  set(opts: Partial<AuthorOpts>): void {
+    setOpts((this as any) as Author, opts);
   }
 
-  setPartial(values: PartialOrNull<AuthorOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, { ignoreUndefined: true, ...opts });
+  setPartial(opts: PartialOrNull<AuthorOpts>): void {
+    setOpts((this as any) as Author, opts as OptsOf<Author>, { partial: true });
   }
 
   get changes(): Changes<Author> {

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -7,8 +7,8 @@ import {
   BaseEntity,
   EntityManager,
   setOpts,
-  OptsOf,
   PartialOrNull,
+  OptsOf,
   Changes,
   newChangesProxy,
   Lens,
@@ -99,7 +99,7 @@ export abstract class BookAdvanceCodegen extends BaseEntity {
 
   constructor(em: EntityManager, opts: BookAdvanceOpts) {
     super(em, bookAdvanceMeta);
-    this.set(opts as BookAdvanceOpts, { calledFromConstructor: true } as any);
+    setOpts((this as any) as BookAdvance, opts, { calledFromConstructor: true });
   }
 
   get id(): BookAdvanceId | undefined {
@@ -122,12 +122,12 @@ export abstract class BookAdvanceCodegen extends BaseEntity {
     setField(this, "status", status);
   }
 
-  set(values: Partial<BookAdvanceOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, opts);
+  set(opts: Partial<BookAdvanceOpts>): void {
+    setOpts((this as any) as BookAdvance, opts);
   }
 
-  setPartial(values: PartialOrNull<BookAdvanceOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, { ignoreUndefined: true, ...opts });
+  setPartial(opts: PartialOrNull<BookAdvanceOpts>): void {
+    setOpts((this as any) as BookAdvance, opts as OptsOf<BookAdvance>, { partial: true });
   }
 
   get changes(): Changes<BookAdvance> {

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -7,8 +7,8 @@ import {
   BaseEntity,
   EntityManager,
   setOpts,
-  OptsOf,
   PartialOrNull,
+  OptsOf,
   Changes,
   newChangesProxy,
   Lens,
@@ -116,7 +116,7 @@ export abstract class BookCodegen extends BaseEntity {
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, { ...bookDefaultValues });
-    this.set(opts as BookOpts, { calledFromConstructor: true } as any);
+    setOpts((this as any) as Book, opts, { calledFromConstructor: true });
   }
 
   get id(): BookId | undefined {
@@ -147,12 +147,12 @@ export abstract class BookCodegen extends BaseEntity {
     return this.__orm.data["updatedAt"];
   }
 
-  set(values: Partial<BookOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, opts);
+  set(opts: Partial<BookOpts>): void {
+    setOpts((this as any) as Book, opts);
   }
 
-  setPartial(values: PartialOrNull<BookOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, { ignoreUndefined: true, ...opts });
+  setPartial(opts: PartialOrNull<BookOpts>): void {
+    setOpts((this as any) as Book, opts as OptsOf<Book>, { partial: true });
   }
 
   get changes(): Changes<Book> {

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -7,8 +7,8 @@ import {
   BaseEntity,
   EntityManager,
   setOpts,
-  OptsOf,
   PartialOrNull,
+  OptsOf,
   Changes,
   newChangesProxy,
   Lens,
@@ -84,7 +84,7 @@ export abstract class BookReviewCodegen extends BaseEntity {
 
   constructor(em: EntityManager, opts: BookReviewOpts) {
     super(em, bookReviewMeta);
-    this.set(opts as BookReviewOpts, { calledFromConstructor: true } as any);
+    setOpts((this as any) as BookReview, opts, { calledFromConstructor: true });
   }
 
   get id(): BookReviewId | undefined {
@@ -114,12 +114,12 @@ export abstract class BookReviewCodegen extends BaseEntity {
     return this.__orm.data["updatedAt"];
   }
 
-  set(values: Partial<BookReviewOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, opts);
+  set(opts: Partial<BookReviewOpts>): void {
+    setOpts((this as any) as BookReview, opts);
   }
 
-  setPartial(values: PartialOrNull<BookReviewOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, { ignoreUndefined: true, ...opts });
+  setPartial(opts: PartialOrNull<BookReviewOpts>): void {
+    setOpts((this as any) as BookReview, opts as OptsOf<BookReview>, { partial: true });
   }
 
   get changes(): Changes<BookReview> {

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -7,8 +7,8 @@ import {
   BaseEntity,
   EntityManager,
   setOpts,
-  OptsOf,
   PartialOrNull,
+  OptsOf,
   Changes,
   newChangesProxy,
   Lens,
@@ -112,7 +112,7 @@ export abstract class ImageCodegen extends BaseEntity {
 
   constructor(em: EntityManager, opts: ImageOpts) {
     super(em, imageMeta);
-    this.set(opts as ImageOpts, { calledFromConstructor: true } as any);
+    setOpts((this as any) as Image, opts, { calledFromConstructor: true });
   }
 
   get id(): ImageId | undefined {
@@ -143,12 +143,12 @@ export abstract class ImageCodegen extends BaseEntity {
     setField(this, "type", type);
   }
 
-  set(values: Partial<ImageOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, opts);
+  set(opts: Partial<ImageOpts>): void {
+    setOpts((this as any) as Image, opts);
   }
 
-  setPartial(values: PartialOrNull<ImageOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, { ignoreUndefined: true, ...opts });
+  setPartial(opts: PartialOrNull<ImageOpts>): void {
+    setOpts((this as any) as Image, opts as OptsOf<Image>, { partial: true });
   }
 
   get changes(): Changes<Image> {

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -7,8 +7,8 @@ import {
   BaseEntity,
   EntityManager,
   setOpts,
-  OptsOf,
   PartialOrNull,
+  OptsOf,
   Changes,
   newChangesProxy,
   Lens,
@@ -97,7 +97,7 @@ export abstract class PublisherCodegen extends BaseEntity {
 
   constructor(em: EntityManager, opts: PublisherOpts) {
     super(em, publisherMeta);
-    this.set(opts as PublisherOpts, { calledFromConstructor: true } as any);
+    setOpts((this as any) as Publisher, opts, { calledFromConstructor: true });
   }
 
   get id(): PublisherId | undefined {
@@ -128,12 +128,12 @@ export abstract class PublisherCodegen extends BaseEntity {
     setField(this, "size", size);
   }
 
-  set(values: Partial<PublisherOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, opts);
+  set(opts: Partial<PublisherOpts>): void {
+    setOpts((this as any) as Publisher, opts);
   }
 
-  setPartial(values: PartialOrNull<PublisherOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, { ignoreUndefined: true, ...opts });
+  setPartial(opts: PartialOrNull<PublisherOpts>): void {
+    setOpts((this as any) as Publisher, opts as OptsOf<Publisher>, { partial: true });
   }
 
   get changes(): Changes<Publisher> {

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -7,8 +7,8 @@ import {
   BaseEntity,
   EntityManager,
   setOpts,
-  OptsOf,
   PartialOrNull,
+  OptsOf,
   Changes,
   newChangesProxy,
   Lens,
@@ -77,7 +77,7 @@ export abstract class TagCodegen extends BaseEntity {
 
   constructor(em: EntityManager, opts: TagOpts) {
     super(em, tagMeta);
-    this.set(opts as TagOpts, { calledFromConstructor: true } as any);
+    setOpts((this as any) as Tag, opts, { calledFromConstructor: true });
   }
 
   get id(): TagId | undefined {
@@ -100,12 +100,12 @@ export abstract class TagCodegen extends BaseEntity {
     return this.__orm.data["updatedAt"];
   }
 
-  set(values: Partial<TagOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, opts);
+  set(opts: Partial<TagOpts>): void {
+    setOpts((this as any) as Tag, opts);
   }
 
-  setPartial(values: PartialOrNull<TagOpts>, opts: { ignoreUndefined?: boolean } = {}): void {
-    setOpts(this, values as OptsOf<this>, { ignoreUndefined: true, ...opts });
+  setPartial(opts: PartialOrNull<TagOpts>): void {
+    setOpts((this as any) as Tag, opts as OptsOf<Tag>, { partial: true });
   }
 
   get changes(): Changes<Tag> {

--- a/packages/integration-tests/src/entities/inserts.ts
+++ b/packages/integration-tests/src/entities/inserts.ts
@@ -32,6 +32,7 @@ export async function insertBookToTag(row: { id?: number; book_id: number; tag_i
 export async function insertBookReview(row: { id?: number; book_id: number; rating: number; is_public?: boolean }) {
   await knex.insert({ is_public: true, ...row }).into("book_reviews");
 }
+
 export async function insertImage(row: {
   id?: number;
   type_id: number;
@@ -41,4 +42,16 @@ export async function insertImage(row: {
   file_name: string;
 }) {
   await knex.insert(row).into("images");
+}
+
+export async function countOfBooks() {
+  return (await knex.select("*").from("books")).length;
+}
+
+export async function countOfTags() {
+  return (await knex.select("*").from("tags")).length;
+}
+
+export async function countOfBookToTags() {
+  return (await knex.select("*").from("books_to_tags")).length;
 }

--- a/packages/orm/src/collections/OneToManyCollection.ts
+++ b/packages/orm/src/collections/OneToManyCollection.ts
@@ -187,7 +187,10 @@ export class OneToManyCollection<T extends Entity, U extends Entity> extends Abs
   private maybeAppendAddedBeforeLoaded(): void {
     if (this.loaded) {
       const newEntities = this.addedBeforeLoaded.filter((e) => !this.loaded?.includes(e));
-      this.loaded.unshift(...newEntities);
+      // Push on the end to better match the db order of "newer things come last"
+      for (const e of newEntities) {
+        this.loaded.push(e);
+      }
       this.addedBeforeLoaded = [];
     }
   }

--- a/packages/orm/src/createOrUpdatePartial.ts
+++ b/packages/orm/src/createOrUpdatePartial.ts
@@ -1,15 +1,5 @@
 import { NullOrDefinedOr } from "./utils";
-import {
-  Entity,
-  EntityConstructor,
-  EntityManager,
-  Exact,
-  getMetadata,
-  IdOf,
-  isEntity,
-  isKey,
-  OptsOf,
-} from "./EntityManager";
+import { Entity, EntityConstructor, EntityManager, getMetadata, IdOf, isEntity, isKey, OptsOf } from "./EntityManager";
 import { PartialOrNull } from "./index";
 
 /**
@@ -28,7 +18,7 @@ type AllowRelationsToBeIdsOrEntitiesOrPartials<T> = {
   [P in keyof T]: T[P] extends NullOrDefinedOr<infer U>
     ? U extends Array<infer V>
       ? V extends Entity
-        ? Array<V | DeepPartialOrNull<V> | IdOf<V>> | null
+        ? Array<V | (DeepPartialOrNull<V> & { delete?: boolean | null; remove?: boolean | null }) | IdOf<V>> | null
         : T[P]
       : U extends Entity
       ? U | DeepPartialOrNull<U> | IdOf<U> | null
@@ -39,10 +29,10 @@ type AllowRelationsToBeIdsOrEntitiesOrPartials<T> = {
 /**
  * A utility function to create-or-update entities coming from a partial-update style API.
  */
-export async function createOrUpdatePartial<T extends Entity, O>(
+export async function createOrUpdatePartial<T extends Entity>(
   em: EntityManager,
   constructor: EntityConstructor<T>,
-  opts: Exact<DeepPartialOrNull<T>, O>,
+  opts: DeepPartialOrNull<T>,
 ): Promise<T> {
   const { id, ...others } = opts;
   const meta = getMetadata(constructor);
@@ -51,6 +41,13 @@ export async function createOrUpdatePartial<T extends Entity, O>(
   const p = Object.entries(others).map(async ([key, value]) => {
     const field = meta.fields.find((f) => f.fieldName === key);
     if (!field) {
+      // Allow delete/remove flags that we assume the API layer (i.e. GraphQL) will have specifically
+      // allowed, i.e. this isn't the Rails form bug where users can POST in any random field they want.
+      const flagField = key === "delete" || key === "remove";
+      if (flagField) {
+        // Pass these along for setOpts to look for
+        return [key, value];
+      }
       throw new Error(`Unknown field ${key}`);
     }
     if (field.kind === "m2o" && !isEntity(value)) {
@@ -67,6 +64,12 @@ export async function createOrUpdatePartial<T extends Entity, O>(
       }
     } else if (field.kind === "o2m" || field.kind === "m2m") {
       // Look for one-to-many/many-to-many partials
+
+      // We allow `delete` and `remove` commands but only if they don't collide with existing fields
+      // Also we trust the API layer, i.e. GraphQL, to not let these fields leak unless explicitly allowed.
+      const allowDelete = !field.otherMetadata().fields.some((f) => f.fieldName === "delete");
+      const allowRemove = !field.otherMetadata().fields.some((f) => f.fieldName === "remove");
+
       const entities = !value
         ? []
         : (value as Array<any>).map(async (value) => {
@@ -75,7 +78,17 @@ export async function createOrUpdatePartial<T extends Entity, O>(
             } else if (isKey(value)) {
               return await em.load(field.otherMetadata().cstr, value);
             } else {
-              return await createOrUpdatePartial(em, field.otherMetadata().cstr, value as any);
+              // Look for `delete: true/false` and `remove: true/false` markers
+              const deleteMarker = allowDelete && value["delete"];
+              const removeMarker = allowRemove && value["remove"];
+              // Remove the markers, regardless of true/false, before recursing into createOrUpdatePartial to avoid unknown fields
+              if (deleteMarker !== undefined) delete value.delete;
+              if (removeMarker !== undefined) delete value.remove;
+              const entity = await createOrUpdatePartial(em, field.otherMetadata().cstr, value as any);
+              // Put the markers back for setOpts to find
+              if (deleteMarker === true) entity.delete = true;
+              if (removeMarker === true) entity.remove = true;
+              return entity;
             }
           });
       return [key, await Promise.all(entities)];

--- a/packages/orm/src/utils.ts
+++ b/packages/orm/src/utils.ts
@@ -46,5 +46,18 @@ export function indexBy<T, Y = T>(list: T[], fn: (x: T) => string, valueFn?: (x:
   return result;
 }
 
+export function partition<T>(array: ReadonlyArray<T>, f: (el: T) => boolean): [T[], T[]] {
+  const trueElements: T[] = [];
+  const falseElements: T[] = [];
+  array.forEach((el) => {
+    if (f(el)) {
+      trueElements.push(el);
+    } else {
+      falseElements.push(el);
+    }
+  });
+  return [trueElements, falseElements];
+}
+
 // Utility type to strip off null and defined and infer only T.
 export type NullOrDefinedOr<T> = T | null | undefined;


### PR DESCRIPTION
We also look for 'delete' and 'remove' markers to either delete or
remove the method from the collection.

Right now 'delete' == `EntityManager.delete` i.e. not soft-deleting.