### PR TITLE
Optimize findExistingInstance and getMetadata.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -227,7 +227,7 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
       ${[o2m, m2o, o2o, m2m]}
 
       constructor(em: ${EntityManager}, opts: ${entityName}Opts) {
-        ${hasDefaultValues ? code`super(em, ${metadata}, {...${defaultValuesName}})` : code`super(em, ${metadata})`};
+        super(em, ${metadata}, ${hasDefaultValues ? `${defaultValuesName}` : "{}"}, opts);
         ${setOpts}(this as any as ${entityName}, opts, { calledFromConstructor: true });
       }
 

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1,4 +1,4 @@
-import { entityLimit, EntityManager, Loaded, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
+import { EntityManager, Loaded, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
 import { Author, Book, Publisher, PublisherSize } from "./entities";
 import { knex, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
 import {

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -143,7 +143,7 @@ export abstract class AuthorCodegen extends BaseEntity {
   readonly image: Reference<Author, Image, undefined> = hasOneToOne(imageMeta, "image", "author");
 
   constructor(em: EntityManager, opts: AuthorOpts) {
-    super(em, authorMeta);
+    super(em, authorMeta, {}, opts);
     setOpts((this as any) as Author, opts, { calledFromConstructor: true });
   }
 

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -104,7 +104,7 @@ export abstract class BookAdvanceCodegen extends BaseEntity {
   readonly publisher: Reference<BookAdvance, Publisher, never> = hasOne(publisherMeta, "publisher", "bookAdvances");
 
   constructor(em: EntityManager, opts: BookAdvanceOpts) {
-    super(em, bookAdvanceMeta);
+    super(em, bookAdvanceMeta, {}, opts);
     setOpts((this as any) as BookAdvance, opts, { calledFromConstructor: true });
   }
 

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -128,7 +128,7 @@ export abstract class BookCodegen extends BaseEntity {
   readonly tags: Collection<Book, Tag> = hasManyToMany("books_to_tags", "tags", "book_id", tagMeta, "books", "tag_id");
 
   constructor(em: EntityManager, opts: BookOpts) {
-    super(em, bookMeta, { ...bookDefaultValues });
+    super(em, bookMeta, bookDefaultValues, opts);
     setOpts((this as any) as Book, opts, { calledFromConstructor: true });
   }
 

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -88,7 +88,7 @@ export abstract class BookReviewCodegen extends BaseEntity {
   readonly book: Reference<BookReview, Book, never> = hasOne(bookMeta, "book", "reviews");
 
   constructor(em: EntityManager, opts: BookReviewOpts) {
-    super(em, bookReviewMeta);
+    super(em, bookReviewMeta, {}, opts);
     setOpts((this as any) as BookReview, opts, { calledFromConstructor: true });
   }
 

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -118,7 +118,7 @@ export abstract class ImageCodegen extends BaseEntity {
   readonly publisher: Reference<Image, Publisher, undefined> = hasOne(publisherMeta, "publisher", "images");
 
   constructor(em: EntityManager, opts: ImageOpts) {
-    super(em, imageMeta);
+    super(em, imageMeta, {}, opts);
     setOpts((this as any) as Image, opts, { calledFromConstructor: true });
   }
 

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -106,7 +106,7 @@ export abstract class PublisherCodegen extends BaseEntity {
   readonly images: Collection<Publisher, Image> = hasMany(imageMeta, "images", "publisher", "publisher_id");
 
   constructor(em: EntityManager, opts: PublisherOpts) {
-    super(em, publisherMeta);
+    super(em, publisherMeta, {}, opts);
     setOpts((this as any) as Publisher, opts, { calledFromConstructor: true });
   }
 

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -81,7 +81,7 @@ export abstract class TagCodegen extends BaseEntity {
   );
 
   constructor(em: EntityManager, opts: TagOpts) {
-    super(em, tagMeta);
+    super(em, tagMeta, {}, opts);
     setOpts((this as any) as Tag, opts, { calledFromConstructor: true });
   }
 

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -21,9 +21,13 @@ export abstract class BaseEntity implements Entity {
   abstract id: string | undefined;
   readonly __orm: EntityOrmField;
 
-  protected constructor(em: EntityManager, metadata: any, data?: Record<string, any>) {
-    this.__orm = { em, metadata, data: data || {}, originalData: {} };
-    em.register(this);
+  protected constructor(em: EntityManager, metadata: any, defaultValues: object, opts: any) {
+    this.__orm = { em, metadata, data: { ...defaultValues }, originalData: {} };
+    // Ensure we have at least id set so the `EntityManager.register` works
+    if (typeof opts === "string") {
+      this.__orm.data["id"] = opts;
+    }
+    em.register(metadata, this);
   }
 
   get idUntagged(): string | undefined {

--- a/packages/orm/src/collections/ManyToOneReference.ts
+++ b/packages/orm/src/collections/ManyToOneReference.ts
@@ -210,6 +210,6 @@ export class ManyToOneReference<T extends Entity, U extends Entity, N extends ne
   }
 
   private maybeFindExisting(): U | undefined {
-    return this.id !== undefined ? getEm(this.entity)["findExistingInstance"](this.otherMeta.cstr, this.id) : undefined;
+    return this.id !== undefined ? getEm(this.entity)["findExistingInstance"](this.id) : undefined;
   }
 }

--- a/packages/orm/src/collections/OneToManyCollection.ts
+++ b/packages/orm/src/collections/OneToManyCollection.ts
@@ -222,7 +222,7 @@ function loaderForCollection<T extends Entity, U extends Entity>(
   const loaderName = `${meta.tableName}.${collection.fieldName}`;
   return getOrSet(em.__data.loaders, loaderName, () => {
     return new DataLoader<string, U[]>(async (_keys) => {
-      const otherMeta = collection.otherMeta;
+      const { otherMeta } = collection;
 
       assertIdsAreTagged(_keys);
       const keys = deTagIds(meta, _keys);

--- a/packages/orm/src/getProperties.ts
+++ b/packages/orm/src/getProperties.ts
@@ -16,7 +16,7 @@ export function getProperties<T extends Entity>(meta: EntityMetadata<T>): string
     ...Object.keys(
       new meta.cstr(
         {
-          register: (entity: any) => {
+          register: (metadata: any, entity: any) => {
             em.currentlyInstantiatingEntity = entity;
           },
         } as any,

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -7,7 +7,6 @@ import {
   EntityOrmField,
   getMetadata,
   IdOf,
-  isEntity,
   Loaded,
   LoadHint,
   OptsOf,
@@ -171,11 +170,12 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
  */
 export function setOpts<T extends Entity>(
   entity: T,
-  values: Partial<OptsOf<T>>,
+  values: Partial<OptsOf<T>> | string | undefined,
   opts?: { calledFromConstructor?: boolean; partial?: boolean },
 ): void {
-  // If `values` is undefined, this instance is being hydrated from a database row, so skip all this.
-  if (values === undefined) {
+  // If `values` is a string (i.e. the id), this instance is being hydrated from a database row, so skip all this.
+  // If `values` is undefined, we're being called by `createPartial` that will do its own opt handling.
+  if (values === undefined || typeof values === "string") {
     return;
   }
   const requiredKeys = getRequiredKeys(entity);


### PR DESCRIPTION
Profiling a query that loaded ~2,000 entities showed large hot-spots
in `findExistingInstance` + `isEntity` + `getMetadata`. It was taking
~60 seconds and eventually timing out.

Adding an index for `findExistingInstance` dropped the time for the
same query to ~3 seconds and then it fails with a "too many entities"
error.

Kinda surprised at how much of a difference this makes, but when loading
~1000s of entities, findExistingInstance is called in a tight loop and
turns out O(N^2) is not a great idea.