### PR TITLE
Fix leaking contexty resource

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "migrate": "./run.sh ../../node_modules/joist-migration-utils",
-    "test": "./node_modules/.bin/jest --runInBand --detectOpenHandles",
+    "test": "./node_modules/.bin/jest --runInBand --detectOpenHandles --logHeapUsage",
     "codegen": "./run.sh ../codegen"
   },
   "dependencies": {


### PR DESCRIPTION
`flush()` throws for validations, so in those cases it never actually gets to `this.contexty.cleanup()`, which leaves a whole bunch of empty maps here: https://github.com/stephenh/joist-ts/blob/master/packages/orm/src/contexty.ts#L3