### PR TITLE
Access context in hooks

### DIFF
--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -20,6 +20,7 @@ export interface EntityConfig {
 }
 
 export interface Config {
+  contextType?: string;
   entitiesDirectory: string;
   codegenPlugins: string[];
   entities: Record<string, EntityConfig>;

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -181,6 +181,7 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
   const hasDefaultValues = defaultValues.length > 0;
   const defaultValuesName = `${camelCase(entityName)}DefaultValues`;
 
+  const contextType = config.contextType ? imp(config.contextType) : "{}";
   const factoryMethod = imp(`new${entity.name}@./entities`);
 
   return code`
@@ -211,7 +212,7 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
     
     ${hasDefaultValues ? code`export const ${defaultValuesName} = { ${defaultValues} };` : ""}
 
-    export const ${configName} = new ${ConfigApi}<${entity.type}>();
+    export const ${configName} = new ${ConfigApi}<${entity.type}, ${contextType}>();
 
     ${generateDefaultValidationRules(meta, configName)}
   

--- a/packages/integration-tests/jest.config.js
+++ b/packages/integration-tests/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   testMatch: ["<rootDir>/src/**/*.test.(ts|tsx)"],
   testEnvironment: "node",
   maxConcurrency: 1,
+  resetMocks: true,
 };

--- a/packages/integration-tests/joist-codegen.json
+++ b/packages/integration-tests/joist-codegen.json
@@ -1,5 +1,6 @@
 {
   "codegenPlugins": ["joist-graphql-codegen"],
+  "contextType": "Context@src/context",
   "entities": {
     "Author": {
       "fields": {

--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -9,12 +9,12 @@ import {
   Publisher,
   Tag,
 } from "@src/entities";
-import { EntityManager, New } from "joist-orm";
-import { knex } from "./setupDbTests";
+import { New } from "joist-orm";
+import { newEntityManager } from "./setupDbTests";
 
 describe("EntityManager.factories", () => {
   it("can create a single top-level entity", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given a simple entity that has no required parents/children
     const p1 = newPublisher(em);
     await em.flush();
@@ -24,7 +24,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a child and a required parent", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given we make a book with no existing/passed authors
     const b1 = newBook(em);
     await em.flush();
@@ -33,7 +33,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a child and a required parent if opt is undefined", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given we make a book with no existing/passed authors
     const b1 = newBook(em, { author: undefined });
     await em.flush();
@@ -42,7 +42,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a child and a required parent with opts", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given we make a book with no existing/passed authors
     const b1 = newBook(em, { author: { firstName: "long name" } });
     await em.flush();
@@ -51,7 +51,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a child and use an existing parent from opt", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given there is an existing author
     const a1 = newAuthor(em);
     // When we explicitly pass it as an opt
@@ -62,7 +62,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a child and use an existing parent from EntityManager", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given there is only a single author
     const a1 = newAuthor(em);
     // When we make a book and don't specify the author
@@ -73,7 +73,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a child and create a new parent if already many existing", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given there are already several authors
     const a1 = newAuthor(em);
     const a2 = newAuthor(em);
@@ -87,7 +87,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a grandchild and specify the grandparent", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given there are multiple existing publishers
     const p1 = newPublisher(em);
     newPublisher(em);
@@ -102,7 +102,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a grandchild and specify the grandparents opts", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // When we make a book and have opts for the grandparent
     const b1 = newBook(em, { author: { publisher: { name: "p1" } } });
     await em.flush();
@@ -115,7 +115,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can create a parent and child with opts", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given we make a new parent + two children
     const a1 = newAuthor(em, { books: [{ title: "b1" }, {}] });
     await em.flush();
@@ -132,7 +132,7 @@ describe("EntityManager.factories", () => {
   });
 
   it("can default a required enum", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given we make a book advance
     const ba = newBookAdvance(em);
     // Then the status field is set to the 1st enum value
@@ -140,13 +140,13 @@ describe("EntityManager.factories", () => {
   });
 
   it("can tweak opts in the factory", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a = newAuthor(em, { isPopular: true });
     expect(a.age).toEqual(50);
   });
 
   it("can completely customize opts in the factory", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const b = newBook(em, { tags: [1, 2] });
     const tags = b.tags.get as New<Tag>[];
     expect(tags[0].name).toEqual("1");
@@ -154,27 +154,27 @@ describe("EntityManager.factories", () => {
   });
 
   it("cannot pass invalid customized opts", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // @ts-expect-error
     newBook(em, { tags: [{ name: "t1" }] });
   });
 
   it("can use tagged ids as shortcuts", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = newAuthor(em);
     const b1 = newBook(em, { author: "a:1" });
     expect(b1.author.get).toEqual(a1);
   });
 
   it("can use tagged ids as shortcuts in list", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = newAuthor(em);
     const p1 = newPublisher(em, { authors: ["a:1"] });
     expect(p1.authors.get).toEqual([a1]);
   });
 
   it("can omit default values for non-required primitive fields", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = newAuthor(em);
     expect(a1.firstName).toEqual("a1");
     expect(a1.lastName).toBeUndefined();

--- a/packages/integration-tests/src/EntityManager.populate.test.ts
+++ b/packages/integration-tests/src/EntityManager.populate.test.ts
@@ -1,13 +1,12 @@
-import { EntityManager } from "joist-orm";
-import { knex, numberOfQueries, resetQueryCount } from "./setupDbTests";
-import { Author, Book, Publisher } from "./entities";
 import { insertAuthor, insertBook, insertPublisher } from "@src/entities/inserts";
+import { Author, Book, Publisher } from "./entities";
+import { newEntityManager, numberOfQueries, resetQueryCount } from "./setupDbTests";
 
 describe("EntityManager.populate", () => {
   it("can populate many-to-one", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const booka = await em.load(Book, "1");
     const bookb = await em.populate(booka, "author");
     expect(bookb.author.get.firstName).toEqual("a1");
@@ -16,7 +15,7 @@ describe("EntityManager.populate", () => {
   it("can populate many-to-one with multiple keys", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const booka = await em.load(Book, "1");
     const bookb = await em.populate(booka, ["author", "tags"]);
     expect(bookb.author.get.firstName).toEqual("a1");
@@ -27,7 +26,7 @@ describe("EntityManager.populate", () => {
     await insertPublisher({ name: "p1" });
     await insertAuthor({ first_name: "a1", publisher_id: 1 });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const booka = await em.load(Book, "1");
     const bookb = await em.populate(booka, { author: "publisher" });
     expect(bookb.author.get.firstName).toEqual("a1");
@@ -42,7 +41,7 @@ describe("EntityManager.populate", () => {
     await insertBook({ title: "b2", author_id: 1 });
     await insertBook({ title: "b3", author_id: 2 });
     await insertBook({ title: "b4", author_id: 2 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
 
     const asyncPub = await em.load(Publisher, "1");
     resetQueryCount();
@@ -61,7 +60,7 @@ describe("EntityManager.populate", () => {
     await insertBook({ title: "b2", author_id: 1 });
     await insertBook({ title: "b3", author_id: 2 });
     await insertBook({ title: "b4", author_id: 2 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
 
     const asyncPub = await em.load(Publisher, "1");
     resetQueryCount();
@@ -75,7 +74,7 @@ describe("EntityManager.populate", () => {
   it("can populate via load", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "1", ["author", "tags"]);
     expect(book.author.get.firstName).toEqual("a1");
     expect(book.tags.get.length).toEqual(0);
@@ -86,7 +85,7 @@ describe("EntityManager.populate", () => {
     await insertBook({ title: "b1", author_id: 1 });
     await insertBook({ title: "b2", author_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const _b1 = await em.load(Book, "1");
     const _b2 = await em.load(Book, "1");
     const [b1, b2] = await em.populate([_b1, _b2], "author");
@@ -99,7 +98,7 @@ describe("EntityManager.populate", () => {
     await insertBook({ title: "b1", author_id: 1 });
     await insertBook({ title: "b2", author_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const _b1 = await em.load(Book, "1");
     const _b2 = await em.load(Book, "1");
     resetQueryCount();
@@ -118,7 +117,7 @@ describe("EntityManager.populate", () => {
     await insertAuthor({ first_name: "a2" });
     await insertBook({ title: "b1", author_id: 1 });
     await insertBook({ title: "b2", author_id: 2 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     resetQueryCount();
     const books = await em.find(Book, {}, { populate: "author" });
     expect(books[0].author.get.firstName).toEqual("a1");
@@ -128,7 +127,7 @@ describe("EntityManager.populate", () => {
 
   it("does not break when populating through null relations  ", async () => {
     await insertAuthor({ first_name: "a1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.load(Author, "1", { publisher: "authors" });
     expect(a1.publisher.get).toBeUndefined();
   });
@@ -136,7 +135,7 @@ describe("EntityManager.populate", () => {
   it("populate assumes ids are loaded", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "1", "author");
     const authorId: string = book.author.id;
     expect(authorId).toEqual("a:1");
@@ -144,7 +143,7 @@ describe("EntityManager.populate", () => {
 
   it("can populate two literals", async () => {
     await insertAuthor({ first_name: "a1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.load(Author, "1", { publisher: {}, books: { reviews: "book" } } as const);
     expect(a1.publisher.get).toEqual(undefined);
     expect(a1.books.get.flatMap((b) => b.reviews.get)).toEqual([]);

--- a/packages/integration-tests/src/EntityManager.txns.test.ts
+++ b/packages/integration-tests/src/EntityManager.txns.test.ts
@@ -2,7 +2,7 @@ import { Publisher } from "@src/entities";
 import { Stepper } from "@src/Stepper.test";
 import { EntityManager, newPgConnectionConfig } from "joist-orm";
 import { Pool } from "pg";
-import { knex } from "./setupDbTests";
+import { knex, newEntityManager } from "./setupDbTests";
 
 describe("EntityManager", () => {
   it("reproduces anomalies w/o transactions", async () => {
@@ -125,7 +125,7 @@ describe("EntityManager", () => {
     const steps = new Stepper();
 
     const t1 = (async () => {
-      const em = new EntityManager(knex);
+      const em = newEntityManager();
       await em.transaction(async () => {
         await steps.on(1, async () => em.find(Publisher, { name: "foo" }));
         await steps.on(3, async () => em.create(Publisher, { name: "foo" }));
@@ -134,7 +134,7 @@ describe("EntityManager", () => {
     })();
 
     const t2 = (async () => {
-      const em = new EntityManager(knex);
+      const em = newEntityManager();
       await em.transaction(async () => {
         await steps.on(2, async () => em.find(Publisher, { name: "foo" }));
         await steps.on(4, async () => em.create(Publisher, { name: "foo" }));

--- a/packages/integration-tests/src/EntityManager.unsafe.test.ts
+++ b/packages/integration-tests/src/EntityManager.unsafe.test.ts
@@ -10,37 +10,37 @@ import {
 } from "@src/entities/inserts";
 import { EntityManager } from "joist-orm";
 import { Author, Book } from "./entities";
-import { knex } from "./setupDbTests";
+import { knex, newEntityManager } from "./setupDbTests";
 
 describe("EntityManager", () => {
   it("can create new entity with valid data", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1" });
     expect(a1.firstName).toEqual("a1");
   });
 
   it("fails to create new entity with invalid data", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     await em.createOrUpdatePartial(Author, { id: null, firstName: null });
     await expect(em.flush()).rejects.toThrow("firstName is required");
   });
 
   it("can update an entity with valid data", async () => {
     await insertAuthor({ first_name: "a1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { id: "1", firstName: "a2" });
     expect(a1.firstName).toEqual("a2");
   });
 
   it("fails to update an entity with valid data", async () => {
     await insertAuthor({ first_name: "a1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     await em.createOrUpdatePartial(Author, { id: "1", firstName: null });
     await expect(em.flush()).rejects.toThrow("firstName is required");
   });
 
   it("can create new children with valid data", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, {
       firstName: "a1",
       mentor: { firstName: "m1" },
@@ -53,7 +53,7 @@ describe("EntityManager", () => {
 
   it("can update existing references with valid data", async () => {
     await insertAuthor({ first_name: "m1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, {
       firstName: "a1",
       mentor: { id: "1", firstName: "m2" },
@@ -67,7 +67,7 @@ describe("EntityManager", () => {
   it("can update existing references without an id", async () => {
     await insertAuthor({ first_name: "m1" });
     await insertAuthor({ first_name: "a1", mentor_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, {
       id: "a:2",
       firstName: "a2",
@@ -81,7 +81,7 @@ describe("EntityManager", () => {
 
   it("can update existing references without an id that is not set", async () => {
     await insertAuthor({ first_name: "a1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, {
       id: "a:1",
       firstName: "a2",
@@ -95,35 +95,35 @@ describe("EntityManager", () => {
 
   it("references can refer to entities by id", async () => {
     await insertAuthor({ first_name: "m1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: "1" });
     expect((await a1.mentor.load())!.firstName).toEqual("m1");
   });
 
   it("references can refer to entities by id opt", async () => {
     await insertAuthor({ first_name: "m1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentorId: "1" });
     expect((await a1.mentor.load())!.firstName).toEqual("m1");
   });
 
   it("references can refer to null", async () => {
     await insertAuthor({ first_name: "m1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: null });
     expect(a1.mentor.isSet).toBeFalsy();
   });
 
   it("references can refer to undefined", async () => {
     await insertAuthor({ first_name: "m1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: undefined });
     expect(a1.mentor.isSet).toBeFalsy();
   });
 
   it("references can refer to entity", async () => {
     await insertAuthor({ first_name: "m1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a1", mentor: await em.load(Author, "1") });
     expect(a1.mentor.id).toEqual("a:1");
   });
@@ -131,7 +131,7 @@ describe("EntityManager", () => {
   it("collections can refer to entities by id", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: ["1"] });
     expect((await a1.books.load())[0].title).toEqual("b1");
   });
@@ -139,7 +139,7 @@ describe("EntityManager", () => {
   it("collections can refer to entities by id opts", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", bookIds: ["1"] });
     expect((await a1.books.load())[0].title).toEqual("b1");
   });
@@ -147,7 +147,7 @@ describe("EntityManager", () => {
   it("collections can refer to null", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: null });
     expect(await a1.books.load()).toEqual([]);
   });
@@ -155,7 +155,7 @@ describe("EntityManager", () => {
   it("collections can refer to undefined", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: undefined });
     expect(await a1.books.load()).toEqual([]);
   });
@@ -163,7 +163,7 @@ describe("EntityManager", () => {
   it("collections are upserted", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", books: [{ title: "b2" }] });
     await em.flush();
     const books = await a1.books.load();
@@ -177,7 +177,7 @@ describe("EntityManager", () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     await insertBook({ title: "b2", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     await em.createOrUpdatePartial(Author, { id: "a:1", books: [{ id: "b:1", delete: true }] });
     await em.flush();
     const rows = await knex.select("*").from("books");
@@ -188,7 +188,7 @@ describe("EntityManager", () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     await insertBook({ title: "b2", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     await em.createOrUpdatePartial(Author, { id: "a:1", books: [{ id: "b:1", title: "b1changed", delete: false }] });
     await em.flush();
     expect(await countOfBooks()).toEqual(2);
@@ -203,7 +203,7 @@ describe("EntityManager", () => {
     await insertTag({ name: "t2" });
     await insertBookToTag({ tag_id: 1, book_id: 1 });
     await insertBookToTag({ tag_id: 2, book_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ id: "t:2", remove: true }] });
     await em.flush();
     expect(await countOfTags()).toEqual(2);
@@ -213,13 +213,13 @@ describe("EntityManager", () => {
   it("collections can refer to entities", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: [await em.load(Book, "1")] });
     expect((await a1.books.load())[0].title).toEqual("b1");
   });
 
   it("createOrUpdatePartial doesnt allow unknown fields to be passed", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given an opt `publisherTypo` (instead of `publisher`) that don't match exactly what Author supports
     await expect(async () => {
       // Then we get a compile error
@@ -229,7 +229,7 @@ describe("EntityManager", () => {
   });
 
   it("createPartial doesnt allow unknown fields to be passed", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     // Given an opt `publisherId` (instead of `publisher`) that don't match exactly what Author supports
     await expect(async () => {
       // Then we get a compile error

--- a/packages/integration-tests/src/collections/CustomCollection.test.ts
+++ b/packages/integration-tests/src/collections/CustomCollection.test.ts
@@ -1,7 +1,6 @@
-import { EntityManager } from "joist-orm";
-import { Book, Image, ImageType, Publisher } from "../entities";
 import { insertAuthor, insertBook, insertImage, insertPublisher } from "@src/entities/inserts";
-import { knex } from "../setupDbTests";
+import { Book, Image, ImageType, Publisher } from "../entities";
+import { newEntityManager } from "../setupDbTests";
 
 describe("CustomCollection", () => {
   it("can load a collection", async () => {
@@ -12,7 +11,7 @@ describe("CustomCollection", () => {
     await insertImage({ file_name: "i2", type_id: 2, author_id: 1 });
     await insertImage({ file_name: "i3", type_id: 1, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const publisher = await em.load(Publisher, "1");
     const images = await publisher.allImages.load();
     expect(images).toHaveLength(3);
@@ -26,7 +25,7 @@ describe("CustomCollection", () => {
     await insertImage({ file_name: "i2", type_id: 2, author_id: 1 });
     await insertImage({ file_name: "i3", type_id: 1, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const publisher = await em.load(Publisher, "1", "allImages");
     expect(publisher.allImages.get).toHaveLength(3);
   });
@@ -38,7 +37,7 @@ describe("CustomCollection", () => {
     await insertImage({ file_name: "i1", type_id: 3, publisher_id: 1 });
     await insertImage({ file_name: "i2", type_id: 2, author_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "1", "image");
     const publisher = await em.load(Publisher, "1", "allImages");
 
@@ -55,7 +54,7 @@ describe("CustomCollection", () => {
     await insertImage({ file_name: "i2", type_id: 2, author_id: 1 });
     await insertImage({ file_name: "i3", type_id: 1, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const publisher = await em.load(Publisher, "1", "allImages");
     const [i1, i2, i3] = await em.loadAll(Image, ["1", "2", "3"], "owner");
     const i4 = em.createPartial(Image, { fileName: "i4" });
@@ -75,7 +74,7 @@ describe("CustomCollection", () => {
     await insertImage({ file_name: "i2", type_id: 2, author_id: 1 });
     await insertImage({ file_name: "i3", type_id: 1, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const publisher = await em.load(Publisher, "1", "allImages");
     const [i1, i2, i3] = await em.loadAll(Image, ["1", "2", "3"], "owner");
     const i4 = em.createPartial(Image, { fileName: "i4" });
@@ -95,7 +94,7 @@ describe("CustomCollection", () => {
     await insertImage({ file_name: "i2", type_id: 2, author_id: 1 });
     await insertImage({ file_name: "i3", type_id: 1, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const publisher = await em.load(Publisher, "1", "allImages");
     const [i1, i2, i3] = await em.loadAll(Image, ["1", "2", "3"], "owner");
 

--- a/packages/integration-tests/src/collections/CustomReference.test.ts
+++ b/packages/integration-tests/src/collections/CustomReference.test.ts
@@ -1,14 +1,13 @@
 import { insertAuthor, insertBook, insertBookReview, insertImage } from "@src/entities/inserts";
-import { EntityManager } from "joist-orm";
 import { Author, Book, BookReview, Image, ImageType } from "../entities";
-import { knex } from "../setupDbTests";
+import { knex, newEntityManager } from "../setupDbTests";
 
 describe("CustomReference", () => {
   it("can load a reference", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertImage({ type_id: 2, file_name: "i1", author_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const i1 = await em.load(Image, "1");
     const a2 = await i1.owner.load();
     expect((a2 as Author).firstName).toEqual("a1");
@@ -18,7 +17,7 @@ describe("CustomReference", () => {
     await insertAuthor({ first_name: "a1" });
     await insertImage({ type_id: 2, file_name: "i1", author_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const image = await em.load(Image, "1", "owner");
     expect((image.owner.get as Author).firstName).toEqual("a1");
   });
@@ -28,7 +27,7 @@ describe("CustomReference", () => {
     await insertAuthor({ first_name: "a2" });
     await insertImage({ type_id: 2, file_name: "f1", author_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const [a1, a2] = await em.find(Author, { id: ["1", "2"] });
     const i1 = await em.load(Image, "1", "owner");
     expect(i1.owner.get).toEqual(a1);
@@ -37,7 +36,7 @@ describe("CustomReference", () => {
   });
 
   it("can set a reference", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const image = em.create(Image, { type: ImageType.AuthorImage, fileName: "f1" });
     const author = em.create(Author, { firstName: "a1" });
     image.owner.set(author);
@@ -52,7 +51,7 @@ describe("CustomReference", () => {
     await insertAuthor({ first_name: "a2" });
     await insertImage({ type_id: 2, file_name: "f1", author_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a2 = await em.load(Author, "2");
     const i1 = await em.load(Image, "1", "owner");
     i1.owner.set(a2);
@@ -68,7 +67,7 @@ describe("CustomReference", () => {
     await insertBook({ title: "b1", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a2 = await em.load(Author, "2");
     const r1 = await em.load(BookReview, "1");
 
@@ -78,7 +77,7 @@ describe("CustomReference", () => {
   it("can load against a new entity", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "1");
     const review = em.createPartial(BookReview, { book, rating: 5 });
     const author = await review.author.load();

--- a/packages/integration-tests/src/collections/ManyToManyCollection.test.ts
+++ b/packages/integration-tests/src/collections/ManyToManyCollection.test.ts
@@ -1,8 +1,7 @@
-import { EntityManager } from "joist-orm";
-import { zeroTo } from "../utils";
-import { knex, numberOfQueries, resetQueryCount } from "../setupDbTests";
-import { Author, Book, Tag } from "../entities";
 import { countOfBookToTags, insertAuthor, insertBook, insertBookToTag, insertTag } from "@src/entities/inserts";
+import { Author, Book, Tag } from "../entities";
+import { knex, newEntityManager, numberOfQueries, resetQueryCount } from "../setupDbTests";
+import { zeroTo } from "../utils";
 
 describe("ManyToManyCollection", () => {
   it("can load a many-to-many", async () => {
@@ -11,7 +10,7 @@ describe("ManyToManyCollection", () => {
     await insertTag({ id: 3, name: "t1" });
     await insertBookToTag({ id: 4, book_id: 2, tag_id: 3 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "2");
     const tags = await book.tags.load();
     expect(tags.length).toEqual(1);
@@ -24,7 +23,7 @@ describe("ManyToManyCollection", () => {
     await insertTag({ id: 3, name: "t1" });
     await insertBookToTag({ id: 4, book_id: 2, tag_id: 3 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "2", "tags");
     const tag = await em.load(Tag, "3", "books");
     expect(book.tags.get.length).toEqual(1);
@@ -45,7 +44,7 @@ describe("ManyToManyCollection", () => {
       }),
     );
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "1");
     resetQueryCount();
     const tags = await book.tags.load();
@@ -72,7 +71,7 @@ describe("ManyToManyCollection", () => {
       }),
     );
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "1");
     const tag = await em.load(Tag, "1");
     resetQueryCount();
@@ -88,7 +87,7 @@ describe("ManyToManyCollection", () => {
     await insertBook({ id: 2, title: "b1", author_id: 1 });
     await insertTag({ id: 3, name: `t1` });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "2");
     const tag = await em.load(Tag, "3");
 
@@ -104,7 +103,7 @@ describe("ManyToManyCollection", () => {
     await insertBook({ id: 2, title: "b1", author_id: 1 });
     await insertTag({ id: 3, name: `t1` });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "2");
     const tag = await em.load(Tag, "3");
 
@@ -116,7 +115,7 @@ describe("ManyToManyCollection", () => {
   });
 
   it("can add a new tag to a new book", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const author = em.create(Author, { firstName: "a1" });
     const book = em.create(Book, { title: "b1", author });
     const tag = em.create(Tag, { name: "t3" });
@@ -138,7 +137,7 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ book_id: 2, tag_id: 3 });
     await insertBookToTag({ book_id: 2, tag_id: 4 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "2", "tags");
     const tag = await em.load(Tag, "3");
     book.tags.remove(tag);
@@ -157,7 +156,7 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ book_id: 2, tag_id: 3 });
     await insertBookToTag({ book_id: 2, tag_id: 4 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "2");
     const tag = await em.load(Tag, "3");
     // When the tag is removed before book.tags is loaded
@@ -180,7 +179,7 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ book_id: 2, tag_id: 3 });
     await insertBookToTag({ book_id: 2, tag_id: 4 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "2");
     const tag = await em.load(Tag, "3");
     // When the tag is removed when book.tags is unloaded
@@ -198,7 +197,7 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ book_id: 2, tag_id: 3 });
     await insertBookToTag({ book_id: 2, tag_id: 4 });
     // Given a book with two tags
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const b1 = await em.load(Book, "2", "tags");
     const t1 = await em.load(Tag, "3");
     const t2 = await em.load(Tag, "4");
@@ -221,7 +220,7 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ book_id: 2, tag_id: 3 });
     await insertBookToTag({ book_id: 2, tag_id: 4 });
     // Given a book with two tags
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const b1 = await em.load(Book, "2", "tags");
     const t1 = await em.load(Tag, "3");
     const t2 = await em.load(Tag, "4");
@@ -240,7 +239,7 @@ describe("ManyToManyCollection", () => {
     await insertBook({ id: 2, title: "b1", author_id: 1 });
     await insertTag({ id: 3, name: "t1" });
     // Given a book with two tags
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const b1 = await em.load(Book, "2");
     const t1 = await em.load(Tag, "3");
     // And the book is deleted
@@ -254,7 +253,7 @@ describe("ManyToManyCollection", () => {
     await insertBook({ id: 2, title: "b1", author_id: 1 });
     await insertTag({ id: 3, name: "t1" });
     // Given a book with two tags
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const b1 = await em.load(Book, "2");
     const t1 = await em.load(Tag, "3");
     // And the book is deleted
@@ -275,7 +274,7 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ book_id: 2, tag_id: 4 });
 
     // When we set t2 and t3
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "2", "tags");
     const [t2, t3] = await em.loadAll(Tag, ["4", "5"]);
     book.tags.set([t2, t3]);

--- a/packages/integration-tests/src/collections/hasManyDerived.test.ts
+++ b/packages/integration-tests/src/collections/hasManyDerived.test.ts
@@ -1,7 +1,6 @@
-import { EntityManager } from "joist-orm";
-import { Author, Book, BookReview } from "../entities";
 import { insertAuthor, insertBook, insertBookReview } from "@src/entities/inserts";
-import { knex } from "../setupDbTests";
+import { Author, Book, BookReview } from "../entities";
+import { newEntityManager } from "../setupDbTests";
 
 describe("hasManyDerived", () => {
   it("can load a collection", async () => {
@@ -9,7 +8,7 @@ describe("hasManyDerived", () => {
     await insertBook({ title: "b1", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const author = await em.load(Author, "1");
     const books = await author.reviewedBooks.load();
     expect(books.length).toBeGreaterThan(0);
@@ -20,7 +19,7 @@ describe("hasManyDerived", () => {
     await insertBook({ title: "b1", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const author = await em.load(Author, "1", "reviewedBooks");
     expect(author.reviewedBooks.get.length).toBeGreaterThan(0);
   });
@@ -31,7 +30,7 @@ describe("hasManyDerived", () => {
     await insertBook({ title: "b2", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const [b1, b2] = await em.find(Book, { id: ["1", "2"] });
     const author = await em.load(Author, "1", "reviewedBooks");
     const review = await em.load(BookReview, "1");
@@ -47,7 +46,7 @@ describe("hasManyDerived", () => {
     await insertBook({ title: "b2", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const [b1, b2] = await em.find(Book, { id: ["1", "2"] });
     const author = await em.load(Author, "1", "reviewedBooks");
 
@@ -61,7 +60,7 @@ describe("hasManyDerived", () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "1", "reviews");
     const author = await em.load(Author, "1", "reviewedBooks");
 
@@ -76,7 +75,7 @@ describe("hasManyDerived", () => {
     await insertBook({ title: "b1", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const book = await em.load(Book, "1", "reviews");
     const author = await em.load(Author, "1", "reviewedBooks");
 

--- a/packages/integration-tests/src/collections/hasManyThrough.test.ts
+++ b/packages/integration-tests/src/collections/hasManyThrough.test.ts
@@ -1,7 +1,6 @@
-import { EntityManager } from "joist-orm";
-import { Author, BookReview } from "../entities";
-import { knex } from "../setupDbTests";
 import { insertAuthor, insertBook, insertBookReview } from "@src/entities/inserts";
+import { Author, BookReview } from "../entities";
+import { newEntityManager } from "../setupDbTests";
 
 describe("hasManyThrough", () => {
   it("can load a collection", async () => {
@@ -9,7 +8,7 @@ describe("hasManyThrough", () => {
     await insertBook({ title: "t", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const author = await em.load(Author, "1");
     const reviews = await author.reviews.load();
     expect(reviews).toHaveLength(1);
@@ -20,7 +19,7 @@ describe("hasManyThrough", () => {
     await insertBook({ title: "t", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const author = await em.load(Author, "1", "reviews");
     expect(author.reviews.get).toHaveLength(1);
   });
@@ -30,7 +29,7 @@ describe("hasManyThrough", () => {
     await insertBook({ title: "t", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const author = await em.load(Author, "1", ["books", "reviews"]);
     const book = author.books.get[0];
     expect(author.reviews.get).toHaveLength(1);

--- a/packages/integration-tests/src/collections/hasOneDerived.test.ts
+++ b/packages/integration-tests/src/collections/hasOneDerived.test.ts
@@ -1,7 +1,6 @@
 import { BookReview } from "@src/entities";
 import { insertAuthor, insertBook, insertBookReview, insertPublisher } from "@src/entities/inserts";
-import { knex } from "@src/setupDbTests";
-import { EntityManager } from "joist-orm";
+import { newEntityManager } from "@src/setupDbTests";
 
 describe("hasOneDerived", () => {
   it("can load a reference", async () => {
@@ -10,7 +9,7 @@ describe("hasOneDerived", () => {
     await insertBook({ title: "t", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const review = await em.load(BookReview, "1");
     const p1 = await review.publisher.load();
     expect(p1?.name).toEqual("p1");
@@ -22,7 +21,7 @@ describe("hasOneDerived", () => {
     await insertBook({ title: "t", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const p1 = await em.load(BookReview, "1", "publisher");
     expect(p1.publisher.get?.name).toEqual("p1");
   });

--- a/packages/integration-tests/src/collections/hasOneThrough.test.ts
+++ b/packages/integration-tests/src/collections/hasOneThrough.test.ts
@@ -1,7 +1,6 @@
 import { Author, BookReview } from "@src/entities";
 import { insertAuthor, insertBook, insertBookReview } from "@src/entities/inserts";
-import { knex } from "@src/setupDbTests";
-import { EntityManager } from "joist-orm";
+import { newEntityManager } from "@src/setupDbTests";
 
 describe("hasOneThrough", () => {
   it("can load a reference", async () => {
@@ -9,7 +8,7 @@ describe("hasOneThrough", () => {
     await insertBook({ title: "t", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const review = await em.load(BookReview, "1");
     const author = await review.author.load();
     expect(author.firstName).toEqual("f");
@@ -20,7 +19,7 @@ describe("hasOneThrough", () => {
     await insertBook({ title: "t", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const review = await em.load(BookReview, "1", "author");
     expect(review.author.get.firstName).toEqual("f");
   });
@@ -31,7 +30,7 @@ describe("hasOneThrough", () => {
     await insertBook({ title: "t", author_id: 1 });
     await insertBookReview({ rating: 5, book_id: 1 });
 
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a2 = await em.load(Author, "2");
     const review = await em.load(BookReview, "1", ["author", "book"]);
     expect(review.author.get.firstName).toEqual("a1");

--- a/packages/integration-tests/src/context.ts
+++ b/packages/integration-tests/src/context.ts
@@ -1,0 +1,3 @@
+export interface Context {
+  makeApiCall(request: string): Promise<void>;
+}

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -100,7 +100,8 @@ authorConfig.addRule("books", async (a) => {
 
 authorConfig.cascadeDelete("books");
 
-authorConfig.beforeFlush((author) => {
+authorConfig.beforeFlush(async (author, ctx) => {
+  await ctx.makeApiCall("Author.beforeFlush");
   author.beforeFlushRan = true;
   if (author.ageForBeforeFlush !== undefined) {
     author.age = author.ageForBeforeFlush;

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -45,6 +45,7 @@ import {
   publisherMeta,
   imageMeta,
 } from "./entities";
+import { Context } from "src/context";
 
 export type AuthorId = Flavor<string, "Author">;
 
@@ -114,7 +115,7 @@ export interface AuthorOrder {
   publisher?: PublisherOrder;
 }
 
-export const authorConfig = new ConfigApi<Author>();
+export const authorConfig = new ConfigApi<Author, Context>();
 
 authorConfig.addRule(newRequiredRule("firstName"));
 authorConfig.addRule(newRequiredRule("initials"));

--- a/packages/integration-tests/src/entities/Book.test.ts
+++ b/packages/integration-tests/src/entities/Book.test.ts
@@ -1,10 +1,9 @@
-import { EntityManager } from "joist-orm";
-import { knex } from "../setupDbTests";
 import { Author, Book } from "../entities";
+import { newEntityManager } from "../setupDbTests";
 
 describe("Book", () => {
   it("non-null reference might still have a null id", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = em.create(Author, { firstName: "a1" });
     const b1 = em.create(Book, { title: "b1", author: a1 });
     expect(b1.author.id).toBeUndefined();
@@ -12,7 +11,7 @@ describe("Book", () => {
   });
 
   it("should have default values populated immediately on create if they aren't provided as opts", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = em.create(Author, { firstName: "a1" });
     const b1 = em.create(Book, { title: "b1", author: a1 });
     expect(b1.order).toEqual(0);

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -40,6 +40,7 @@ import {
   bookMeta,
   publisherMeta,
 } from "./entities";
+import { Context } from "src/context";
 
 export type BookAdvanceId = Flavor<string, "BookAdvance">;
 
@@ -81,7 +82,7 @@ export interface BookAdvanceOrder {
   publisher?: PublisherOrder;
 }
 
-export const bookAdvanceConfig = new ConfigApi<BookAdvance>();
+export const bookAdvanceConfig = new ConfigApi<BookAdvance, Context>();
 
 bookAdvanceConfig.addRule(newRequiredRule("createdAt"));
 bookAdvanceConfig.addRule(newRequiredRule("updatedAt"));

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -50,6 +50,7 @@ import {
   imageMeta,
   tagMeta,
 } from "./entities";
+import { Context } from "src/context";
 
 export type BookId = Flavor<string, "Book">;
 
@@ -100,7 +101,7 @@ export interface BookOrder {
 
 export const bookDefaultValues = { order: 0 };
 
-export const bookConfig = new ConfigApi<Book>();
+export const bookConfig = new ConfigApi<Book, Context>();
 
 bookConfig.addRule(newRequiredRule("title"));
 bookConfig.addRule(newRequiredRule("createdAt"));

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -28,6 +28,7 @@ import {
   setField,
 } from "joist-orm";
 import { BookReview, newBookReview, bookReviewMeta, Book, BookId, BookOrder, bookMeta } from "./entities";
+import { Context } from "src/context";
 
 export type BookReviewId = Flavor<string, "BookReview">;
 
@@ -67,7 +68,7 @@ export interface BookReviewOrder {
   book?: BookOrder;
 }
 
-export const bookReviewConfig = new ConfigApi<BookReview>();
+export const bookReviewConfig = new ConfigApi<BookReview, Context>();
 
 bookReviewConfig.addRule(newRequiredRule("rating"));
 bookReviewConfig.addRule(newRequiredRule("isPublic"));

--- a/packages/integration-tests/src/entities/Image.test.ts
+++ b/packages/integration-tests/src/entities/Image.test.ts
@@ -1,11 +1,10 @@
 import { Author, Image, ImageType, Publisher } from "@src/entities";
 import { insertAuthor, insertImage } from "@src/entities/inserts";
-import { knex } from "@src/setupDbTests";
-import { EntityManager } from "joist-orm";
+import { newEntityManager } from "@src/setupDbTests";
 
 describe("Image", () => {
   it("can have an owner", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const a1 = em.create(Author, { firstName: "a1" });
     const i = em.create(Image, { type: ImageType.AuthorImage, author: a1, fileName: "f1" });
     await em.flush();
@@ -13,7 +12,7 @@ describe("Image", () => {
   });
 
   it("cannot have multiple owners", async () => {
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const p1 = em.create(Publisher, { name: "p1" });
     const a1 = em.create(Author, { firstName: "a1" });
     const i = em.create(Image, { type: ImageType.AuthorImage, author: a1, publisher: p1, fileName: "f1" });
@@ -23,7 +22,7 @@ describe("Image", () => {
   it("has owner with an image", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertImage({ type_id: 2, author_id: 1, file_name: "i1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const i1 = await em.load(Image, "1");
     expect(await i1.owner.load()).toBeInstanceOf(Author);
   });
@@ -31,7 +30,7 @@ describe("Image", () => {
   it("has owner that can preload", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertImage({ type_id: 2, author_id: 1, file_name: "i1" });
-    const em = new EntityManager(knex);
+    const em = newEntityManager();
     const i1 = await em.load(Image, "1", "owner");
     expect((i1.owner.get! as Author).firstName).toEqual("a1");
   });

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -44,6 +44,7 @@ import {
   bookMeta,
   publisherMeta,
 } from "./entities";
+import { Context } from "src/context";
 
 export type ImageId = Flavor<string, "Image">;
 
@@ -94,7 +95,7 @@ export interface ImageOrder {
   publisher?: PublisherOrder;
 }
 
-export const imageConfig = new ConfigApi<Image>();
+export const imageConfig = new ConfigApi<Image, Context>();
 
 imageConfig.addRule(newRequiredRule("fileName"));
 imageConfig.addRule(newRequiredRule("createdAt"));

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -37,6 +37,7 @@ import {
   bookAdvanceMeta,
   imageMeta,
 } from "./entities";
+import { Context } from "src/context";
 
 export type PublisherId = Flavor<string, "Publisher">;
 
@@ -78,7 +79,7 @@ export interface PublisherOrder {
   size?: OrderBy;
 }
 
-export const publisherConfig = new ConfigApi<Publisher>();
+export const publisherConfig = new ConfigApi<Publisher, Context>();
 
 publisherConfig.addRule(newRequiredRule("name"));
 publisherConfig.addRule(newRequiredRule("createdAt"));

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -22,6 +22,7 @@ import {
   setField,
 } from "joist-orm";
 import { Tag, newTag, tagMeta, Book, BookId, bookMeta } from "./entities";
+import { Context } from "src/context";
 
 export type TagId = Flavor<string, "Tag">;
 
@@ -55,7 +56,7 @@ export interface TagOrder {
   updatedAt?: OrderBy;
 }
 
-export const tagConfig = new ConfigApi<Tag>();
+export const tagConfig = new ConfigApi<Tag, Context>();
 
 tagConfig.addRule(newRequiredRule("name"));
 tagConfig.addRule(newRequiredRule("createdAt"));

--- a/packages/integration-tests/src/setupDbTests.ts
+++ b/packages/integration-tests/src/setupDbTests.ts
@@ -1,6 +1,7 @@
-import Knex from "knex";
 import { config } from "dotenv";
+import { EntityManager } from "joist-orm";
 import { newPgConnectionConfig } from "joist-utils";
+import Knex from "knex";
 
 if (process.env.DATABASE_CONNECTION_INFO === undefined) {
   config({ path: "./local.env" });
@@ -8,6 +9,11 @@ if (process.env.DATABASE_CONNECTION_INFO === undefined) {
 
 // Create a shared test context that tests can use and also we'll use to auto-flush the db between tests.
 export let knex: Knex;
+export const makeApiCall = jest.fn();
+
+export function newEntityManager() {
+  return new EntityManager({ knex, makeApiCall });
+}
 
 export let numberOfQueries = 0;
 export let queries: string[] = [];

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -191,21 +191,23 @@ type MaybePromise<T> = T | PromiseLike<T>;
 export type EntityManagerHook = "beforeTransaction";
 type HookFn = (em: EntityManager, knex: Knex.Transaction) => MaybePromise<any>;
 
-export class EntityManager<C = {}> {
+export type HasKnex = { knex: Knex };
+
+export class EntityManager<C extends HasKnex = HasKnex> {
   private readonly ctx: C;
   public knex: Knex;
 
   constructor(em: EntityManager<C>);
-  constructor(knex: Knex, context?: C);
-  constructor(emOrKnex: EntityManager<C> | Knex, ctx?: C) {
-    if (emOrKnex instanceof EntityManager) {
-      const em = emOrKnex;
+  constructor(ctx: C);
+  constructor(emOrCtx: EntityManager<C> | C) {
+    if (emOrCtx instanceof EntityManager) {
+      const em = emOrCtx;
       this.knex = em.knex;
       this.hooks = { beforeTransaction: [...em.hooks.beforeTransaction] };
       this.ctx = em.ctx!;
     } else {
-      this.knex = emOrKnex;
-      this.ctx = ctx!;
+      this.ctx = emOrCtx!;
+      this.knex = emOrCtx.knex;
     }
   }
 

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -191,18 +191,21 @@ type MaybePromise<T> = T | PromiseLike<T>;
 export type EntityManagerHook = "beforeTransaction";
 type HookFn = (em: EntityManager, knex: Knex.Transaction) => MaybePromise<any>;
 
-export class EntityManager {
+export class EntityManager<C = {}> {
+  private readonly ctx: C;
   public knex: Knex;
 
-  constructor(em: EntityManager);
-  constructor(knex: Knex);
-  constructor(emOrKnex: EntityManager | Knex) {
+  constructor(em: EntityManager<C>);
+  constructor(knex: Knex, context?: C);
+  constructor(emOrKnex: EntityManager<C> | Knex, ctx?: C) {
     if (emOrKnex instanceof EntityManager) {
       const em = emOrKnex;
       this.knex = em.knex;
       this.hooks = { beforeTransaction: [...em.hooks.beforeTransaction] };
+      this.ctx = em.ctx!;
     } else {
       this.knex = emOrKnex;
+      this.ctx = ctx!;
     }
   }
 
@@ -634,14 +637,14 @@ export class EntityManager {
         await addReactiveValidations(todos);
 
         // run our hooks
-        await beforeDelete(todos);
+        await beforeDelete(this.ctx, todos);
         // We defer doing this cascade logic until flush() so that delete() can remain synchronous.
         await cascadeDeletesIntoRelations(todos);
-        await beforeFlush(todos);
+        await beforeFlush(this.ctx, todos);
         recalcDerivedFields(todos);
         await recalcAsyncDerivedFields(this, todos);
         await validate(todos);
-        await afterValidation(todos);
+        await afterValidation(this.ctx, todos);
 
         entitiesToFlush.push(...pendingEntities);
         pendingEntities = this.entities.filter((e) => e.isPendingFlush && !entitiesToFlush.includes(e));
@@ -669,7 +672,7 @@ export class EntityManager {
 
         // TODO: This is really "after flush" if we're being called from a transaction that
         // is going to make multiple `em.flush()` calls?
-        await afterCommit(entityTodos);
+        await afterCommit(this.ctx, entityTodos);
 
         Object.values(entityTodos).forEach((todo) => {
           todo.inserts.forEach((e) => this._entityIndex.set(e.id!, e));
@@ -939,7 +942,7 @@ export interface EntityMetadata<T extends Entity> {
   // Eventually our dbType should go away to support N-column fields
   columns: Array<ColumnMeta>;
   fields: Array<Field>;
-  config: ConfigApi<T>;
+  config: ConfigApi<T, any>;
   factory: (em: EntityManager, opts?: any) => New<T>;
 }
 
@@ -1121,6 +1124,7 @@ async function beforeTransaction(em: EntityManager, knex: Knex.Transaction): Pro
 }
 
 async function runHook(
+  ctx: unknown,
   hook: EntityHook,
   todos: Record<string, Todo>,
   keys: ("inserts" | "deletes" | "updates" | "validates")[],
@@ -1131,26 +1135,26 @@ async function runHook(
     return keys
       .flatMap((k) => todo[k].filter((e) => k === "deletes" || !e.isDeletedEntity))
       .flatMap((entity) => {
-        return hookFns.map(async (fn) => fn(entity));
+        return hookFns.map(async (fn) => fn(entity, ctx as any));
       });
   });
   await Promise.all(p);
 }
 
-async function beforeDelete(todos: Record<string, Todo>): Promise<void> {
-  await runHook("beforeDelete", todos, ["deletes"]);
+async function beforeDelete(ctx: unknown, todos: Record<string, Todo>): Promise<void> {
+  await runHook(ctx, "beforeDelete", todos, ["deletes"]);
 }
 
-async function beforeFlush(todos: Record<string, Todo>): Promise<void> {
-  await runHook("beforeFlush", todos, ["inserts", "updates"]);
+async function beforeFlush(ctx: unknown, todos: Record<string, Todo>): Promise<void> {
+  await runHook(ctx, "beforeFlush", todos, ["inserts", "updates"]);
 }
 
-async function afterValidation(todos: Record<string, Todo>): Promise<void> {
-  await runHook("afterValidation", todos, ["inserts", "updates"]);
+async function afterValidation(ctx: unknown, todos: Record<string, Todo>): Promise<void> {
+  await runHook(ctx, "afterValidation", todos, ["inserts", "updates"]);
 }
 
-async function afterCommit(todos: Record<string, Todo>): Promise<void> {
-  await runHook("afterCommit", todos, ["inserts", "updates"]);
+async function afterCommit(ctx: unknown, todos: Record<string, Todo>): Promise<void> {
+  await runHook(ctx, "afterCommit", todos, ["inserts", "updates"]);
 }
 
 function coerceError(


### PR DESCRIPTION
Should let us move resolver things like:

```
    await ctx.eventbridge.sendBillUpdateEvent(ctx, bill.idOrFail);
```

Into model `beforeFlush` / `afterCommit` hooks.

I'm not entirely satisfied b/c IMO these sort of `afterCommit`s really need to leverage database-as-a-queue such that a single transaction atomically commits both the business data change + the _intent_ to publish an event, such that if the event publishing blows up (even the publishing to eventbridge itself) we have a retry / known-dropped-event.

Granted, this blind spot is probably fine and also super/annoyingly common where applications assume "the event system will take care of retries" but gloss over "...what if the event doesn't get to the event system in the first place"? 