### PR TITLE
Add `repository` to package.json files

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -2,6 +2,11 @@
   "name": "joist-codegen",
   "version": "0.1.0-bump",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stephenh/joist-ts.git",
+    "directory": "packages/codegen"
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {

--- a/packages/graphql-codegen/package.json
+++ b/packages/graphql-codegen/package.json
@@ -2,6 +2,11 @@
   "name": "joist-graphql-codegen",
   "version": "0.1.0-bump",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stephenh/joist-ts.git",
+    "directory": "packages/graphql-codegen"
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -2,6 +2,11 @@
   "name": "joist-integration-tests",
   "version": "0.1.0-bump",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stephenh/joist-ts.git",
+    "directory": "packages/integration-tests"
+  },
   "scripts": {
     "migrate": "./run.sh ../../node_modules/joist-migration-utils",
     "test": "./node_modules/.bin/jest --runInBand --detectOpenHandles --logHeapUsage",

--- a/packages/migration-utils/package.json
+++ b/packages/migration-utils/package.json
@@ -2,6 +2,11 @@
   "name": "joist-migration-utils",
   "version": "0.1.0-bump",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stephenh/joist-ts.git",
+    "directory": "packages/migration-utils"
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -2,6 +2,11 @@
   "name": "joist-orm",
   "version": "0.1.0-bump",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stephenh/joist-ts.git",
+    "directory": "packages/joist-orm"
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
This allows users to easily jump into the proper place in the monorepo via `npm repo` from the CLI, e.g.

```
npm repo joist-orm
```