### PR TITLE
Upgrade node-pg-migrate to 5.x

### DIFF
--- a/packages/migration-utils/package.json
+++ b/packages/migration-utils/package.json
@@ -6,7 +6,7 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@types/pluralize": "0.0.29",
-    "node-pg-migrate": "^4.7.0",
+    "node-pg-migrate": "^5.0.0",
     "pg": "^8.3.0",
     "pg-structure": "^5.10.13",
     "pluralize": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3836,16 +3836,16 @@ node-notifier@^7.0.0:
     uuid "^7.0.3"
     which "^2.0.2"
 
-node-pg-migrate@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/node-pg-migrate/-/node-pg-migrate-4.7.0.tgz#40a0b883203f7103944ccdd8b5bac4411ebd480b"
-  integrity sha512-HP6i7KvBdjtKhzONGen0HMbr29Lv2ATwrD2hmwr8dkYOopdWrpp84vCaSbAL2MGDSZaRxCTMvOTC3iLQiMukkg==
+node-pg-migrate@^5.0.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/node-pg-migrate/-/node-pg-migrate-5.5.0.tgz#2dbc9d01d329b8728418b8f5254d408628ca025d"
+  integrity sha512-3traJNXEMNA6TVzegn35G7uVzziQNKsFSPsG5WdLCMCkVlQ3AURJ6xqhp3Yqvrd7CawO4oHwVrT5R4bVQ7Svqw==
   dependencies:
     "@types/pg" "^7.4.0"
     decamelize "^4.0.0"
     lodash "~4.17.0"
     mkdirp "~1.0.0"
-    yargs "~15.3.0"
+    yargs "~15.4.0"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -5538,7 +5538,7 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yargs-parser@18.x, yargs-parser@^18.1.1:
+yargs-parser@18.x, yargs-parser@^18.1.1, yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
@@ -5546,7 +5546,7 @@ yargs-parser@18.x, yargs-parser@^18.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs@^15.3.1, yargs@~15.3.0:
+yargs@^15.3.1:
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
   integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
@@ -5562,6 +5562,23 @@ yargs@^15.3.1, yargs@~15.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
+
+yargs@~15.4.0:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
This will allow users to use utility functions with 5.x.