### PR TITLE
renamed relation onDelete callbacks

### DIFF
--- a/packages/integration-tests/src/collections/OneToOneReference.test.ts
+++ b/packages/integration-tests/src/collections/OneToOneReference.test.ts
@@ -114,8 +114,8 @@ describe("OneToOneReference", () => {
     const em = newEntityManager();
     const a1 = await em.load(Author, "1", "image");
     await insertImage({ type_id: 2, file_name: "f1", author_id: 1 });
-    await em.refresh()
-    expect(a1.image.isSet).toBeTruthy()
+    await em.refresh();
+    expect(a1.image.isSet).toBeTruthy();
     em.delete(a1);
     await em.flush();
     expect((await knex.select("*").from("images")).length).toEqual(0);
@@ -125,7 +125,7 @@ describe("OneToOneReference", () => {
     await insertAuthor({ first_name: "a1" });
     const em = newEntityManager();
     const a1 = await em.load(Author, "1", "image");
-    expect(a1.image.isSet).toBeFalsy()
+    expect(a1.image.isSet).toBeFalsy();
     em.delete(a1);
     await em.flush();
     expect((await knex.select("*").from("authors")).length).toEqual(0);
@@ -135,7 +135,7 @@ describe("OneToOneReference", () => {
     await insertAuthor({ first_name: "a1" });
     const em = newEntityManager();
     const a1 = await em.load(Author, "1");
-    await em.refresh()
-    expect(() => a1.image.isSet).toThrow("Author:1.image was not loaded")
+    await em.refresh();
+    expect(() => a1.image.isSet).toThrow("Author:1.image was not loaded");
   });
 });

--- a/packages/orm/src/collections/AbstractRelationImpl.ts
+++ b/packages/orm/src/collections/AbstractRelationImpl.ts
@@ -16,13 +16,14 @@ export abstract class AbstractRelationImpl<U> {
 
   /**
    * Called when our entity has been `EntityManager.delete`'d _and_ `EntityManager.flush` is being called,
-   * so we can unset any foreign keys to the being-deleted entity.
+   * so we can unset any foreign keys to the being-deleted entity and clear out any pointers to it.
    */
-  abstract async onEntityDeletedAndFlushing(): Promise<void>;
+  abstract async cleanupOnEntityDeleted(): Promise<void>;
 
   /**
-   * Called when our entity has been `EntityManager.delete`'d so that we can run any special behavior
-   * like cascades
+   * Called to cascade deletes into the relation if it has cascade behavior enabled.  This function is called twice,
+   * once on the initial `EntityManager.delete` call in a potentially unloaded state, then again from a `beforeDelete`
+   * hook after the relation is fully loaded.
    */
-  abstract onEntityDelete(): void;
+  abstract maybeCascadeDelete(): void;
 }

--- a/packages/orm/src/collections/CustomCollection.ts
+++ b/packages/orm/src/collections/CustomCollection.ts
@@ -120,8 +120,8 @@ export class CustomCollection<T extends Entity, U extends Entity> extends Abstra
   }
 
   // these callbacks should be no-ops as they ought to be handled by the underlying relations
-  async onEntityDeletedAndFlushing(): Promise<void> {}
-  onEntityDelete(): void {}
+  async cleanupOnEntityDeleted(): Promise<void> {}
+  maybeCascadeDelete(): void {}
   async refreshIfLoaded(): Promise<void> {}
 
   /** Finds this CustomCollections field name by looking in the entity for the key that we're assigned to. */

--- a/packages/orm/src/collections/CustomReference.ts
+++ b/packages/orm/src/collections/CustomReference.ts
@@ -1,5 +1,5 @@
 import { Entity, IdOf } from "../EntityManager";
-import { deTagIds, ensureNotDeleted, fail, Reference, unsafeDeTagIds } from "../index";
+import { ensureNotDeleted, fail, Reference, unsafeDeTagIds } from "../index";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 
 export type CustomReferenceOpts<T extends Entity, U extends Entity, N extends never | undefined> = {
@@ -106,8 +106,8 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
   }
 
   // these callbacks should be no-ops as they ought to be handled by the underlying relations
-  async onEntityDeletedAndFlushing(): Promise<void> {}
-  onEntityDelete(): void {}
+  async cleanupOnEntityDeleted(): Promise<void> {}
+  maybeCascadeDelete(): void {}
   async refreshIfLoaded(): Promise<void> {}
 
   /** Finds this CustomReferences field name by looking in the entity for the key that we're assigned to. */

--- a/packages/orm/src/collections/ManyToManyCollection.ts
+++ b/packages/orm/src/collections/ManyToManyCollection.ts
@@ -191,13 +191,13 @@ export class ManyToManyCollection<T extends Entity, U extends Entity> extends Ab
     }
   }
 
-  onEntityDelete() {
+  maybeCascadeDelete() {
     if (this.isCascadeDelete) {
       this.current({ withDeleted: true }).forEach(getEm(this.entity).delete);
     }
   }
 
-  async onEntityDeletedAndFlushing(): Promise<void> {
+  async cleanupOnEntityDeleted(): Promise<void> {
     const entities = await this.load({ withDeleted: true });
     entities.forEach((other) => {
       const m2m = (other[this.otherFieldName] as any) as ManyToManyCollection<U, T>;

--- a/packages/orm/src/collections/ManyToOneReference.ts
+++ b/packages/orm/src/collections/ManyToOneReference.ts
@@ -125,7 +125,7 @@ export class ManyToOneReference<T extends Entity, U extends Entity, N extends ne
     }
   }
 
-  onEntityDelete(): void {
+  maybeCascadeDelete(): void {
     if (this.isCascadeDelete) {
       const current = this.current({ withDeleted: true });
       if (current !== undefined && typeof current !== "string") {
@@ -134,7 +134,7 @@ export class ManyToOneReference<T extends Entity, U extends Entity, N extends ne
     }
   }
 
-  async onEntityDeletedAndFlushing(): Promise<void> {
+  async cleanupOnEntityDeleted(): Promise<void> {
     const current = await this.load({ withDeleted: true });
     if (current !== undefined) {
       const o2m = this.getOtherRelation(current);

--- a/packages/orm/src/collections/OneToManyCollection.ts
+++ b/packages/orm/src/collections/OneToManyCollection.ts
@@ -164,14 +164,14 @@ export class OneToManyCollection<T extends Entity, U extends Entity> extends Abs
     }
   }
 
-  onEntityDelete(): void {
+  maybeCascadeDelete(): void {
     if (this.isCascadeDelete) {
       this.current({ withDeleted: true }).forEach(getEm(this.entity).delete);
     }
   }
 
   // We already unhooked all children in our addedBeforeLoaded list; now load the full list if necessary.
-  async onEntityDeletedAndFlushing(): Promise<void> {
+  async cleanupOnEntityDeleted(): Promise<void> {
     const current = await this.load({ withDeleted: true });
     current.forEach((other) => {
       const m2o = this.getOtherRelation(other);

--- a/packages/orm/src/collections/OneToOneReference.ts
+++ b/packages/orm/src/collections/OneToOneReference.ts
@@ -1,12 +1,4 @@
-import {
-  deTagIds,
-  ensureNotDeleted,
-  fail,
-  getEm,
-  IdOf,
-  Reference,
-  setField,
-} from "../";
+import { deTagIds, ensureNotDeleted, fail, getEm, IdOf, Reference, setField } from "../";
 import { Entity, EntityMetadata, getMetadata } from "../EntityManager";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { ManyToOneReference } from "./ManyToOneReference";
@@ -89,7 +81,7 @@ export class OneToOneReference<T extends Entity, U extends Entity> extends Abstr
   }
 
   set(other: U): void {
-    ensureNotDeleted(this.entity, { ignore: "pending" })
+    ensureNotDeleted(this.entity, { ignore: "pending" });
     if (other === this.loaded) {
       return;
     }
@@ -140,16 +132,16 @@ export class OneToOneReference<T extends Entity, U extends Entity> extends Abstr
     }
   }
 
-  onEntityDelete(): void {
+  maybeCascadeDelete(): void {
     if (this.isCascadeDelete && this.loaded) {
       getEm(this.entity).delete(this.loaded);
     }
   }
 
-  async onEntityDeletedAndFlushing(): Promise<void> {
+  async cleanupOnEntityDeleted(): Promise<void> {
     const current = await this.load({ withDeleted: true });
     if (current !== undefined) {
-      this.getOtherRelation(current).set(undefined as any)
+      this.getOtherRelation(current).set(undefined as any);
       setField(current, this.otherFieldName as string, undefined);
     }
     this.loaded = undefined as any;

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -218,11 +218,7 @@ export function setOpts<T extends Entity>(
     }
   });
   if (calledFromConstructor) {
-    Object.values(entity).forEach((v) => {
-      if (v instanceof AbstractRelationImpl) {
-        v.initializeForNewEntity();
-      }
-    });
+    getRelations(entity).forEach((v) => v.initializeForNewEntity());
   }
 }
 
@@ -317,8 +313,8 @@ export class ConfigApi<T extends Entity, C> {
   cascadeDelete(relationship: keyof RelationsIn<T>): void {
     this.__data.cascadeDeleteFields.push(relationship);
     this.beforeDelete(relationship, (entity) => {
-      const relation = (entity[relationship] as any) as AbstractRelationImpl<T>;
-      relation.onEntityDelete();
+      const relation = (entity[relationship] as any) as AbstractRelationImpl<any>;
+      relation.maybeCascadeDelete();
     });
   }
 
@@ -397,4 +393,8 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
 
 export function getEm(entity: Entity): EntityManager {
   return entity.__orm.em;
+}
+
+export function getRelations(entity: Entity): AbstractRelationImpl<any>[] {
+  return Object.values(entity).filter((v) => v instanceof AbstractRelationImpl);
 }


### PR DESCRIPTION
Makes their use more explicit.  Also added a `getRelations` helper method to replace a commonly repeated pattern.