### PR TITLE
Adds option to determine whether optional fk fields are set to existing entities

### DIFF
--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -86,6 +86,26 @@ describe("EntityManager.factories", () => {
     expect(b1.author.get.firstName).toEqual("a3");
   });
 
+  it("can create a author and set mentor automatically", async () => {
+    const em = newEntityManager();
+    // Given there is an existing author
+    const a1 = newAuthor(em);
+    // When we create the second author
+    const a2 = newAuthor(em);
+    // Then we expect it to be mentored by the first
+    expect(a2.mentor.get).toBe(a1);
+  });
+
+  it("can create a author and configure to not set the mentor", async () => {
+    const em = newEntityManager();
+    // Given there is an existing author
+    newAuthor(em);
+    // When we create the second author
+    const a2 = newAuthor(em, { associateOptionalEntities: { mentor: false }});
+    // Then we expect a2 not to have a mentor
+    expect(a2.mentor.get).toBeUndefined();
+  });
+
   it("can create a grandchild and specify the grandparent", async () => {
     const em = newEntityManager();
     // Given there are multiple existing publishers

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -338,6 +338,14 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(2);
   });
 
+  it("can find by ilike", async () => {
+    await insertAuthor({ first_name: "a1", age: 1 });
+    await insertAuthor({ first_name: "a2", age: 2 });
+    const em = newEntityManager();
+    const authors = await em.find(Author, { firstName: { ilike: "A%" } });
+    expect(authors.length).toEqual(2);
+  });
+
   it("can find by like and join with not equal enum", async () => {
     await insertPublisher({ name: "p1", size_id: 1 });
     await insertPublisher({ name: "p2", size_id: 2 });

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -29,7 +29,8 @@ export type ValueFilter<V, N> =
   | { ne: V | N }
   | { lt: V }
   | { lte: V }
-  | { like: V };
+  | { like: V }
+  | { ilike: V };
 
 // For filtering by a foreign key T, i.e. either joining/recursing into with FilterQuery<T>, or matching it is null/not null/etc.
 export type EntityFilter<T, I, F, N> = T | I | I[] | F | N | { ne: T | I | N };
@@ -49,6 +50,7 @@ export type ValueGraphQLFilter<V> =
       lt?: V | null;
       lte?: V | null;
       like?: V | null;
+      ilike?: V | null;
     }
   | { op: Operator; value: Primitive }
   | V
@@ -60,7 +62,7 @@ export type EnumGraphQLFilter<V> = V[] | null | undefined;
 /** A GraphQL version of EntityFilter. */
 export type EntityGraphQLFilter<T, I, F> = T | I | I[] | F | { ne: T | I } | null | undefined;
 
-const operators = ["eq", "gt", "gte", "ne", "lt", "lte", "like", "in"] as const;
+const operators = ["eq", "gt", "gte", "ne", "lt", "lte", "like", "ilike", "in"] as const;
 export type Operator = typeof operators[number];
 const opToFn: Record<Operator, string> = {
   eq: "=",
@@ -70,6 +72,7 @@ const opToFn: Record<Operator, string> = {
   lt: "<",
   lte: "<=",
   like: "LIKE",
+  ilike: "ILIKE",
   in: "...",
 };
 

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -3,7 +3,7 @@ import {
   ActualFactoryOpts,
   Entity,
   EntityConstructor,
-  EntityManager,
+  EntityManager, Field,
   getMetadata,
   IdOf,
   isEntity,
@@ -24,8 +24,11 @@ import { fail } from "./utils";
  * use the one in `use` instead of making a new one).
  *
  * 2. Works specifically against the constructor/entity opts fields.
+ *
+ * 3. Adds `associateOptionalEntities` to indicate whether optional fk's to other entities should be populated when
+ * there is a single entity or not. If no value is specified for a field, it will default to true for backwards compatibility.
  */
-export type FactoryOpts<T extends Entity> = DeepPartialOpts<T> & { use?: Entity | Entity[] };
+export type FactoryOpts<T extends Entity> = DeepPartialOpts<T> & { use?: Entity | Entity[], associateOptionalEntities?: Partial<Record<keyof OptsOf<T>, boolean>> };
 
 // Chosen b/c it's a monday https://www.timeanddate.com/calendar/monthly.html?year=2018&month=1&country=1
 export const jan1 = new Date(2018, 0, 1);
@@ -113,9 +116,9 @@ export function newTestInstance<T extends Entity>(
           const otherMeta = field.otherMetadata();
 
           // If there is a single existing instance of this type, assume the caller is fine with that,
-          // even if the field is not required.
+          // even if the field is not required, unless they specified otherwise via `opts.associateOptionalEntities`
           const existing = em.entities.filter((e) => e instanceof otherMeta.cstr);
-          if (existing.length === 1) {
+          if (existing.length === 1 && associateOptionalEntities(field, opts)) {
             return [fieldName, existing[0]];
           }
 
@@ -202,4 +205,14 @@ type AllowRelationsOrPartials<T> = {
 
 function maybeArray<T>(array: T | T[] | undefined): T[] | undefined {
   return array ? (Array.isArray(array) ? array : [array]) : undefined;
+}
+
+function associateOptionalEntities<T extends Entity>(field: Field, opts: FactoryOpts<T>): boolean {
+  if (field.required) {
+    // This field isn't optional, associate entities if you have them!
+    return true;
+  }
+
+  // Default to true if a specific value hasn't been set
+  return opts.associateOptionalEntities?.[field.fieldName as keyof OptsOf<T>] ?? true;
 }


### PR DESCRIPTION
Fixes #62 

Attempts to follow existing patters from the `FactoryOpts.use` example