### PR TITLE
Ignore date sets of same value

### DIFF
--- a/packages/integration-tests/jest.config.js
+++ b/packages/integration-tests/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   moduleNameMapper: {
     "^@src/(.*)": "<rootDir>/src/$1",
   },
-  // globalSetup: "<rootDir>/src/setupTestEnv.js",
+  globalSetup: "<rootDir>/src/setupTestEnv.ts",
   setupFilesAfterEnv: ["<rootDir>/src/setupDbTests.ts"],
   testMatch: ["<rootDir>/src/**/*.test.(ts|tsx)"],
   testEnvironment: "node",

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -569,6 +569,14 @@ describe("EntityManager", () => {
     expect(a1.__orm.originalData).toEqual({});
   });
 
+  it("ignores date sets of the same value", async () => {
+    await knex.insert({ first_name: "a1", initials: "a", number_of_books: 1, graduated: "2000-01-01" }).into("authors");
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "1");
+    a1.graduated = new Date(2000, 0, 1);
+    expect(a1.__orm.originalData).toEqual({});
+  });
+
   it("cannot flush while another flush is in progress", async () => {
     await insertPublisher({ name: "p1" });
     await insertAuthor({ first_name: "a1", publisher_id: 1 });

--- a/packages/integration-tests/src/setupTestEnv.ts
+++ b/packages/integration-tests/src/setupTestEnv.ts
@@ -1,0 +1,3 @@
+export default function globalSetup() {
+  process.env.TZ = "UTC";
+}

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -146,7 +146,7 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
 
   // Push this logic into a field serde type abstraction?
   const currentValue = data[fieldName];
-  if (currentValue === newValue) {
+  if (equal(currentValue, newValue)) {
     return false;
   }
 


### PR DESCRIPTION
This relates to #65. It's the same issue, just another place we need to use the new `equal` method vs. `===`.