### PR TITLE
Wait for DB when running locally

### DIFF
--- a/packages/integration-tests/Makefile
+++ b/packages/integration-tests/Makefile
@@ -11,7 +11,7 @@ build:
 
 # Create/recreate the database for applying migrations from scratch.
 db:
-	docker-compose up -d db
+	docker-compose up db-wait
 	docker-compose exec db ./reset.sh
 	npm run migrate
 	npm run codegen


### PR DESCRIPTION
The `db-wait` task was actually already defined and used for CircleCI, just not in the `Makefile`, which is used for running locally.

Closes #69 