### PR TITLE
Include extraPrimitives from enum tables in graphql and resolvers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,6 +52,7 @@ After checkout:
 - `cd packages/integration-tests`
 - Run `make db` to boot up a Docker postgres instance w/the integration test schema.
 - Run `yarn test` to run the tests.
+- Prior to committing your changes, please run `yarn workspaces run format`
 
 ### Todo
 

--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -5,7 +5,7 @@ import { imp } from "ts-poet";
 import { SymbolSpec } from "ts-poet/build/SymbolSpecs";
 import { Config, isAsyncDerived, isDerived, isProtected, ormMaintainedFields, relationName } from "./config";
 import { ColumnMetaData } from "./generateEntityCodegenFile";
-import { isEnumTable, isJoinTable, mapSimpleDbType, tableToEntityName } from "./utils";
+import { isEnumTable, isJoinTable, mapSimpleDbTypeToTypescriptType, tableToEntityName } from "./utils";
 
 // TODO Populate from config
 const columnCustomizations: Record<string, ColumnMetaData> = {};
@@ -316,7 +316,7 @@ function entityType(entityName: string): SymbolSpec {
 function mapType(tableName: string, columnName: string, dbColumnType: string): ColumnMetaData {
   return (
     columnCustomizations[`${tableName}.${columnName}`] || {
-      fieldType: mapSimpleDbType(dbColumnType),
+      fieldType: mapSimpleDbTypeToTypescriptType(dbColumnType),
     }
   );
 }

--- a/packages/codegen/src/generateEnumFile.ts
+++ b/packages/codegen/src/generateEnumFile.ts
@@ -1,17 +1,12 @@
-import { Table } from "@homebound/pg-structure";
 import { pascalCase } from "change-case";
 import pluralize from "pluralize";
 import { code, Code } from "ts-poet";
 import { Config } from "./config";
-import { EntityDbMetadata, EnumRows } from "./index";
+import { EnumTableData } from "./index";
 
-export function generateEnumFile(config: Config, table: Table, enumRows: EnumRows, enumName: string): Code {
-  const rows = enumRows[table.name];
+export function generateEnumFile(config: Config, enumData: EnumTableData, enumName: string): Code {
+  const { rows, extraPrimitives } = enumData;
   const detailsName = `${enumName}Details`;
-  // We're not really an entity, but appropriate EntityDbMetadata's `primitives` filtering
-  const extraPrimitives = new EntityDbMetadata(config, table).primitives.filter(
-    (p) => !["code", "name"].includes(p.fieldName),
-  );
   const detailsDefinition = [
     "id: number;",
     `code: ${enumName};`,

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -42,7 +42,7 @@ export function tableToEntityName(config: Config, table: Table): string {
 }
 
 /** Maps db types, i.e. `int`, to JS types, i.e. `number`. */
-export function mapSimpleDbType(dbType: string): string {
+export function mapSimpleDbTypeToTypescriptType(dbType: string): string {
   switch (dbType) {
     case "boolean":
       return "boolean";

--- a/packages/graphql-codegen/src/generateEnumDetailResolvers.ts
+++ b/packages/graphql-codegen/src/generateEnumDetailResolvers.ts
@@ -5,7 +5,7 @@ import { code, imp } from "ts-poet";
 
 /** Generates a `src/resolvers/enumResolvers.ts` with a resolver for each of our domain's "enum detail" types. */
 export function generateEnumDetailResolvers(enums: EnumMetadata): CodeGenFile {
-  const enumNames = Object.values(enums).map(({name}) => name);
+  const enumNames = Object.values(enums).map(({ name }) => name);
 
   const resolvers = Object.values(enums).map(({ name, extraPrimitives }) => {
     const type = imp(`${pluralize(name)}@src/entities`);
@@ -14,8 +14,8 @@ export function generateEnumDetailResolvers(enums: EnumMetadata): CodeGenFile {
         code: (root) => root,
         name: (root) => ${type}.getByCode(root).name,
         ${extraPrimitives
-          .map(p => camelCase(p.columnName))
-          .map(fieldName => code`${fieldName}: (root) => ${type}.getByCode(root).${fieldName},`)}
+          .map((p) => camelCase(p.columnName))
+          .map((fieldName) => code`${fieldName}: (root) => ${type}.getByCode(root).${fieldName},`)}
       },
     `;
   });

--- a/packages/graphql-codegen/src/generateEnumsGraphql.ts
+++ b/packages/graphql-codegen/src/generateEnumsGraphql.ts
@@ -1,6 +1,6 @@
-import { CodeGenFile, EnumMetadata } from "joist-codegen";
-import { formatGraphQL } from "./graphqlUtils";
 import { camelCase } from "change-case";
+import { CodeGenFile, EnumMetadata } from "joist-codegen";
+import { formatGraphQL, mapSimpleDbTypeToGraphQLType } from "./graphqlUtils";
 
 /** Generates a `schema/enums.graphql` with GQL enums that match all of our domain enums. */
 export async function generateEnumsGraphql(enums: EnumMetadata): Promise<CodeGenFile> {
@@ -8,7 +8,8 @@ export async function generateEnumsGraphql(enums: EnumMetadata): Promise<CodeGen
     .map(({ name, rows, extraPrimitives }) => {
       const enumDecl = `enum ${name} { ${rows.map((r) => r.code).join(" ")} }`;
       const detailDecl = `type ${name}Detail { code: ${name}! name: String! ${extraPrimitives
-        .map(p => `${camelCase(p.columnName)}: ${mapSimpleDbType(p.columnType)}!`).join(" ")} }`;
+        .map((p) => `${camelCase(p.columnName)}: ${mapSimpleDbTypeToGraphQLType(p.columnType)}!`)
+        .join(" ")} }`;
       return [enumDecl, "", detailDecl, ""];
     })
     .flat()
@@ -17,24 +18,4 @@ export async function generateEnumsGraphql(enums: EnumMetadata): Promise<CodeGen
   const formatted = await formatGraphQL(contents);
 
   return { name: "../../schema/enums.graphql", overwrite: true, contents: formatted };
-}
-
-/** Maps db types, i.e. `int`, to GraphQL types, i.e. `Int`. */
-function mapSimpleDbType(dbType: string): string {
-  switch (dbType) {
-    case "boolean":
-      return "Boolean";
-    case "int":
-    case "numeric":
-      return "Int";
-    case "text":
-    case "citext":
-    case "character varying":
-      return "String";
-    case "timestamp with time zone":
-    case "date":
-      return "Date";
-    default:
-      throw new Error(`Unrecognized type "${dbType}"`);
-  }
 }

--- a/packages/graphql-codegen/src/generateEnumsGraphql.ts
+++ b/packages/graphql-codegen/src/generateEnumsGraphql.ts
@@ -1,14 +1,14 @@
-import { pascalCase } from "change-case";
-import { CodeGenFile, EnumRows } from "joist-codegen";
+import { CodeGenFile, EnumMetadata } from "joist-codegen";
 import { formatGraphQL } from "./graphqlUtils";
+import { camelCase } from "change-case";
 
 /** Generates a `schema/enums.graphql` with GQL enums that match all of our domain enums. */
-export async function generateEnumsGraphql(enums: EnumRows): Promise<CodeGenFile> {
-  const contents = Object.entries(enums)
-    .map(([_name, rows]) => {
-      const name = pascalCase(_name);
+export async function generateEnumsGraphql(enums: EnumMetadata): Promise<CodeGenFile> {
+  const contents = Object.values(enums)
+    .map(({ name, rows, extraPrimitives }) => {
       const enumDecl = `enum ${name} { ${rows.map((r) => r.code).join(" ")} }`;
-      const detailDecl = `type ${name}Detail { code: ${name}! name: String! }`;
+      const detailDecl = `type ${name}Detail { code: ${name}! name: String! ${extraPrimitives
+        .map(p => `${camelCase(p.columnName)}: ${mapSimpleDbType(p.columnType)}!`).join(" ")} }`;
       return [enumDecl, "", detailDecl, ""];
     })
     .flat()
@@ -17,4 +17,24 @@ export async function generateEnumsGraphql(enums: EnumRows): Promise<CodeGenFile
   const formatted = await formatGraphQL(contents);
 
   return { name: "../../schema/enums.graphql", overwrite: true, contents: formatted };
+}
+
+/** Maps db types, i.e. `int`, to GraphQL types, i.e. `Int`. */
+function mapSimpleDbType(dbType: string): string {
+  switch (dbType) {
+    case "boolean":
+      return "Boolean";
+    case "int":
+    case "numeric":
+      return "Int";
+    case "text":
+    case "citext":
+    case "character varying":
+      return "String";
+    case "timestamp with time zone":
+    case "date":
+      return "Date";
+    default:
+      throw new Error(`Unrecognized type "${dbType}"`);
+  }
 }

--- a/packages/graphql-codegen/src/generateGraphqlCodegen.test.ts
+++ b/packages/graphql-codegen/src/generateGraphqlCodegen.test.ts
@@ -1,4 +1,4 @@
-import { EntityDbMetadata, EnumMetadata } from "joist-codgen";
+import { EntityDbMetadata, EnumMetadata } from "joist-codegen";
 import { generateGraphqlCodegen } from "./generateGraphqlCodegen";
 
 describe("generateGraphqlCodegen", () => {

--- a/packages/graphql-codegen/src/generateGraphqlCodegen.test.ts
+++ b/packages/graphql-codegen/src/generateGraphqlCodegen.test.ts
@@ -1,10 +1,10 @@
-import { EntityDbMetadata, EnumRows } from "joist-codgen";
+import { EntityDbMetadata, EnumMetadata } from "joist-codgen";
 import { generateGraphqlCodegen } from "./generateGraphqlCodegen";
 
 describe("generateGraphqlCodegen", () => {
   it("creates a json file", () => {
     const entities: EntityDbMetadata[] = [];
-    const enums: EnumRows = {};
+    const enums: EnumMetadata = {};
     const file = generateGraphqlCodegen(entities, enums);
     expect(file.contents.toString()).toMatchInlineSnapshot(`
       "const mappers = {};

--- a/packages/graphql-codegen/src/generateGraphqlCodegen.ts
+++ b/packages/graphql-codegen/src/generateGraphqlCodegen.ts
@@ -1,10 +1,9 @@
-import { pascalCase } from "change-case";
-import { CodeGenFile, EntityDbMetadata, EnumRows } from "joist-codegen";
+import { CodeGenFile, EntityDbMetadata, EnumMetadata } from "joist-codegen";
 import { code } from "ts-poet";
 
 /** Generates a `graphql-codegen-joist.js` with the auto-generated mapped type/enum value settings. */
-export function generateGraphqlCodegen(entities: EntityDbMetadata[], enums: EnumRows): CodeGenFile {
-  const enumNames = Object.keys(enums).map((name) => pascalCase(name));
+export function generateGraphqlCodegen(entities: EntityDbMetadata[], enums: EnumMetadata): CodeGenFile {
+  const enumNames = Object.values(enums).map(({ name }) => name);
 
   // Combine the entity mapped types and enum detail mapped types
   const mappedTypes = sortObject(

--- a/packages/graphql-codegen/src/generateGraphqlSchemaFiles.ts
+++ b/packages/graphql-codegen/src/generateGraphqlSchemaFiles.ts
@@ -1,8 +1,7 @@
 import { camelCase } from "change-case";
 import { EntityDbMetadata } from "joist-codegen";
 import { groupBy } from "joist-utils";
-import { SymbolSpec } from "ts-poet/build/SymbolSpecs";
-import { GqlField, upsertIntoFile } from "./graphqlUtils";
+import { GqlField, mapTypescriptTypeToGraphQLType, upsertIntoFile } from "./graphqlUtils";
 import { loadHistory, writeHistory } from "./history";
 import { Fs } from "./utils";
 
@@ -58,7 +57,7 @@ function createEntityFields(entities: EntityDbMetadata[]): GqlField[] {
     const id: GqlField = { ...common, fieldName: "id", fieldType: "ID!" };
 
     const primitives = e.primitives.map(({ fieldName, fieldType: tsType, notNull }) => {
-      const fieldType = `${mapFieldTypeToGraphQLType(tsType)}${maybeRequired(notNull)}`;
+      const fieldType = `${mapTypescriptTypeToGraphQLType(tsType)}${maybeRequired(notNull)}`;
       return { ...common, fieldName, fieldType };
     });
 
@@ -119,7 +118,7 @@ function createSaveEntityInputFields(entities: EntityDbMetadata[]): GqlField[] {
     const id: GqlField = { ...common, fieldName: "id", fieldType: "ID" };
 
     const primitives = e.primitives.map(({ fieldName, fieldType: tsType }) => {
-      const fieldType = `${mapFieldTypeToGraphQLType(tsType)}`;
+      const fieldType = `${mapTypescriptTypeToGraphQLType(tsType)}`;
       return { ...common, fieldName, fieldType };
     });
 
@@ -148,19 +147,6 @@ function createSaveEntityResultFields(entities: EntityDbMetadata[]): GqlField[] 
     const entity: GqlField = { file, objectType, objectName, fieldName, fieldType: `${name}!` };
     return [entity];
   });
-}
-
-function mapFieldTypeToGraphQLType(type: string | SymbolSpec): string | SymbolSpec {
-  switch (type) {
-    case "string":
-      return "String";
-    case "boolean":
-      return "Boolean";
-    case "number":
-      return "Int";
-    default:
-      return type;
-  }
 }
 
 function maybeRequired(notNull: boolean): string {

--- a/packages/graphql-codegen/src/generateObjectResolvers.ts
+++ b/packages/graphql-codegen/src/generateObjectResolvers.ts
@@ -1,5 +1,5 @@
 import { camelCase, sentenceCase } from "change-case";
-import { CodeGenFile, Config, EntityDbMetadata } from "joist-codgen";
+import { CodeGenFile, Config, EntityDbMetadata } from "joist-codegen";
 import { code, imp } from "ts-poet";
 
 const getMetadata = imp("getMetadata@joist-orm");

--- a/packages/graphql-codegen/src/generateSaveResolvers.ts
+++ b/packages/graphql-codegen/src/generateSaveResolvers.ts
@@ -1,5 +1,5 @@
 import { camelCase } from "change-case";
-import { CodeGenFile, Config, EntityDbMetadata } from "joist-codgen";
+import { CodeGenFile, Config, EntityDbMetadata } from "joist-codegen";
 import { code, imp } from "ts-poet";
 
 const context = imp("Context@src/context");

--- a/packages/graphql-codegen/src/graphqlUtils.ts
+++ b/packages/graphql-codegen/src/graphqlUtils.ts
@@ -1,6 +1,8 @@
 import { DocumentNode, InputObjectTypeDefinitionNode, ObjectTypeDefinitionNode, parse, print, visit } from "graphql";
+import { mapSimpleDbTypeToTypescriptType } from "joist-codegen";
 import { groupBy } from "joist-utils";
 import prettier, { resolveConfig } from "prettier";
+import { SymbolSpec } from "ts-poet/build/SymbolSpecs";
 import { Fs } from "./utils";
 
 /** A type for the fields we want to add to `*.graphql` files. */
@@ -136,4 +138,21 @@ function mergeDocs(existingDoc: DocumentNode, newDocs: [string, DocumentNode][])
       return node;
     },
   });
+}
+
+export function mapTypescriptTypeToGraphQLType(type: string | SymbolSpec): string | SymbolSpec {
+  switch (type) {
+    case "string":
+      return "String";
+    case "boolean":
+      return "Boolean";
+    case "number":
+      return "Int";
+    default:
+      return type;
+  }
+}
+
+export function mapSimpleDbTypeToGraphQLType(type: string): string | SymbolSpec {
+  return mapTypescriptTypeToGraphQLType(mapSimpleDbTypeToTypescriptType(type));
 }

--- a/packages/graphql-codegen/src/index.ts
+++ b/packages/graphql-codegen/src/index.ts
@@ -1,5 +1,5 @@
-import { CodeGenFile, Config, EntityDbMetadata, EnumRows } from "joist-codegen";
 import { Code } from "ts-poet";
+import { Config, CodeGenFile, EntityDbMetadata, EnumMetadata } from "joist-codegen";
 import { generateEnumDetailResolvers } from "./generateEnumDetailResolvers";
 import { generateEnumsGraphql } from "./generateEnumsGraphql";
 import { generateGraphqlCodegen } from "./generateGraphqlCodegen";
@@ -9,7 +9,7 @@ import { generateSaveResolvers } from "./generateSaveResolvers";
 import { loadHistory, writeHistory } from "./history";
 import { Fs, newFsImpl } from "./utils";
 
-export async function run(config: Config, entities: EntityDbMetadata[], enums: EnumRows): Promise<CodeGenFile[]> {
+export async function run(config: Config, entities: EntityDbMetadata[], enums: EnumMetadata): Promise<CodeGenFile[]> {
   const fs = newFsImpl("./schema");
 
   // We upsert directly into schema files so we don't use the usual `CodeGenFile[]` return type;

--- a/packages/graphql-codegen/src/index.ts
+++ b/packages/graphql-codegen/src/index.ts
@@ -1,5 +1,5 @@
+import { CodeGenFile, Config, EntityDbMetadata, EnumMetadata } from "joist-codegen";
 import { Code } from "ts-poet";
-import { Config, CodeGenFile, EntityDbMetadata, EnumMetadata } from "joist-codegen";
 import { generateEnumDetailResolvers } from "./generateEnumDetailResolvers";
 import { generateEnumsGraphql } from "./generateEnumsGraphql";
 import { generateGraphqlCodegen } from "./generateGraphqlCodegen";

--- a/packages/graphql-codegen/tsconfig.json
+++ b/packages/graphql-codegen/tsconfig.json
@@ -15,7 +15,7 @@
     "baseUrl": "./src",
     "paths": {
       "joist-utils": ["../../utils/src"],
-      "joist-codgen": ["../../codegen/src"]
+      "joist-codegen": ["../../codegen/src"]
     }
   },
   "references": [{ "path": "../utils" }, { "path": "../codegen" }]

--- a/packages/integration-tests/schema/enums.graphql
+++ b/packages/integration-tests/schema/enums.graphql
@@ -18,6 +18,7 @@ enum ImageType {
 type ImageTypeDetail {
   code: ImageType!
   name: String!
+  sortOrder: Int!
 }
 
 enum PublisherSize {

--- a/packages/integration-tests/src/generated/graphql-types.ts
+++ b/packages/integration-tests/src/generated/graphql-types.ts
@@ -40,6 +40,7 @@ export type Resolvers = {
   ImageTypeDetail: {
     code: (root: ImageType) => string;
     name: (root: ImageType) => string;
+    sortOrder: (root: ImageType) => number;
   };
 
   AdvanceStatusDetail: {

--- a/packages/integration-tests/src/resolvers/enumResolvers.ts
+++ b/packages/integration-tests/src/resolvers/enumResolvers.ts
@@ -12,6 +12,7 @@ export const enumResolvers: Pick<Resolvers, EnumDetails> = {
   ImageTypeDetail: {
     code: (root) => root,
     name: (root) => ImageTypes.getByCode(root).name,
+    sortOrder: (root) => ImageTypes.getByCode(root).sortOrder,
   },
 
   PublisherSizeDetail: {


### PR DESCRIPTION
This takes support for extra columns in enum tables all of the way through the generated graphql code as well as the resolvers.

`enums.graphql`
![image](https://user-images.githubusercontent.com/24765506/98045694-e2d98a80-1df6-11eb-95d6-2d4574a8f9b7.png)

`enumResolvers.ts`
![image](https://user-images.githubusercontent.com/24765506/98045710-eb31c580-1df6-11eb-9920-2fb721b725b0.png)
