### PR TITLE
Circular Dependency Fix

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -2,7 +2,7 @@ import { camelCase, pascalCase } from "change-case";
 import { code, Code, imp } from "ts-poet";
 import { SymbolSpec } from "ts-poet/build/SymbolSpecs";
 import { Config } from "./config";
-import { EntityDbMetadata, PrimitiveField } from "./EntityDbMetadata";
+import { EntityDbMetadata, PrimitiveField, PrimitiveTypescriptType } from "./EntityDbMetadata";
 import {
   BaseEntity,
   BooleanFilter,
@@ -40,7 +40,7 @@ import {
 
 export interface ColumnMetaData {
   typeConverter?: SymbolSpec;
-  fieldType: SymbolSpec | string;
+  fieldType: PrimitiveTypescriptType;
 }
 
 /** Creates the base class with the boilerplate annotations. */

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -3,6 +3,11 @@ import { pascalCase } from "change-case";
 import isPlainObject from "is-plain-object";
 import pluralize from "pluralize";
 import { Config } from "./config";
+import { DatabaseColumnType, PrimitiveTypescriptType } from "./EntityDbMetadata";
+
+export function assertNever(x: never): never {
+  throw new Error("Unexpected object: " + x);
+}
 
 export function isEntityTable(t: Table): boolean {
   const columnNames = t.columns.map((c) => c.name);
@@ -42,7 +47,7 @@ export function tableToEntityName(config: Config, table: Table): string {
 }
 
 /** Maps db types, i.e. `int`, to JS types, i.e. `number`. */
-export function mapSimpleDbTypeToTypescriptType(dbType: string): string {
+export function mapSimpleDbTypeToTypescriptType(dbType: DatabaseColumnType): PrimitiveTypescriptType {
   switch (dbType) {
     case "boolean":
       return "boolean";
@@ -52,12 +57,13 @@ export function mapSimpleDbTypeToTypescriptType(dbType: string): string {
     case "text":
     case "citext":
     case "character varying":
+    case "varchar":
       return "string";
     case "timestamp with time zone":
     case "date":
       return "Date";
     default:
-      throw new Error(`Unrecognized type "${dbType}"`);
+      assertNever(dbType);
   }
 }
 

--- a/packages/graphql-codegen/src/generateEnumsGraphql.ts
+++ b/packages/graphql-codegen/src/generateEnumsGraphql.ts
@@ -1,6 +1,6 @@
 import { camelCase } from "change-case";
 import { CodeGenFile, EnumMetadata } from "joist-codegen";
-import { formatGraphQL, mapSimpleDbTypeToGraphQLType } from "./graphqlUtils";
+import { formatGraphQL, mapTypescriptTypeToGraphQLType } from "./graphqlUtils";
 
 /** Generates a `schema/enums.graphql` with GQL enums that match all of our domain enums. */
 export async function generateEnumsGraphql(enums: EnumMetadata): Promise<CodeGenFile> {
@@ -8,7 +8,7 @@ export async function generateEnumsGraphql(enums: EnumMetadata): Promise<CodeGen
     .map(({ name, rows, extraPrimitives }) => {
       const enumDecl = `enum ${name} { ${rows.map((r) => r.code).join(" ")} }`;
       const detailDecl = `type ${name}Detail { code: ${name}! name: String! ${extraPrimitives
-        .map((p) => `${camelCase(p.columnName)}: ${mapSimpleDbTypeToGraphQLType(p.columnType)}!`)
+        .map((p) => `${camelCase(p.columnName)}: ${mapTypescriptTypeToGraphQLType(p.fieldType)}!`)
         .join(" ")} }`;
       return [enumDecl, "", detailDecl, ""];
     })

--- a/packages/graphql-codegen/src/generateGraphqlSchemaFiles.test.ts
+++ b/packages/graphql-codegen/src/generateGraphqlSchemaFiles.test.ts
@@ -18,6 +18,10 @@ describe("generateGraphqlSchemaFiles", () => {
         id: ID!
       }
 
+      extend type Mutation {
+        saveAuthor(input: SaveAuthorInput!): SaveAuthorResult!
+      }
+
       input SaveAuthorInput {
         id: ID
       }
@@ -56,6 +60,10 @@ describe("generateGraphqlSchemaFiles", () => {
         firstName: String
       }
 
+      extend type Mutation {
+        saveAuthor(input: SaveAuthorInput!): SaveAuthorResult!
+      }
+
       type SaveAuthorResult {
         author: Author!
       }
@@ -67,6 +75,9 @@ describe("generateGraphqlSchemaFiles", () => {
         "Author": Array [
           "firstName",
           "id",
+        ],
+        "Mutation": Array [
+          "saveAuthor",
         ],
         "SaveAuthorInput": Array [
           "firstName",
@@ -107,6 +118,10 @@ describe("generateGraphqlSchemaFiles", () => {
         firstName: String
       }
 
+      extend type Mutation {
+        saveAuthor(input: SaveAuthorInput!): SaveAuthorResult!
+      }
+
       type SaveAuthorResult {
         author: Author!
       }
@@ -133,6 +148,10 @@ describe("generateGraphqlSchemaFiles", () => {
     expect(await fs.load("author.graphql")).toMatchInlineSnapshot(`
       "type Author {
         id: ID!
+      }
+
+      extend type Mutation {
+        saveAuthor(input: SaveAuthorInput!): SaveAuthorResult!
       }
 
       input SaveAuthorInput {
@@ -176,6 +195,10 @@ describe("generateGraphqlSchemaFiles", () => {
       input SaveAuthorInput {
         id: ID
         firstName: String
+      }
+
+      extend type Mutation {
+        saveAuthor(input: SaveAuthorInput!): SaveAuthorResult!
       }
 
       type SaveAuthorResult {

--- a/packages/graphql-codegen/src/graphqlUtils.ts
+++ b/packages/graphql-codegen/src/graphqlUtils.ts
@@ -1,8 +1,7 @@
 import { DocumentNode, InputObjectTypeDefinitionNode, ObjectTypeDefinitionNode, parse, print, visit } from "graphql";
-import { mapSimpleDbTypeToTypescriptType } from "joist-codegen";
+import { PrimitiveTypescriptType } from "joist-codegen/build/EntityDbMetadata";
 import { groupBy } from "joist-utils";
 import prettier, { resolveConfig } from "prettier";
-import { SymbolSpec } from "ts-poet/build/SymbolSpecs";
 import { Fs } from "./utils";
 
 /** A type for the fields we want to add to `*.graphql` files. */
@@ -140,7 +139,9 @@ function mergeDocs(existingDoc: DocumentNode, newDocs: [string, DocumentNode][])
   });
 }
 
-export function mapTypescriptTypeToGraphQLType(type: string | SymbolSpec): string | SymbolSpec {
+export type GraphQLType = "Boolean" | "String" | "Int" | "Date";
+
+export function mapTypescriptTypeToGraphQLType(type: PrimitiveTypescriptType): GraphQLType {
   switch (type) {
     case "string":
       return "String";
@@ -151,8 +152,4 @@ export function mapTypescriptTypeToGraphQLType(type: string | SymbolSpec): strin
     default:
       return type;
   }
-}
-
-export function mapSimpleDbTypeToGraphQLType(type: string): string | SymbolSpec {
-  return mapTypescriptTypeToGraphQLType(mapSimpleDbTypeToTypescriptType(type));
 }


### PR DESCRIPTION
Added explicit types for PrimitiveFIeld's columnType / fieldType so they aren't just string and fixed a circular dependency issue in graphql-codegen