### PR TITLE
[Ranch-1048] Return Changed Entities from `em.flush()`

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -9,7 +9,6 @@ import {
 import { Loaded, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
 import { Author, Book, Publisher, PublisherSize } from "./entities";
 import { knex, newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
-import {assertNever} from "joist-codegen/build/utils";
 
 describe("EntityManager", () => {
   it("can load an entity", async () => {

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -9,6 +9,7 @@ import {
 import { Loaded, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
 import { Author, Book, Publisher, PublisherSize } from "./entities";
 import { knex, newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
+import {assertNever} from "joist-codegen/build/utils";
 
 describe("EntityManager", () => {
   it("can load an entity", async () => {
@@ -977,6 +978,51 @@ describe("EntityManager", () => {
     await em.flush();
     expect(a1.isNewEntity).toBeFalsy();
     expect(a1.isDirtyEntity).toBeFalsy();
+  });
+
+  it("returns newly created entities from flush()", async () => {
+    const em = newEntityManager();
+
+    // Given a newly created entity
+    const a1 = new Author(em, { firstName: "a1" });
+
+    // When we flush the entity manager
+    const [result] = await em.flush();
+
+    // Then the entity was returned from the flush
+    expect(result).toEqual(a1);
+  });
+
+  it("returns updated entities from flush()", async () => {
+    const em = newEntityManager();
+
+    // Given an entity
+    const a1 = new Author(em, { firstName: "a1" });
+    await em.flush();
+
+    // When we update that entity
+    a1.firstName = "new name";
+    // And we flush the entity manager
+    const [result] = await em.flush();
+
+    // Then the updated entity was returned from the flush
+    expect((result as Author).firstName).toEqual("new name");
+  });
+
+  it("returns deleted entities from flush()", async () => {
+    const em = newEntityManager();
+
+    // Given an entity
+    const a1 = new Author(em, { firstName: "a1" });
+    await em.flush();
+
+    // When we delete that entity
+    em.delete(a1);
+    // And we flush the entity manager
+    const [result] = await em.flush();
+
+    // Then the deleted entity was returned from the flush
+    expect(result).toEqual(a1);
   });
 });
 

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -612,8 +612,10 @@ export class EntityManager<C = {}> {
    * If this is run within an existing transaction, i.e. `EntityManager.transaction`,
    * then it will only issue `INSERT`s/etc. and defer to the caller to `COMMIT`
    * the transaction.
+   *
+   * It returns entities that have changed (an entity is considered changed if it has been deleted, inserted, or updated)
    */
-  async flush(): Promise<void> {
+  async flush(): Promise<Entity[]> {
     if (this.isFlushing) {
       throw new Error("Cannot flush while another flush is already in progress");
     }
@@ -686,6 +688,8 @@ export class EntityManager<C = {}> {
         this.loadLoaders = {};
         this.findLoaders = {};
       }
+
+      return entitiesToFlush;
     } finally {
       this._isFlushing = false;
     }


### PR DESCRIPTION
This change makes `em.flush()` return changed entities so that clients can know what specifically changed as a result of their queries