### PR TITLE
allow for deleting an object in a transaction

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -969,6 +969,18 @@ describe("EntityManager", () => {
     expect(afterTransactionCount).toEqual(1);
   });
 
+  it("can delete an entity with a reverseHint in a transaction", async () => {
+    const em = newEntityManager();
+    const a1 = new Author(em, { firstName: "a1" });
+    const b1 = new Book(em, { title: "title", author: a1 })
+    await em.flush();
+    await em.transaction(async () => {
+      em.delete(b1);
+      await em.flush();
+    });
+    expect(b1.isDeletedEntity).toBeTruthy()
+  });
+
   it("can save entities", async () => {
     const em = newEntityManager();
     const a1 = new Author(em, { firstName: "a1" });

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -760,6 +760,7 @@ export class EntityManager<C = {}> {
           todo.inserts.forEach((e) => this._entityIndex.set(e.id!, e));
           todo.inserts.forEach((e) => (e.__orm.originalData = {}));
           todo.updates.forEach((e) => (e.__orm.originalData = {}));
+          todo.deletes.forEach((e) => (e.__orm.originalData = {}));
         });
 
         // Reset the find caches b/c data will have changed in the db


### PR DESCRIPTION
Clearing out the original data for deleted objects such that we don't re-run them in follow-on flushes within a transaction.  