### PR TITLE
Enhance ValidationError to make it work better with potential operations

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1039,15 +1039,15 @@ async function afterCommit(ctx: unknown, todos: Record<string, Todo>): Promise<v
 function coerceError(
   entity: Entity,
   maybeError: string | ValidationError | ValidationError[] | undefined,
-): ValidationError[] {
+): Required<ValidationError>[] {
   if (maybeError === undefined) {
     return [];
   } else if (typeof maybeError === "string") {
     return [{ entity, message: maybeError }];
   } else if (Array.isArray(maybeError)) {
-    return maybeError as ValidationError[];
+    return (maybeError as ValidationError[]).map(ve => ({ entity, ...ve}));
   } else {
-    return [maybeError];
+    return [{ entity, ...maybeError}];
   }
 }
 

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -13,6 +13,7 @@ import {
   ConfigApi,
   DeepPartialOrNull,
   EntityHook,
+  GenericError,
   getEm,
   getRelations,
   keyToString,
@@ -27,6 +28,7 @@ import {
   tagIfNeeded,
   ValidationError,
   ValidationErrors,
+  ValidationRuleResult,
 } from "./index";
 import { combineJoinRows, createTodos, getTodo, Todo } from "./Todo";
 import { fail, NullOrDefinedOr } from "./utils";
@@ -1038,14 +1040,14 @@ async function afterCommit(ctx: unknown, todos: Record<string, Todo>): Promise<v
 
 function coerceError(
   entity: Entity,
-  maybeError: string | ValidationError | ValidationError[] | undefined,
-): Required<ValidationError>[] {
+  maybeError: ValidationRuleResult<any>,
+): ValidationError[] {
   if (maybeError === undefined) {
     return [];
   } else if (typeof maybeError === "string") {
     return [{ entity, message: maybeError }];
   } else if (Array.isArray(maybeError)) {
-    return (maybeError as ValidationError[]).map(ve => ({ entity, ...ve}));
+    return (maybeError as GenericError[]).map(ve => ({ entity, ...ve}));
   } else {
     return [{ entity, ...maybeError}];
   }

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -244,8 +244,12 @@ export function getRequiredKeys<T extends Entity>(entityOrType: T | EntityConstr
     .map((f) => f.fieldName);
 }
 
-/** Return type of a `ValidationRule` before being `MaybePromise`'d */
-export type ValidationRuleResult<E extends ValidationError> = string | E | E[] | undefined;
+/**
+ * Return type of a `ValidationRule`.
+ *
+ * Consumers can extend `GenericError` to add fields relevant for their application.
+ */
+export type ValidationRuleResult<E extends GenericError> = string | E | E[] | undefined;
 
 /** Entity validation errors; if `entity` is invalid, throw a `ValidationError`. */
 export type ValidationRule<T extends Entity> = (
@@ -254,7 +258,10 @@ export type ValidationRule<T extends Entity> = (
 
 type MaybePromise<T> = T | PromiseLike<T>;
 
-export type ValidationError = { entity?: Entity; message: string };
+/** A generic error which contains only a message field */
+export type GenericError = { message: string };
+/** An extension to GenericError which associates the error to a specific entity */
+export type ValidationError = { entity: Entity; } & GenericError;
 
 export class ValidationErrors extends Error {
   constructor(public errors: ValidationError[]) {

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -244,14 +244,17 @@ export function getRequiredKeys<T extends Entity>(entityOrType: T | EntityConstr
     .map((f) => f.fieldName);
 }
 
+/** Return type of a `ValidationRule` before being `MaybePromise`'d */
+export type ValidationRuleResult = string | ValidationError | ValidationError[] | undefined;
+
 /** Entity validation errors; if `entity` is invalid, throw a `ValidationError`. */
 export type ValidationRule<T extends Entity> = (
   entity: T,
-) => MaybePromise<string | ValidationError | ValidationError[] | undefined>;
+) => MaybePromise<ValidationRuleResult>;
 
 type MaybePromise<T> = T | PromiseLike<T>;
 
-export type ValidationError = { entity: Entity; message: string };
+export type ValidationError = { entity?: Entity; message: string };
 
 export class ValidationErrors extends Error {
   constructor(public errors: ValidationError[]) {

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -245,12 +245,12 @@ export function getRequiredKeys<T extends Entity>(entityOrType: T | EntityConstr
 }
 
 /** Return type of a `ValidationRule` before being `MaybePromise`'d */
-export type ValidationRuleResult = string | ValidationError | ValidationError[] | undefined;
+export type ValidationRuleResult<E extends ValidationError> = string | E | E[] | undefined;
 
 /** Entity validation errors; if `entity` is invalid, throw a `ValidationError`. */
 export type ValidationRule<T extends Entity> = (
   entity: T,
-) => MaybePromise<ValidationRuleResult>;
+) => MaybePromise<ValidationRuleResult<any>>;
 
 type MaybePromise<T> = T | PromiseLike<T>;
 


### PR DESCRIPTION
- Make `ValidationError.entity` optional so that we don't need to specify it when making potential operations
- Export `ValidationRuleResult` type to avoid need to make a similar one in graphql-service
- Stamp in the `ValidationError.entity` field as part of `coerceError`