### PR TITLE
chore: show Node 16.2.0 issue in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
               # We should test against "latest Node 16", but there's an issue with 16.2
               # This will be updated soon, along with a bug report to Node.js
               # node-version: ["lts/erbium", "lts/fermium", "16"]
-              node-version: ["lts/erbium", "lts/fermium", "16.1"]
+              node-version: ["lts/erbium", "lts/fermium", "16.1", "16.2.0"]
 
 jobs:
   build:

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "migrate": "./run.sh ../../node_modules/joist-migration-utils",
-    "test": "jest --runInBand --detectOpenHandles --logHeapUsage",
+    "test": "jest --runInBand --logHeapUsage",
     "format": "prettier --write '{schema,migrations,src}/**/*.{ts,js,tsx,jsx,graphql}'",
     "codegen": "./run.sh ../codegen"
   },


### PR DESCRIPTION
This PR enables testing against Node 16.1.0 and Node 16.2.0 to show a regression we're experiencing with 16.2.0. There's a longer-form writeup of the issue here: https://github.com/DataDog/dd-trace-js/issues/1095#issuecomment-845451520

TODO:
- [ ] debug deadlock caused when `--detectOpenHandles` is removed
- [x] add logging to EntityManager to show issue (@stephenh)
- [x] rebase this branch from `main` once #121 is merged (`git rebase --onto main feature/matrix-build chore/node-16-2-issue`)