### PR TITLE
Add getters for enum details.

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -68,6 +68,7 @@ export type EnumField = Field & {
   enumName: string;
   enumType: Import;
   enumDetailType: Import;
+  enumDetailsType: Import;
   enumRows: EnumRow[];
   notNull: boolean;
 };
@@ -212,6 +213,7 @@ function newEnumField(config: Config, entity: Entity, r: M2ORelation, enums: Enu
   const enumName = tableToEntityName(config, r.targetTable);
   const enumType = imp(`${enumName}@./entities`);
   const enumDetailType = imp(`${plural(enumName)}@./entities`);
+  const enumDetailsType = imp(`${enumName}Details@./entities`);
   const notNull = column.notNull;
   const ignore = isFieldIgnored(config, entity, fieldName, notNull, column.default !== null);
   return {
@@ -220,6 +222,7 @@ function newEnumField(config: Config, entity: Entity, r: M2ORelation, enums: Enu
     enumName,
     enumType,
     enumDetailType,
+    enumDetailsType,
     notNull,
     ignore,
     enumRows: enums[r.targetTable.name].rows,
@@ -236,7 +239,7 @@ function newManyToOneField(config: Config, entity: Entity, r: M2ORelation): Many
     ? oneToOneName(config, otherEntity, entity)
     : collectionName(config, otherEntity, entity, r).fieldName;
   const notNull = column.notNull;
-  const ignore = isFieldIgnored(config, entity, fieldName, notNull,column.default !== null);
+  const ignore = isFieldIgnored(config, entity, fieldName, notNull, column.default !== null);
   return { fieldName, columnName, otherEntity, otherFieldName, notNull, ignore };
 }
 

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -101,11 +101,16 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
 
   // Add ManyToOne enums
   meta.enums.forEach((e) => {
-    const { fieldName, enumType, notNull, enumRows } = e;
+    const { fieldName, enumType, enumDetailType, enumDetailsType, notNull, enumRows } = e;
     const maybeOptional = notNull ? "" : " | undefined";
+    const getByCode = code`${enumDetailType}.getByCode(this.${fieldName})`;
     const getter = code`
       get ${fieldName}(): ${enumType}${maybeOptional} {
         return this.__orm.data["${fieldName}"];
+      }
+
+      get ${fieldName}Details(): ${enumDetailsType}${maybeOptional} {
+        return ${notNull ? getByCode : code`this.${fieldName} ? ${getByCode} : undefined`};
       }
    `;
     const setter = code`

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -29,6 +29,8 @@ import {
 import { Context } from "src/context";
 import {
   AdvanceStatus,
+  AdvanceStatusDetails,
+  AdvanceStatuses,
   Book,
   BookAdvance,
   bookAdvanceMeta,
@@ -123,6 +125,10 @@ export abstract class BookAdvanceCodegen extends BaseEntity {
 
   get status(): AdvanceStatus {
     return this.__orm.data["status"];
+  }
+
+  get statusDetails(): AdvanceStatusDetails {
+    return AdvanceStatuses.getByCode(this.status);
   }
 
   set status(status: AdvanceStatus) {

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -39,6 +39,8 @@ import {
   Image,
   imageMeta,
   ImageType,
+  ImageTypeDetails,
+  ImageTypes,
   newImage,
   Publisher,
   PublisherId,
@@ -145,6 +147,10 @@ export abstract class ImageCodegen extends BaseEntity {
 
   get type(): ImageType {
     return this.__orm.data["type"];
+  }
+
+  get typeDetails(): ImageTypeDetails {
+    return ImageTypes.getByCode(this.type);
   }
 
   set type(type: ImageType) {

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -37,7 +37,11 @@ import {
   Publisher,
   publisherMeta,
   PublisherSize,
+  PublisherSizeDetails,
+  PublisherSizes,
   PublisherType,
+  PublisherTypeDetails,
+  PublisherTypes,
 } from "./entities";
 
 export type PublisherId = Flavor<string, "Publisher">;
@@ -176,6 +180,10 @@ export abstract class PublisherCodegen extends BaseEntity {
     return this.__orm.data["size"];
   }
 
+  get sizeDetails(): PublisherSizeDetails | undefined {
+    return this.size ? PublisherSizes.getByCode(this.size) : undefined;
+  }
+
   set size(size: PublisherSize | undefined) {
     setField(this, "size", size);
   }
@@ -190,6 +198,10 @@ export abstract class PublisherCodegen extends BaseEntity {
 
   get type(): PublisherType | undefined {
     return this.__orm.data["type"];
+  }
+
+  get typeDetails(): PublisherTypeDetails | undefined {
+    return this.type ? PublisherTypes.getByCode(this.type) : undefined;
   }
 
   set type(type: PublisherType | undefined) {


### PR DESCRIPTION
I wrote:

```
  name() {
    const detail = ProcurementRequestTypes.getByCode(this.type);
    return `${detail.name} Request ${this.idUntagged}`;
  }
```

And wanted it to be `this.typeDetails.name` instead