### PR TITLE
refactored isNewEntity behavior in afterCommit hooks

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -122,6 +122,8 @@ describe("Author", () => {
     expect(a1.beforeCreateRan).toBeFalsy();
     expect(a1.beforeUpdateRan).toBeFalsy();
     expect(a1.afterCommitRan).toBeFalsy();
+    expect(a1.afterCommitIdIsSet).toBeFalsy();
+    expect(a1.afterCommitIsNewEntity).toBeFalsy();
     expect(a1.afterValidationRan).toBeFalsy();
     expect(a1.beforeDeleteRan).toBeFalsy();
     await em.flush();
@@ -131,6 +133,8 @@ describe("Author", () => {
     expect(a1.beforeDeleteRan).toBeFalsy();
     expect(a1.afterValidationRan).toBeTruthy();
     expect(a1.afterCommitRan).toBeTruthy();
+    expect(a1.afterCommitIdIsSet).toBeTruthy();
+    expect(a1.afterCommitIsNewEntity).toBeTruthy();
     a1.firstName = "new name";
     a1.beforeCreateRan = false;
     await em.flush();
@@ -383,12 +387,21 @@ describe("Author", () => {
     expect(i).toBeTruthy();
   });
 
-  it("has isNewEntity", async () => {
-    const em = newEntityManager();
-    const a1 = await em.create(Author, { firstName: "a1" });
-    expect(a1.isNewEntity).toBeTruthy();
-    await em.flush();
-    expect(a1.isNewEntity).toBeFalsy();
+  describe("isNewEntity", () => {
+    it("is false after fetch for existing entities", async () => {
+      await insertAuthor({ first_name: "a1" });
+      const em = newEntityManager();
+      const a1 = await em.findOneOrFail(Author, { firstName: "a1" });
+      expect(a1.isNewEntity).toBeFalsy();
+    });
+
+    it("is true for new entities until they are flushed", async () => {
+      const em = newEntityManager();
+      const a1 = await em.create(Author, { firstName: "a1" });
+      expect(a1.isNewEntity).toBeTruthy();
+      await em.flush();
+      expect(a1.isNewEntity).toBeFalsy();
+    });
   });
 
   it("can populate itself easily", async () => {

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -34,6 +34,8 @@ export class Author extends AuthorCodegen {
   public beforeDeleteRan = false;
   public afterValidationRan = false;
   public afterCommitRan = false;
+  public afterCommitIdIsSet = false;
+  public afterCommitIsNewEntity = false;
   public ageForBeforeFlush?: number;
 
   /** Example of using populate within an entity on itself. */
@@ -128,7 +130,10 @@ authorConfig.beforeDelete((author) => {
 });
 
 authorConfig.afterCommit((author) => {
+  // make sure we're still a new entity even though the id has been set
   author.afterCommitRan = true;
+  author.afterCommitIdIsSet = author.id !== undefined;
+  author.afterCommitIsNewEntity = author.isNewEntity;
 });
 
 authorConfig.setAsyncDerivedField("numberOfBooks", "books", (author) => {

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -19,6 +19,7 @@ import {
  */
 export abstract class BaseEntity implements Entity {
   abstract id: string | undefined;
+  private __isNewEntity: boolean = true;
   readonly __orm: EntityOrmField;
 
   protected constructor(em: EntityManager, metadata: any, defaultValues: object, opts: any) {
@@ -26,6 +27,7 @@ export abstract class BaseEntity implements Entity {
     // Ensure we have at least id set so the `EntityManager.register` works
     if (typeof opts === "string") {
       this.__orm.data["id"] = opts;
+      this.__isNewEntity = false;
     }
     em.register(metadata, this);
   }
@@ -54,7 +56,7 @@ export abstract class BaseEntity implements Entity {
   }
 
   get isNewEntity(): boolean {
-    return this.id === undefined;
+    return this.__isNewEntity;
   }
 
   get isDeletedEntity(): boolean {


### PR DESCRIPTION
`isNewEntity` should now return true during an `afterCommit` if the entity was inserted as part of that flush