### PR TITLE
added explicit isLoaded to all relation types

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -35,7 +35,7 @@ import {
   ValidationRuleResult,
 } from "./index";
 import { combineJoinRows, createTodos, getTodo, Todo } from "./Todo";
-import { fail, NullOrDefinedOr } from "./utils";
+import { fail, NullOrDefinedOr, toArray } from "./utils";
 
 export interface EntityConstructor<T> {
   new (em: EntityManager, opts: any): T;
@@ -588,7 +588,7 @@ export class EntityManager<C = {}> {
     entityOrList: T | T[],
     hint: H,
   ): Promise<Loaded<T, H> | Array<Loaded<T, H>>> {
-    const list: T[] = Array.isArray(entityOrList) ? entityOrList : [entityOrList];
+    const list = toArray(entityOrList);
     const promises = list
       .filter((e) => e !== undefined && (e.isPendingDelete || !e.isDeletedEntity))
       .flatMap((entity) => {

--- a/packages/orm/src/collections/ManyToManyCollection.ts
+++ b/packages/orm/src/collections/ManyToManyCollection.ts
@@ -104,6 +104,10 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     }
   }
 
+  get isLoaded(): boolean {
+    return this.loaded !== undefined;
+  }
+
   private doGet(): U[] {
     ensureNotDeleted(this.entity);
     if (this.loaded === undefined) {

--- a/packages/orm/src/collections/OneToManyCollection.ts
+++ b/packages/orm/src/collections/OneToManyCollection.ts
@@ -54,6 +54,10 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     return (await this.load()).find((u) => u.id === id);
   }
 
+  get isLoaded(): boolean {
+    return this.loaded !== undefined;
+  }
+
   get get(): U[] {
     return this.filterDeleted(this.doGet(), { withDeleted: false });
   }

--- a/packages/orm/src/utils.ts
+++ b/packages/orm/src/utils.ts
@@ -59,5 +59,10 @@ export function partition<T>(array: ReadonlyArray<T>, f: (el: T) => boolean): [T
   return [trueElements, falseElements];
 }
 
+// Utility function to wrap an object or value in an array, unless it's already an array
+export function toArray<T>(maybeArray: T | T[]): T[] {
+  return Array.isArray(maybeArray) ? maybeArray : [maybeArray];
+}
+
 // Utility type to strip off null and defined and infer only T.
 export type NullOrDefinedOr<T> = T | null | undefined;


### PR DESCRIPTION
also refactored `isReference` / `isCollection` to actually check against the concrete implementation classes instead of just seeing if the object looked like a relation