### PR TITLE
chore: re-enable node 16 testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,7 @@ workflows:
       - build:
           matrix:
             parameters:
-              # We should test against "latest Node 16", but there's an issue with 16.2
-              # This will be updated soon, along with a bug report to Node.js
-              # node-version: ["lts/erbium", "lts/fermium", "16"]
-              node-version: ["lts/erbium", "lts/fermium", "16.1"]
+              node-version: ["lts/erbium", "lts/fermium", "16"]
 
 jobs:
   build:

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/stephenh/joist-ts.git",
     "directory": "packages/joist-orm"
   },
+  "engines": {
+    "node": "^12.17.0 || ^13.10.0 || ^14 || >= 16.0.0 < 16.2.0 || >= 16.3.0"
+  },
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This fix in Node 16.3.0 should fix compatibility with Joist / jest: https://github.com/nodejs/node/pull/38821