### PR TITLE
Add 'incremental' operation to handle when sets might be empty.

### DIFF
--- a/packages/integration-tests/src/EntityManager.createOrUpdatePartial.test.ts
+++ b/packages/integration-tests/src/EntityManager.createOrUpdatePartial.test.ts
@@ -266,6 +266,20 @@ describe("EntityManager", () => {
     expect(await countOfBookToTags()).toEqual(2);
   });
 
+  it("collections can incrementally not clear collections by seeing a marker", async () => {
+    // Given an book with one tag
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertTag({ name: "t1" });
+    await insertBookToTag({ tag_id: 1, book_id: 1 });
+    const em = newEntityManager();
+    // When we incrementally "set" tags to empty
+    await em.createOrUpdatePartial(Book, { id: "b:1", tags: [{ op: "incremental" }] });
+    await em.flush();
+    // Then we have the m2m row
+    expect(await countOfBookToTags()).toEqual(1);
+  });
+
   it("collections can refer to entities", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });

--- a/packages/orm/src/createOrUpdatePartial.ts
+++ b/packages/orm/src/createOrUpdatePartial.ts
@@ -34,7 +34,7 @@ type AllowRelationsToBeIdsOrEntitiesOrPartials<T> = {
             | (DeepPartialOrNull<V> & {
                 delete?: boolean | null;
                 remove?: boolean | null;
-                op?: "remove" | "delete" | "include";
+                op?: "remove" | "delete" | "include" | "incremental";
               })
             | IdOf<V>
           > | null
@@ -129,6 +129,10 @@ export async function createOrUpdatePartial<T extends Entity>(
               const deleteMarker = allowDelete && value["delete"];
               const removeMarker = allowRemove && value["remove"];
               const opMarker = allowOp && value["op"];
+              // If this is the incremental marker, just leave it in as-is so that setOpts can see it
+              if (opMarker === "incremental") {
+                return value;
+              }
               // Remove the markers, regardless of true/false, before recursing into createOrUpdatePartial to avoid unknown fields
               if (deleteMarker !== undefined) delete value.delete;
               if (removeMarker !== undefined) delete value.remove;

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -241,6 +241,8 @@ export function setOpts<T extends Entity>(
               (current as any).remove(v);
             } else if (v.op === "include") {
               (current as any).add(v);
+            } else if (v.op === "incremental") {
+              // This is a marker entry to opt-in to incremental behavior, just drop it
             }
           });
           return; // return from the op-based incremental behavior


### PR DESCRIPTION
This addresses @haislip 's use case where the client might send in `children: [{ delete: true, ... }, { delete: false }, ...]` but they might also send in `children: []` but that doesn't mean "clear the collection" it just means "there are no incremental operations to perform".

Now the resolver (or even the client) can include a throw-away `{ op: "incremental" }` that won't do anything other than turn on the incremental/non-exhaustive behavior.