### PR TITLE
Scaffold DateTimes for ...At fields.

### DIFF
--- a/packages/graphql-codegen/src/generateEnumsGraphql.ts
+++ b/packages/graphql-codegen/src/generateEnumsGraphql.ts
@@ -8,7 +8,7 @@ export async function generateEnumsGraphql(enums: EnumMetadata): Promise<CodeGen
     .map(({ name, rows, extraPrimitives }) => {
       const enumDecl = `enum ${name} { ${rows.map((r) => r.code).join(" ")} }`;
       const detailDecl = `type ${name}Detail { code: ${name}! name: String! ${extraPrimitives
-        .map((p) => `${camelCase(p.columnName)}: ${mapTypescriptTypeToGraphQLType(p.fieldType)}!`)
+        .map((p) => `${camelCase(p.columnName)}: ${mapTypescriptTypeToGraphQLType(p.fieldName, p.fieldType)}!`)
         .join(" ")} }`;
       return [enumDecl, "", detailDecl, ""];
     })

--- a/packages/graphql-codegen/src/generateGraphqlSchemaFiles.test.ts
+++ b/packages/graphql-codegen/src/generateGraphqlSchemaFiles.test.ts
@@ -246,6 +246,50 @@ describe("generateGraphqlSchemaFiles", () => {
       "
     `);
   });
+
+  it("can output both Date and DateTime types", async () => {
+    // Given an author
+    const entities: EntityDbMetadata[] = [
+      newEntityMetadata("Author", {
+        primitives: [
+          // With a regular field
+          newPrimitiveField("firstName"),
+          // And a timestamp field  with the `_at` convention
+          newPrimitiveField("createdAt", { fieldType: "Date" }),
+          // And also a date field with the `_date` convention
+          newPrimitiveField("startDate", { fieldType: "Date" }),
+        ],
+      }),
+    ];
+    // When ran
+    const fs = newFs({});
+    await generateGraphqlSchemaFiles(fs, entities);
+    // Then the input has both both types of fields as appropriate
+    expect(await fs.load("author.graphql")).toMatchInlineSnapshot(`
+"type Author {
+  id: ID!
+  firstName: String!
+  createdAt: DateTime!
+  startDate: Date!
+}
+
+extend type Mutation {
+  saveAuthor(input: SaveAuthorInput!): SaveAuthorResult!
+}
+
+input SaveAuthorInput {
+  id: ID
+  firstName: String
+  createdAt: DateTime
+  startDate: Date
+}
+
+type SaveAuthorResult {
+  author: Author!
+}
+"
+`);
+  });
 });
 
 function newFs(files: Record<string, string>): Fs {

--- a/packages/graphql-codegen/src/generateGraphqlSchemaFiles.ts
+++ b/packages/graphql-codegen/src/generateGraphqlSchemaFiles.ts
@@ -57,7 +57,7 @@ function createEntityFields(entities: EntityDbMetadata[]): GqlField[] {
     const id: GqlField = { ...common, fieldName: "id", fieldType: "ID!" };
 
     const primitives = e.primitives.map(({ fieldName, fieldType: tsType, notNull }) => {
-      const fieldType = `${mapTypescriptTypeToGraphQLType(tsType)}${maybeRequired(notNull)}`;
+      const fieldType = `${mapTypescriptTypeToGraphQLType(fieldName, tsType)}${maybeRequired(notNull)}`;
       return { ...common, fieldName, fieldType };
     });
 
@@ -120,7 +120,7 @@ function createSaveEntityInputFields(entities: EntityDbMetadata[]): GqlField[] {
     const primitives = e.primitives
       .filter((f) => f.derived === false)
       .map(({ fieldName, fieldType: tsType }) => {
-        const fieldType = `${mapTypescriptTypeToGraphQLType(tsType)}`;
+        const fieldType = `${mapTypescriptTypeToGraphQLType(fieldName, tsType)}`;
         return { ...common, fieldName, fieldType };
       });
 

--- a/packages/graphql-codegen/src/graphqlUtils.ts
+++ b/packages/graphql-codegen/src/graphqlUtils.ts
@@ -139,9 +139,9 @@ function mergeDocs(existingDoc: DocumentNode, newDocs: [string, DocumentNode][])
   });
 }
 
-export type GraphQLType = "Boolean" | "String" | "Int" | "Date";
+export type GraphQLType = "Boolean" | "String" | "Int" | "Date" | "DateTime";
 
-export function mapTypescriptTypeToGraphQLType(type: PrimitiveTypescriptType): GraphQLType {
+export function mapTypescriptTypeToGraphQLType(fieldName: string, type: PrimitiveTypescriptType): GraphQLType {
   switch (type) {
     case "string":
       return "String";
@@ -149,6 +149,14 @@ export function mapTypescriptTypeToGraphQLType(type: PrimitiveTypescriptType): G
       return "Boolean";
     case "number":
       return "Int";
+    case "Date":
+      // Joist doesn't yet have different `date` vs. `datetime` types (which is surprising...),
+      // but we do in GraphQL, so for now lean on the `..._at` suffix convention to know "DateTime".
+      if (fieldName.endsWith("At")) {
+        return "DateTime";
+      } else {
+        return "Date";
+      }
     default:
       return type;
   }


### PR DESCRIPTION
To fix all of our `createdAt`s being `Date`s and so not sorting correctly if they happen to be on the same day.