### PR TITLE
Fix: Support multiple primitive filters as ANDs.

### DIFF
--- a/packages/integration-tests/src/EntityManager.queries.memory.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.memory.test.ts
@@ -347,6 +347,15 @@ describe("EntityManager.queries.memory", () => {
     expect(authors.length).toEqual(2);
   });
 
+  it("can find by gte and lte at the same time", async () => {
+    await insertAuthor({ first_name: "a1", age: 1 });
+    await insertAuthor({ first_name: "a1", age: 3 });
+    await insertAuthor({ first_name: "a2", age: 5 });
+    const em = newEntityManager();
+    const authors = await em.find(Author, { age: { gte: 2, lte: 4 } });
+    expect(authors.length).toEqual(1);
+  });
+
   it("can find by not equal", async () => {
     await insertAuthor({ first_name: "a1", age: 1 });
     await insertAuthor({ first_name: "a2", age: 2 });

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -395,6 +395,15 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(2);
   });
 
+  it("can find by gte and lte at the same time", async () => {
+    await insertAuthor({ first_name: "a1", age: 1 });
+    await insertAuthor({ first_name: "a1", age: 3 });
+    await insertAuthor({ first_name: "a2", age: 5 });
+    const em = newEntityManager();
+    const authors = await em.find(Author, { age: { gte: 2, lte: 4 } });
+    expect(authors.length).toEqual(1);
+  });
+
   it("can find by not equal", async () => {
     await insertAuthor({ first_name: "a1", age: 1 });
     await insertAuthor({ first_name: "a2", age: 2 });

--- a/packages/orm/src/drivers/InMemoryDriver.ts
+++ b/packages/orm/src/drivers/InMemoryDriver.ts
@@ -210,29 +210,33 @@ function rowMatches(driver: InMemoryDriver, meta: EntityMetadata<any>, row: any,
           } else if (field.kind === "primaryKey") {
             fn = (v) => keyToNumber(meta, v as any);
           }
-          const filter = parseValueFilter(value as ValueFilter<any, any>);
-          switch (filter.kind) {
-            case "eq":
-              return currentValue === fn(filter.value);
-            case "ne":
-              return notEqual(currentValue, fn(filter.value));
-            case "in":
-              return filter.value.map(fn).includes(currentValue);
-            case "gt":
-            case "gte":
-            case "lt":
-            case "lte":
-            case "like":
-            case "ilike":
-              const a = currentValue;
-              const b = fn(filter.value);
-              const op = ops[filter.kind];
-              return op(a, b);
-            case "pass":
-              return true;
-            default:
-              throw new Error("Unsupported");
-          }
+          const filters = parseValueFilter(value as ValueFilter<any, any>);
+          return filters
+            .map((filter) => {
+              switch (filter.kind) {
+                case "eq":
+                  return currentValue === fn(filter.value);
+                case "ne":
+                  return notEqual(currentValue, fn(filter.value));
+                case "in":
+                  return filter.value.map(fn).includes(currentValue);
+                case "gt":
+                case "gte":
+                case "lt":
+                case "lte":
+                case "like":
+                case "ilike":
+                  const a = currentValue;
+                  const b = fn(filter.value);
+                  const op = ops[filter.kind];
+                  return op(a, b);
+                case "pass":
+                  return true;
+                default:
+                  throw new Error("Unsupported");
+              }
+            })
+            .every((r) => r);
         case "m2o":
           const otherMeta = field.otherMetadata();
           const ef = parseEntityFilter(otherMeta, value);


### PR DESCRIPTION
The types supported `{ gte: 1, lte: 5 }` but the parsing did not.