### PR TITLE
Better handle children creating parents via factories.

### DIFF
--- a/packages/integration-tests/src/entities/Book.factories.ts
+++ b/packages/integration-tests/src/entities/Book.factories.ts
@@ -1,6 +1,10 @@
 import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
 import { Book } from "./entities";
 
+// for testing factories
+export let lastBookFactoryOpts: any = null;
+
 export function newBook(em: EntityManager, opts?: FactoryOpts<Book>): New<Book> {
+  lastBookFactoryOpts = opts;
   return newTestInstance(em, Book, opts);
 }

--- a/packages/integration-tests/src/entities/Book.test.ts
+++ b/packages/integration-tests/src/entities/Book.test.ts
@@ -1,4 +1,4 @@
-import { Author, Book } from "../entities";
+import { Author, Book, lastBookFactoryOpts, newBookReview } from "../entities";
 import { newEntityManager } from "../setupDbTests";
 
 describe("Book", () => {
@@ -15,5 +15,14 @@ describe("Book", () => {
     const a1 = em.create(Author, { firstName: "a1" });
     const b1 = em.create(Book, { title: "b1", author: a1 });
     expect(b1.order).toEqual(0);
+  });
+
+  it("factory should be passed reviews as null if created bottom-up", async () => {
+    const em = newEntityManager();
+    newBookReview(em, { book: {} });
+    expect(lastBookFactoryOpts).toEqual({
+      use: undefined,
+      reviews: null,
+    });
   });
 });

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -68,7 +68,17 @@ export function newTestInstance<T extends Entity>(
             } else if (optValue && !isPlainObject(optValue)) {
               return field.otherMetadata().factory(em, opts);
             }
-            return [fieldName, field.otherMetadata().factory(em, { ...optValue, use: opts.use })];
+            return [
+              fieldName,
+              field.otherMetadata().factory(em, {
+                ...optValue,
+                // We include null as a marker for "don't create the children", i.e. if you're doing
+                // `newLineItem(em, { parent: { ... } });` then any factory defaults inside the parent's
+                // factory, i.e. `lineItems: [{}]`, should be skipped.
+                [field.otherFieldName]: null,
+                use: opts.use,
+              }),
+            ];
           }
 
           // If this is a list of children, watch for partials that should be newTestInstance'd


### PR DESCRIPTION
I.e. if a parent factory has:

```
export function newParent(...) {
  return newTestInstance(em, {
    // Always have one child
    children: [{}],
    ...opts
  });
}
```

But a test is creating the child "bottom up", i.e. doing:

```
newChild(em, { parent: ... });
```

Then we know the parent is going to get a list of children already (from
the one that is currently being created), so we don't need its `children:
[{}]` default to apply.

So we send in `opts.children: null`, as if the programmer had written
that by hand, such that the `...opts` convention of the factories will
write over the `children: [{}]` default.