### PR TITLE
fix: Add missing semi-colon.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -419,7 +419,7 @@ function generateOptsFields(config: Config, meta: EntityDbMetadata): Code[] {
     return code`${fieldName}?: ${otherEntity.type}[];`;
   });
   const polys = meta.polymorphics.map(({ fieldName, notNull, fieldType }) => {
-    return code`${fieldName}${maybeOptional(notNull)}:  ${fieldType}`;
+    return code`${fieldName}${maybeOptional(notNull)}: ${fieldType};`;
   });
   return [...primitives, ...enums, ...m2o, ...polys, ...o2o, ...o2m, ...m2m];
 }


### PR DESCRIPTION
It was working for `Comment.parent` b/c it happened to be the last opt in the type, so prettier auto-added the semi-colon. :-) Wasn't until another opt comes after it, that it becomes a syntax error. 