### PR TITLE
Change hasChanged to be true on create.

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -328,12 +328,13 @@ describe("Author", () => {
   });
 
   describe("changes", () => {
-    it("on create nothing is considered changed", async () => {
+    it("on create set fields are considered changed", async () => {
       const em = newEntityManager();
       const a1 = new Author(em, { firstName: "f1", lastName: "ln" });
-      expect(a1.changes.firstName.hasChanged).toBeFalsy();
+      expect(a1.changes.firstName.hasChanged).toBeTruthy();
       expect(a1.changes.firstName.originalValue).toBeUndefined();
-      expect(a1.changes.fields).toEqual([]);
+      expect(a1.changes.isPopular.hasChanged).toBeFalsy();
+      expect(a1.changes.fields).toEqual(["createdAt", "updatedAt", "firstName", "lastName"]);
     });
 
     it("after initial load nothing is considered changed", async () => {

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -89,7 +89,7 @@ authorConfig.addRule((a) => {
 });
 
 authorConfig.addRule((a) => {
-  if (a.changes.lastName.hasChanged) {
+  if (!a.isNewEntity && a.changes.lastName.hasChanged) {
     return "lastName cannot be changed";
   }
 });


### PR DESCRIPTION
It seems like we almost always do `foo.hasChanged || isNewEntity`, i.e. `hasChanged` should just be true for set fields on new entities.