### PR TITLE
Pass use entities directly to factories.

### DIFF
--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -103,6 +103,7 @@ describe("EntityManager.factories", () => {
     expect(a1.firstName).toEqual("a1");
     // And it has the publisher set
     expect(a1.publisher.get).toEqual(p1);
+    expect(lastAuthorFactoryOpts).toEqual({ publisher: p1, use: p1 });
   });
 
   it("can create a grandchild and specify the grandparents opts", async () => {


### PR DESCRIPTION
Previously we looked them up after a factory has called newTestInstance,
which worked but meant that the factory's internal default behavior
logic might kick in, instead of using the entity passed in `use`.