### PR TITLE
Fix calling new with both use & a required field set as undefined.

### DIFF
--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -103,7 +103,7 @@ describe("EntityManager.factories", () => {
     expect(a1.firstName).toEqual("a1");
     // And it has the publisher set
     expect(a1.publisher.get).toEqual(p1);
-    expect(lastAuthorFactoryOpts).toEqual({ publisher: p1, use: p1 });
+    expect(lastAuthorFactoryOpts).toMatchObject({ publisher: p1 });
   });
 
   it("can create a grandchild and specify the grandparents opts", async () => {
@@ -188,8 +188,7 @@ describe("EntityManager.factories", () => {
   it("should default children to empty array if created bottom-up", async () => {
     const em = newEntityManager();
     newBookReview(em, { book: {} });
-    expect(lastBookFactoryOpts).toEqual({
-      use: undefined,
+    expect(lastBookFactoryOpts).toMatchObject({
       reviews: [],
     });
   });
@@ -197,8 +196,7 @@ describe("EntityManager.factories", () => {
   it("should default o2o as null if created bottom-up", async () => {
     const em = newEntityManager();
     newImage(em, { author: {} });
-    expect(lastAuthorFactoryOpts).toEqual({
-      use: undefined,
+    expect(lastAuthorFactoryOpts).toMatchObject({
       image: null,
     });
   });

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -5,11 +5,17 @@ import {
   EntityManager,
   EntityMetadata,
   EntityOrmField,
+  Field,
   getMetadata,
   IdOf,
   Loaded,
   LoadHint,
+  ManyToManyField,
+  ManyToOneField,
+  OneToManyField,
+  OneToOneField,
   OptsOf,
+  PolymorphicField,
   RelationsIn,
 } from "./EntityManager";
 import { maybeResolveReferenceToId, tagFromId } from "./keys";
@@ -550,4 +556,32 @@ export function isLoadedAsyncProperty(
   maybeAsyncProperty: any,
 ): maybeAsyncProperty is AsyncProperty<any, any> & LoadedProperty<any, any> {
   return isAsyncProperty(maybeAsyncProperty) && maybeAsyncProperty.isLoaded;
+}
+
+export function isOneToManyField(ormField: Field): ormField is OneToManyField {
+  return ormField.kind === "o2m";
+}
+
+export function isManyToOneField(ormField: Field): ormField is ManyToOneField {
+  return ormField.kind === "m2o";
+}
+
+export function isManyToManyField(ormField: Field): ormField is ManyToManyField {
+  return ormField.kind === "m2m";
+}
+
+export function isOneToOneField(ormField: Field): ormField is OneToOneField {
+  return ormField.kind === "o2o";
+}
+
+export function isPolymorphicField(ormField: Field): ormField is PolymorphicField {
+  return ormField.kind === "poly";
+}
+
+export function isReferenceField(ormField: Field): ormField is ManyToOneField | OneToOneField | PolymorphicField {
+  return ormField.kind === "m2o" || ormField.kind === "o2o" || ormField.kind === "poly";
+}
+
+export function isCollectionField(ormField: Field): ormField is OneToManyField | ManyToManyField {
+  return ormField.kind === "o2m" || ormField.kind === "m2m";
 }

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -88,7 +88,6 @@ export function newTestInstance<T extends Entity>(
                 // `newLineItem(em, { parent: { ... } });` then any factory defaults inside the parent's
                 // factory, i.e. `lineItems: [{}]`, should be skipped.
                 [field.otherFieldName]: otherField.kind === "o2o" ? null : [],
-                use,
               }),
             ];
           }
@@ -115,7 +114,6 @@ export function newTestInstance<T extends Entity>(
                 // parent set. It might be better to do o2ms as a 2nd-pass, after we've done the em.create
                 // call and could directly pass this entity instead of null.
                 [field.otherFieldName]: null,
-                use,
               });
             });
             return [fieldName, values];
@@ -148,7 +146,7 @@ export function newTestInstance<T extends Entity>(
           }
           // Otherwise only make a new entity only if the field is required
           if (field.required) {
-            return [fieldName, otherMeta.factory(em, { ...applyUse({}, use, otherMeta), use })];
+            return [fieldName, otherMeta.factory(em, applyUse({}, use, otherMeta))];
           }
         } else if (field.kind === "enum" && field.required) {
           return [fieldName, field.enumDetailType.getValues()[0]];
@@ -177,6 +175,7 @@ function applyUse(opts: object, use: UseMap, metadata: EntityMetadata<any>): obj
         (opts as any)[f.fieldName] = use.get(f.otherMetadata().cstr);
       }
     });
+  (opts as any).use = use;
   return opts;
 }
 

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -40,8 +40,7 @@ export function newTestInstance<T extends Entity>(
   opts: FactoryOpts<T> = {},
 ): New<T> {
   const meta = getMetadata(cstr);
-  // We share a single `use` array for a given `newEntity` factory call; if the user
-  // doesn't pass one in, just create a new one.
+  // We share a single `use` map for a given `newEntity` factory call
   const use = useMap(opts.use);
 
   // fullOpts will end up being a full/type-safe opts with every required field
@@ -171,11 +170,12 @@ export function newTestInstance<T extends Entity>(
 
 /** Given we're going to call a factory, make sure any `use`s are put into `opts`. */
 function applyUse(opts: object, use: UseMap, metadata: EntityMetadata<any>): object {
-  // Look for any fields that have this entity's type
+  // Find any unset fields
   metadata.fields
     .filter((f) => !(f.fieldName in opts))
     .forEach((f) => {
       if (isManyToOneField(f) || isOneToOneField(f)) {
+        // And set them to the current `use` entity for their type, if it exists
         (opts as any)[f.fieldName] = use.get(f.otherMetadata().cstr);
       }
     });


### PR DESCRIPTION
Also converts `use` internally over to a map to avoid less sequential
scanning of things.