### PR TITLE
Generate opts as a default value.

### DIFF
--- a/packages/codegen/src/generateFactoriesFiles.ts
+++ b/packages/codegen/src/generateFactoriesFiles.ts
@@ -11,7 +11,7 @@ export function generateFactoriesFiles(entities: EntityDbMetadata[]): CodeGenFil
     const contents = code`
       export function new${name}(
         em: ${EntityManager},
-        opts?: ${FactoryOpts}<${entity.type}>
+        opts: ${FactoryOpts}<${entity.type}> = {},
       ): ${New}<${entity.type}> {
         return ${newTestInstance}(em, ${entity.type}, opts);
       }`;

--- a/packages/integration-tests/src/entities/Critic.factories.ts
+++ b/packages/integration-tests/src/entities/Critic.factories.ts
@@ -1,6 +1,6 @@
 import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
 import { Critic } from "./entities";
 
-export function newCritic(em: EntityManager, opts?: FactoryOpts<Critic>): New<Critic> {
+export function newCritic(em: EntityManager, opts: FactoryOpts<Critic> = {}): New<Critic> {
   return newTestInstance(em, Critic, opts);
 }


### PR DESCRIPTION
Makes the factory code slightly simpler to always have `opts` defined. 