### PR TITLE
Fix array columns.

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1193,12 +1193,35 @@ describe("EntityManager", () => {
     expect(rows[0].favorite_colors).toEqual([2]);
   });
 
-  it("can save an empty enum array", async () => {
+  it("can create an empty enum array", async () => {
     const em = newEntityManager();
     em.create(Author, { firstName: "a1" });
     await em.flush();
     const rows = await knex.select("*").from("authors");
     expect(rows[0].favorite_colors).toEqual([]);
+  });
+
+  it("can update an empty enum array", async () => {
+    await insertAuthor({ first_name: "f", favorite_colors: [1, 2] });
+    const em = newEntityManager();
+    const author = await em.load(Author, "1");
+    author.favoriteColors = [];
+    await em.flush();
+    const rows = await knex.select("*").from("authors");
+    expect(rows[0].favorite_colors).toEqual([]);
+  });
+
+  it("can update multiple enum array", async () => {
+    await insertAuthor({ first_name: "f", favorite_colors: [1] });
+    await insertAuthor({ first_name: "f", favorite_colors: [2] });
+    const em = newEntityManager();
+    const [a1, a2] = await em.find(Author, {});
+    a1.favoriteColors = [Color.Red, Color.Green];
+    a2.favoriteColors = [Color.Red, Color.Blue, Color.Green];
+    await em.flush();
+    const rows = await knex.select("*").from("authors").orderBy("id");
+    expect(rows[0].favorite_colors).toEqual([1, 2]);
+    expect(rows[1].favorite_colors).toEqual([1, 3, 2]);
   });
 
   describe("jsonb columns", () => {


### PR DESCRIPTION
Turns out array columns where just horribly broken because of how
our UPDATE statements work.

We had used a trick where, to update 10 authors in 1 SQL statement,
we send 1 SQL UPDATE and then make a mini-temp-table by sending
in 10 first names, 10 last names, etc., each as an array, and then
`unnest`-ing each array into a given column, i.e. we'd get a temp
table with 10 rows, with each row's first name/last name/etc.

When I added array support, I tried to treat the array column in
this scenario as a "list of lists", i.e. something like 1st entity's
colors is [1], 2nd entity's colors is [2, 3], so send over [[1], [2,3]]
as a 2-dimensional array.

However, 2-dimensional arrays are not sparse, i.e. they have to be
[[1, 4], [2, 3]], which of course just doesn't make sense/can't work
for what I was trying to use them for.

So, instead if enum arrays are involved, we fallback to a different
UPDATE syntax that is still 1 statement, but uses multiple `VALUES
(...)` clauses in the SQL to create the mini-temp-table.

So, the same goal is achieved, just with a slightly longer SQL
statement, as the SQL statement itself needs to repeat the column
list for each entity being updated. But this shouldn't be a big deal,
and is actually how the INSERTs work, as we use a knex.batchInsert
method that uses the same `VALUES (...), (...)` approach.

I'm still keeping the unnest-based approach for when enum array
columns aren't being updated, b/c, dunno, it seems slightly better
given the SQL string is a constant size.