### PR TITLE
Add hasUpdated as prior hasChanges behavior.

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -328,10 +328,11 @@ describe("Author", () => {
   });
 
   describe("changes", () => {
-    it("on create set fields are considered changed", async () => {
+    it("on create set fields are considered changed but not updated", async () => {
       const em = newEntityManager();
       const a1 = new Author(em, { firstName: "f1", lastName: "ln" });
       expect(a1.changes.firstName.hasChanged).toBeTruthy();
+      expect(a1.changes.firstName.hasUpdated).toBeFalsy();
       expect(a1.changes.firstName.originalValue).toBeUndefined();
       expect(a1.changes.isPopular.hasChanged).toBeFalsy();
       expect(a1.changes.fields).toEqual(["createdAt", "updatedAt", "firstName", "lastName"]);
@@ -342,6 +343,7 @@ describe("Author", () => {
       const em = newEntityManager();
       const a1 = await em.load(Author, "1");
       expect(a1.changes.firstName.hasChanged).toBeFalsy();
+      expect(a1.changes.firstName.hasUpdated).toBeFalsy();
       expect(a1.changes.firstName.originalValue).toBeUndefined();
       expect(a1.changes.fields).toEqual([]);
     });
@@ -351,10 +353,12 @@ describe("Author", () => {
       const em = newEntityManager();
       const a1 = await em.load(Author, "1");
       expect(a1.changes.firstName.hasChanged).toBeFalsy();
+      expect(a1.changes.firstName.hasUpdated).toBeFalsy();
       expect(a1.changes.firstName.originalValue).toBeUndefined();
       expect(a1.changes.fields).toEqual([]);
       a1.firstName = "a2";
       expect(a1.changes.firstName.hasChanged).toBeTruthy();
+      expect(a1.changes.firstName.hasUpdated).toBeTruthy();
       expect(a1.changes.firstName.originalValue).toEqual("a1");
       expect(a1.changes.fields).toEqual(["firstName"]);
     });

--- a/packages/orm/src/changes.ts
+++ b/packages/orm/src/changes.ts
@@ -2,7 +2,11 @@ import { Entity, IdOf, OptsOf } from "./EntityManager";
 
 /** Exposes a field's changed/original value in each entity's `this.changes` property. */
 export interface FieldStatus<T> {
+  /** True if the field has been changed on either create or update. */
   hasChanged: boolean;
+  /** True only if the field has been updated i.e. not on the initial create. */
+  hasUpdated: boolean;
+  /** The original value, will be `undefined` if the entity new. */
   originalValue?: T;
 }
 
@@ -44,7 +48,8 @@ export function newChangesProxy<T extends Entity>(entity: T): Changes<T> {
 
       const originalValue = entity.__orm.originalData[p];
       const hasChanged = (entity.isNewEntity && p in entity.__orm.data) || p in entity.__orm.originalData;
-      return { hasChanged, originalValue };
+      const hasUpdated = !entity.isNewEntity && p in entity.__orm.originalData;
+      return { hasChanged, hasUpdated, originalValue };
     },
   }) as any;
 }


### PR DESCRIPTION
So that call sites can pick whether they want "changed at all" or "updated but not the initial create".