### PR TITLE
feat: Automatically dedup adds to m2ms.

### DIFF
--- a/packages/integration-tests/src/relations/ManyToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/ManyToManyCollection.test.ts
@@ -98,7 +98,7 @@ describe("ManyToManyCollection", () => {
     expect(rows[0]).toEqual(expect.objectContaining({ id: 1, book_id: 2, tag_id: 3 }));
   });
 
-  it("can an an existing tag-to-book", async () => {
+  it("can add existing tag-to-book m2m rows without failing", async () => {
     await insertAuthor({ first_name: "a1" });
     // Given two books/two tags, and 1 book->tag each
     await insertBook({ id: 2, title: "b1", author_id: 1 });
@@ -116,20 +116,31 @@ describe("ManyToManyCollection", () => {
 
     // When we add the existing relations again
     b2.tags.add(t4);
-    t4.books.add(b2);
+    t5.books.add(b3);
     // And also add new m2ms
     b2.tags.add(t5);
     t4.books.add(b3);
     await em.flush();
 
     // Then both the old and new m2ms exist
-    const rows = await knex.select("*").from("books_to_tags").orderBy("id");
+    let rows = await knex.select("*").from("books_to_tags").orderBy("id");
     expect(rows).toMatchObject([
       { id: 1, book_id: 2, tag_id: 4 },
       { id: 2, book_id: 3, tag_id: 5 },
-      { id: 4, book_id: 2, tag_id: 5 },
-      { id: 5, book_id: 3, tag_id: 4 },
+      { id: 5, book_id: 2, tag_id: 5 },
+      { id: 6, book_id: 3, tag_id: 4 },
     ]);
+
+    // And if we then remove all of those rows
+    b2.tags.remove(t4);
+    t5.books.remove(b3);
+    b2.tags.remove(t5);
+    t4.books.remove(b3);
+    await em.flush();
+
+    // Then there are none left
+    rows = await knex.select("*").from("books_to_tags").orderBy("id");
+    expect(rows).toMatchObject([]);
   });
 
   it("can add a new book to a tag", async () => {

--- a/packages/integration-tests/src/relations/ManyToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/ManyToManyCollection.test.ts
@@ -98,6 +98,40 @@ describe("ManyToManyCollection", () => {
     expect(rows[0]).toEqual(expect.objectContaining({ id: 1, book_id: 2, tag_id: 3 }));
   });
 
+  it("can an an existing tag-to-book", async () => {
+    await insertAuthor({ first_name: "a1" });
+    // Given two books/two tags, and 1 book->tag each
+    await insertBook({ id: 2, title: "b1", author_id: 1 });
+    await insertBook({ id: 3, title: "b2", author_id: 1 });
+    await insertTag({ id: 4, name: `t1` });
+    await insertTag({ id: 5, name: `t2` });
+    await insertBookToTag({ book_id: 2, tag_id: 4 });
+    await insertBookToTag({ book_id: 3, tag_id: 5 });
+
+    const em = newEntityManager();
+    const b2 = await em.load(Book, "b:2");
+    const b3 = await em.load(Book, "b:3");
+    const t4 = await em.load(Tag, "t:4");
+    const t5 = await em.load(Tag, "t:5");
+
+    // When we add the existing relations again
+    b2.tags.add(t4);
+    t4.books.add(b2);
+    // And also add new m2ms
+    b2.tags.add(t5);
+    t4.books.add(b3);
+    await em.flush();
+
+    // Then both the old and new m2ms exist
+    const rows = await knex.select("*").from("books_to_tags").orderBy("id");
+    expect(rows).toMatchObject([
+      { id: 1, book_id: 2, tag_id: 4 },
+      { id: 2, book_id: 3, tag_id: 5 },
+      { id: 4, book_id: 2, tag_id: 5 },
+      { id: 5, book_id: 3, tag_id: 4 },
+    ]);
+  });
+
   it("can add a new book to a tag", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ id: 2, title: "b1", author_id: 1 });

--- a/packages/orm/src/drivers/PostgresDriver.ts
+++ b/packages/orm/src/drivers/PostgresDriver.ts
@@ -246,7 +246,7 @@ export class PostgresDriver implements Driver {
           VALUES ${zeroTo(newRows.length)
             .map(() => "(?, ?) ")
             .join(", ")}
-          ON CONFLICT (${m2m.columnName}, ${m2m.otherColumnName}) DO NOTHING
+          ON CONFLICT (${m2m.columnName}, ${m2m.otherColumnName}) DO UPDATE SET id = ${joinTableName}.id
           RETURNING id;
         `);
         const meta1 = getMetadata(m2m.entity);
@@ -259,7 +259,7 @@ export class PostgresDriver implements Driver {
         });
         const { rows } = await knex.raw(sql, bindings);
         for (let i = 0; i < rows.length; i++) {
-          newRows[i].id = rows[i][0];
+          newRows[i].id = rows[i].id;
         }
       }
       if (deletedRows.length > 0) {


### PR DESCRIPTION
If a user adds an entity to an unloaded m2m, and that entity happened to
already be in the m2m table, we will avoid the unique constraint
conflict and just ues the existing row.

Fixes #179