### PR TITLE
Implement optimistic locking.

### DIFF
--- a/packages/orm/src/keys.ts
+++ b/packages/orm/src/keys.ts
@@ -61,6 +61,11 @@ export function deTagIds(meta: HasTagName, keys: readonly string[]): readonly st
   return keys.map((k) => deTagId(meta, k));
 }
 
+/** Adds the tag prefixes. */
+export function tagIds(meta: HasTagName, keys: readonly (string | number)[]): readonly string[] {
+  return keys.map((k) => tagIfNeeded(meta, String(k)));
+}
+
 export function deTagId(meta: HasTagName, id: string | number): string;
 export function deTagId(entity: Entity): string;
 export function deTagId(entityOrMeta: Entity | HasTagName, id?: string | number): string {


### PR DESCRIPTION
Per discussions, this is pretty easy for the ORM to keep track of and
just handle for us, and we can't really be sure how often it's happening
today because we can't detect it (although it is almost certainly
basically never).