### PR TITLE
fix: Fix faulty hooks orphaning the remaining hooks.

### DIFF
--- a/packages/codegen/tsconfig.json
+++ b/packages/codegen/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/graphql-codegen/tsconfig.json
+++ b/packages/graphql-codegen/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "strict": true,
     "types": ["jest", "node"],
     "esModuleInterop": true,

--- a/packages/migration-utils/tsconfig.json
+++ b/packages/migration-utils/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/orm/src/dataloaders/oneToOneDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToOneDataLoader.ts
@@ -34,7 +34,7 @@ export function oneToOneDataLoader<T extends Entity, U extends Entity>(
         // dummy value.
         return ownerId ?? "dummyNoLongerOwned";
       });
-      return _keys.map((k) => rowsById.get(k)?.[0]);
+      return _keys.map((k) => rowsById.get(k)?.[0] as U | undefined);
     });
   });
 }

--- a/packages/orm/tsconfig.json
+++ b/packages/orm/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],


### PR DESCRIPTION
With `Promise.all([...hooks...])` if one hook failed (_cough_ `Bill.beforeDelete`-cannot-delete-a-paid-bill _cough_), then `Promise.all` would immediately return.

However, the remaining hooks are not proactively aborted, and continue on their merry way.

This can lead to confusing things like:

- the failed hook makes `em.flush` early return
- the test stops and the pool shuts down
- one of the remaining hooks, still navigating through its populate hint, tries to load an entity/collection
- the connection pool throws a `TimeoutError` (??)
- in general various lingering lambdas confuse jest and subsequent tests