### PR TITLE
Remove DATABASE_CONNECTION_INFO.

### DIFF
--- a/docs/docs/getting-started/adding-to-your-project.md
+++ b/docs/docs/getting-started/adding-to-your-project.md
@@ -27,12 +27,10 @@ It assumes that:
 
 Run `npm install --save-dev joist-codegen`.
 
-Define your local postgres creds in a `DATABASE_CONNECTION_INFO` environment variable, i.e. in an `local.env` file similar to:
+Define your local postgres creds in a `DATABASE_URL` environment variable, i.e. in an `local.env` file similar to:
 
 ```shell
-DATABASE_CONNECTION_INFO=postgres://joist:local@localhost:5435/joist
-# the AWS RDS/SecretsManager JSON format is also supported natively
-DATABASE_CONNECTION_INFO={"host":"localhost","port":5435,"username":"joist","password":"local","dbname":"joist"}
+DATABASE_URL=postgres://joist:local@localhost:5435/joist
 ```
 
 With this env variable set, run the `joist-codegen` module, i.e. with `env` or [`run.sh`](https://github.com/stephenh/joist-ts/blob/master/packages/integration-tests/run.sh):
@@ -43,7 +41,7 @@ With this env variable set, run the `joist-codegen` module, i.e. with `env` or [
 
 ### If using node-pg-migrate
 
-If you do use `node-pg-migrate`, the `joist-migration-utils` package has some helper methods + glue code to invoke `node-pg-migrate` with the same `DATABASE_CONNECTION_INFO` environment variable.
+If you do use `node-pg-migrate`, the `joist-migration-utils` package has some helper methods + glue code to invoke `node-pg-migrate` with the same `DATABASE_URL` environment variable.
 
 ```shell
 ./run.sh joist-migration-utils

--- a/packages/integration-tests/local.env
+++ b/packages/integration-tests/local.env
@@ -1,2 +1,2 @@
-DATABASE_CONNECTION_INFO={"host":"localhost","port":5435,"username":"joist","password":"local","dbname":"joist"}
+DATABASE_URL=postgres://joist:local@localhost:5435/joist
 ADD_FLUSH_DATABASE=true

--- a/packages/integration-tests/src/setupDbTests.ts
+++ b/packages/integration-tests/src/setupDbTests.ts
@@ -6,7 +6,7 @@ import { toMatchEntity } from "joist-test-utils";
 import { newPgConnectionConfig } from "joist-utils";
 import { knex as createKnex, Knex } from "knex";
 
-if (process.env.DATABASE_CONNECTION_INFO === undefined) {
+if (process.env.DATABASE_URL === undefined) {
   config({ path: "./local.env" });
 }
 

--- a/packages/integration-tests/src/setupMemoryTests.ts
+++ b/packages/integration-tests/src/setupMemoryTests.ts
@@ -3,7 +3,7 @@ import { EntityManager } from "@src/entities";
 import { config } from "dotenv";
 import { InMemoryDriver } from "joist-orm";
 
-if (process.env.DATABASE_CONNECTION_INFO === undefined) {
+if (process.env.DATABASE_URL === undefined) {
   config({ path: "./local.env" });
 }
 

--- a/packages/tests/uuid-ids/local.env
+++ b/packages/tests/uuid-ids/local.env
@@ -1,2 +1,2 @@
-DATABASE_CONNECTION_INFO={"host":"localhost","port":5435,"username":"joist","password":"local","dbname":"uuid_ids"}
+DATABASE_URL=postgres://joist:local@localhost:5435/uuid_ids
 ADD_FLUSH_DATABASE=true

--- a/packages/tests/uuid-ids/src/setupDbTests.ts
+++ b/packages/tests/uuid-ids/src/setupDbTests.ts
@@ -6,7 +6,7 @@ import { toMatchEntity } from "joist-test-utils";
 import { newPgConnectionConfig } from "joist-utils";
 import { knex as createKnex, Knex } from "knex";
 
-if (process.env.DATABASE_CONNECTION_INFO === undefined) {
+if (process.env.DATABASE_URL === undefined) {
   config({ path: "./local.env" });
 }
 

--- a/packages/utils/src/connection.test.ts
+++ b/packages/utils/src/connection.test.ts
@@ -1,10 +1,8 @@
-import { parsePgConnectionConfig } from "./connection";
+import { newPgConnectionConfig } from "./connection";
 
 describe("connection", () => {
-  it("should parse RDS-style json", () => {
-    const info = parsePgConnectionConfig(
-      `{"host":"db","port":5432,"username":"joist","password":"local","dbname":"joist"}`,
-    );
+  it("should parse single DATABASE_URL", () => {
+    const info = newPgConnectionConfig({ DATABASE_URL: "postgres://joist:local@db:5432/joist" });
     expect(info).toEqual({
       database: "joist",
       host: "db",
@@ -14,8 +12,14 @@ describe("connection", () => {
     });
   });
 
-  it("should parse connection-string-style", () => {
-    const info = parsePgConnectionConfig("postgres://joist:local@db:5432/joist");
+  it("should parse multiple DB variables", () => {
+    const info = newPgConnectionConfig({
+      DB_USER: "joist",
+      DB_PASSWORD: "local",
+      DB_DATABASE: "joist",
+      DB_HOST: "db",
+      DB_PORT: "5432",
+    });
     expect(info).toEqual({
       database: "joist",
       host: "db",


### PR DESCRIPTION
It was a legacy RDS cruft-ism that we don't need anymore.

Replaced with DATABASE_URL (a connection string) or DB_USER/PASSWORD/HOST/PORT/DATABASE.