### PR TITLE
Borrow the __orm field for the __types hints.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -14,6 +14,7 @@ import {
   EntityFilter,
   EntityGraphQLFilter,
   EntityManager,
+  EntityOrmField,
   EnumGraphQLFilter,
   FilterOf,
   Flavor,
@@ -301,14 +302,14 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
     ${generateDefaultValidationRules(meta, configName)}
   
     export abstract class ${entityName}Codegen extends ${BaseEntity} {
-      readonly __types: {
+      readonly __orm!: ${EntityOrmField} & {
         filterType: ${entityName}Filter;
         gqlFilterType: ${entityName}GraphQLFilter;
         orderType: ${entityName}Order;
         optsType: ${entityName}Opts;
         optIdsType: ${entityName}IdsOpts;
         factoryOptsType: Parameters<typeof ${factoryMethod}>[1];
-      } = null!;
+      };
       ${[o2m, m2o, o2o, m2m, polymorphic]}
 
       constructor(em: ${EntityManager}, opts: ${entityName}Opts) {

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -8,6 +8,7 @@ import {
   EntityFilter,
   EntityGraphQLFilter,
   EntityManager,
+  EntityOrmField,
   EnumGraphQLFilter,
   FilterOf,
   Flavor,
@@ -145,14 +146,14 @@ authorConfig.addRule(newRequiredRule("createdAt"));
 authorConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class AuthorCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;
     optsType: AuthorOpts;
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
-  } = null!;
+  };
 
   readonly authors: Collection<Author, Author> = hasMany(authorMeta, "authors", "mentor", "mentor_id");
 

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -5,6 +5,7 @@ import {
   EntityFilter,
   EntityGraphQLFilter,
   EntityManager,
+  EntityOrmField,
   EnumGraphQLFilter,
   FilterOf,
   Flavor,
@@ -93,14 +94,14 @@ bookAdvanceConfig.addRule(newRequiredRule("book"));
 bookAdvanceConfig.addRule(newRequiredRule("publisher"));
 
 export abstract class BookAdvanceCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: BookAdvanceFilter;
     gqlFilterType: BookAdvanceGraphQLFilter;
     orderType: BookAdvanceOrder;
     optsType: BookAdvanceOpts;
     optIdsType: BookAdvanceIdsOpts;
     factoryOptsType: Parameters<typeof newBookAdvance>[1];
-  } = null!;
+  };
 
   readonly book: ManyToOneReference<BookAdvance, Book, never> = hasOne(bookMeta, "book", "advances");
 

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -6,6 +6,7 @@ import {
   EntityFilter,
   EntityGraphQLFilter,
   EntityManager,
+  EntityOrmField,
   FilterOf,
   Flavor,
   getEm,
@@ -117,14 +118,14 @@ bookConfig.addRule(newRequiredRule("updatedAt"));
 bookConfig.addRule(newRequiredRule("author"));
 
 export abstract class BookCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;
     optsType: BookOpts;
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
-  } = null!;
+  };
 
   readonly advances: Collection<Book, BookAdvance> = hasMany(bookAdvanceMeta, "advances", "book", "book_id");
 

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -7,6 +7,7 @@ import {
   EntityFilter,
   EntityGraphQLFilter,
   EntityManager,
+  EntityOrmField,
   FilterOf,
   Flavor,
   getEm,
@@ -94,14 +95,14 @@ bookReviewConfig.addRule(newRequiredRule("updatedAt"));
 bookReviewConfig.addRule(newRequiredRule("book"));
 
 export abstract class BookReviewCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: BookReviewFilter;
     gqlFilterType: BookReviewGraphQLFilter;
     orderType: BookReviewOrder;
     optsType: BookReviewOpts;
     optIdsType: BookReviewIdsOpts;
     factoryOptsType: Parameters<typeof newBookReview>[1];
-  } = null!;
+  };
 
   readonly book: ManyToOneReference<BookReview, Book, never> = hasOne(bookMeta, "book", "reviews");
 

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -7,6 +7,7 @@ import {
   EntityFilter,
   EntityGraphQLFilter,
   EntityManager,
+  EntityOrmField,
   Flavor,
   getEm,
   hasOnePolymorphic,
@@ -82,14 +83,14 @@ commentConfig.addRule(newRequiredRule("updatedAt"));
 commentConfig.addRule(newRequiredRule("parent"));
 
 export abstract class CommentCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: CommentFilter;
     gqlFilterType: CommentGraphQLFilter;
     orderType: CommentOrder;
     optsType: CommentOpts;
     optIdsType: CommentIdsOpts;
     factoryOptsType: Parameters<typeof newComment>[1];
-  } = null!;
+  };
 
   readonly parent: PolymorphicReference<Comment, CommentParent, never> = hasOnePolymorphic("parent");
 

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -3,6 +3,7 @@ import {
   Changes,
   ConfigApi,
   EntityManager,
+  EntityOrmField,
   Flavor,
   getEm,
   Lens,
@@ -58,14 +59,14 @@ criticConfig.addRule(newRequiredRule("createdAt"));
 criticConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class CriticCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: CriticFilter;
     gqlFilterType: CriticGraphQLFilter;
     orderType: CriticOrder;
     optsType: CriticOpts;
     optIdsType: CriticIdsOpts;
     factoryOptsType: Parameters<typeof newCritic>[1];
-  } = null!;
+  };
 
   constructor(em: EntityManager, opts: CriticOpts) {
     super(em, criticMeta, {}, opts);

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -5,6 +5,7 @@ import {
   EntityFilter,
   EntityGraphQLFilter,
   EntityManager,
+  EntityOrmField,
   EnumGraphQLFilter,
   FilterOf,
   Flavor,
@@ -105,14 +106,14 @@ imageConfig.addRule(newRequiredRule("updatedAt"));
 imageConfig.addRule(newRequiredRule("type"));
 
 export abstract class ImageCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: ImageFilter;
     gqlFilterType: ImageGraphQLFilter;
     orderType: ImageOrder;
     optsType: ImageOpts;
     optIdsType: ImageIdsOpts;
     factoryOptsType: Parameters<typeof newImage>[1];
-  } = null!;
+  };
 
   readonly author: ManyToOneReference<Image, Author, undefined> = hasOne(authorMeta, "author", "image");
 

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -4,6 +4,7 @@ import {
   Collection,
   ConfigApi,
   EntityManager,
+  EntityOrmField,
   EnumGraphQLFilter,
   Flavor,
   getEm,
@@ -109,14 +110,14 @@ publisherConfig.addRule(newRequiredRule("createdAt"));
 publisherConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class PublisherCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: PublisherFilter;
     gqlFilterType: PublisherGraphQLFilter;
     orderType: PublisherOrder;
     optsType: PublisherOpts;
     optIdsType: PublisherIdsOpts;
     factoryOptsType: Parameters<typeof newPublisher>[1];
-  } = null!;
+  };
 
   readonly authors: Collection<Publisher, Author> = hasMany(authorMeta, "authors", "publisher", "publisher_id");
 

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -4,6 +4,7 @@ import {
   Collection,
   ConfigApi,
   EntityManager,
+  EntityOrmField,
   Flavor,
   getEm,
   hasManyToMany,
@@ -63,14 +64,14 @@ tagConfig.addRule(newRequiredRule("createdAt"));
 tagConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class TagCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: TagFilter;
     gqlFilterType: TagGraphQLFilter;
     orderType: TagOrder;
     optsType: TagOpts;
     optIdsType: TagIdsOpts;
     factoryOptsType: Parameters<typeof newTag>[1];
-  } = null!;
+  };
 
   readonly books: Collection<Tag, Book> = hasManyToMany(
     "books_to_tags",

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -39,28 +39,28 @@ export interface EntityConstructor<T> {
 }
 
 /** Return the `FooOpts` type a given `Foo` entity constructor. */
-export type OptsOf<T> = T extends { __types: { optsType: infer O } } ? O : never;
+export type OptsOf<T> = T extends { __orm: { optsType: infer O } } ? O : never;
 
-export type OptIdsOf<T> = T extends { __types: { optIdsType: infer O } } ? O : never;
+export type OptIdsOf<T> = T extends { __orm: { optIdsType: infer O } } ? O : never;
 
 /** Return the `Foo` type for a given `Foo` entity constructor. */
 export type EntityOf<C> = C extends new (em: EntityManager, opts: any) => infer T ? T : never;
 
 /** Pulls the entity query type out of a given entity type T. */
-export type FilterOf<T> = T extends { __types: { filterType: infer Q } } ? Q : never;
+export type FilterOf<T> = T extends { __orm: { filterType: infer Q } } ? Q : never;
 
 /** Pulls the entity GraphQL query type out of a given entity type T. */
-export type GraphQLFilterOf<T> = T extends { __types: { gqlFilterType: infer Q } } ? Q : never;
+export type GraphQLFilterOf<T> = T extends { __orm: { gqlFilterType: infer Q } } ? Q : never;
 
 /** Pulls the entity order type out of a given entity type T. */
-export type OrderOf<T> = T extends { __types: { orderType: infer Q } } ? Q : never;
+export type OrderOf<T> = T extends { __orm: { orderType: infer Q } } ? Q : never;
 
 /**
  * Returns the opts of the entity's `newEntity` factory method, as exists in the actual file.
  *
  * This is because `FactoryOpts` is a set of defaults, but the user can customize it if they want.
  */
-export type ActualFactoryOpts<T> = T extends { __types: { factoryOptsType: infer Q } } ? Q : never;
+export type ActualFactoryOpts<T> = T extends { __orm: { factoryOptsType: infer Q } } ? Q : never;
 
 /** Pulls the entity's id type out of a given entity type T. */
 export type IdOf<T> = T extends { id: infer I | undefined } ? I : never;

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -4,6 +4,7 @@ import {
   Collection,
   ConfigApi,
   EntityManager,
+  EntityOrmField,
   Flavor,
   getEm,
   hasMany,
@@ -67,14 +68,14 @@ authorConfig.addRule(newRequiredRule("createdAt"));
 authorConfig.addRule(newRequiredRule("updatedAt"));
 
 export abstract class AuthorCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;
     optsType: AuthorOpts;
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
-  } = null!;
+  };
 
   readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id");
 

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -5,6 +5,7 @@ import {
   EntityFilter,
   EntityGraphQLFilter,
   EntityManager,
+  EntityOrmField,
   FilterOf,
   Flavor,
   getEm,
@@ -71,14 +72,14 @@ bookConfig.addRule(newRequiredRule("updatedAt"));
 bookConfig.addRule(newRequiredRule("author"));
 
 export abstract class BookCodegen extends BaseEntity {
-  readonly __types: {
+  readonly __orm!: EntityOrmField & {
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;
     optsType: BookOpts;
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
-  } = null!;
+  };
 
   readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
 


### PR DESCRIPTION
Pretty minor, but it avoids a throw-away `__types` field on each entity instance, which only existed for the type system to do inferred / type lookups.