### PR TITLE
feat: Add ManyToMany.includes.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -164,8 +164,14 @@ export class EntityManager<C = {}> {
     }
   }
 
+  /** Returns a read-only shallow copy of the currently-loaded entities. */
   get entities(): ReadonlyArray<Entity> {
     return [...this._entities];
+  }
+
+  /** Looks up `id` in the list of already-loaded entities. */
+  getEntity<T extends Entity>(id: IdOf<T>): T | undefined {
+    return this._entityIndex.get(id) as T | undefined;
   }
 
   public async find<T extends Entity>(type: EntityConstructor<T>, where: FilterOf<T>): Promise<T[]>;
@@ -401,6 +407,7 @@ export class EntityManager<C = {}> {
   }
 
   /** Returns an instance of `type` for the given `id`, resolving to an existing instance if in our Unit of Work. */
+  public async load<T>(id: IdOf<T>): Promise<T>;
   public async load(id: string): Promise<Entity>;
   public async load<T extends Entity>(type: EntityConstructor<T>, id: string): Promise<T>;
   public async load<T extends Entity, H extends LoadHint<T>>(

--- a/packages/orm/src/dataloaders/manyToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyDataLoader.ts
@@ -4,13 +4,18 @@ import { getEm, keyToString, ManyToManyCollection } from "../index";
 import { JoinRow } from "../relations/ManyToManyCollection";
 import { getOrSet } from "../utils";
 
+/** Batches m2m.load calls. */
 export function manyToManyDataLoader<T extends Entity, U extends Entity>(
   em: EntityManager,
   collection: ManyToManyCollection<T, U>,
 ) {
-  return getOrSet(em.loadLoaders, collection.joinTableName, () => {
-    return new DataLoader<string, Entity[]>((keys) => load(collection, keys));
-  });
+  // Note that we cache the dataloader on the joinTableName, and not
+  // which side of the relation the `collection` is coming from, so
+  // the `load` impl will have to handle keys that come from either
+  // side of the relation.
+  return getOrSet(em.loadLoaders, collection.joinTableName, () =>
+    new DataLoader<string, Entity[]>((keys) => load(collection, keys))
+  );
 }
 
 /**

--- a/packages/orm/src/dataloaders/manyToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyFindDataLoader.ts
@@ -1,0 +1,44 @@
+import DataLoader from "dataloader";
+import { Entity, EntityManager } from "../EntityManager";
+import { getEm, ManyToManyCollection, tagId } from "../index";
+import { getOrSet } from "../utils";
+
+/** Batches m2m.find/include calls (i.e. that don't fully load the m2m relation). */
+export function manyToManyFindDataLoader<T extends Entity, U extends Entity>(
+  em: EntityManager,
+  collection: ManyToManyCollection<T, U>,
+): DataLoader<string, boolean> {
+  return getOrSet(
+    em.loadLoaders,
+    `find-${collection.joinTableName}`,
+    () => new DataLoader<string, boolean>((keys) => load(collection, keys)),
+  );
+}
+
+async function load<T extends Entity, U extends Entity>(
+  collection: ManyToManyCollection<T, U>,
+  keys: ReadonlyArray<string>,
+): Promise<boolean[]> {
+  const { joinTableName } = collection;
+  const em = getEm(collection.entity);
+
+  const rows = await em.driver.findManyToMany(em, collection, keys);
+
+  const column1 = collection.columnName;
+  const column2 = collection.otherColumnName;
+  const meta1 = collection.meta;
+  const meta2 = collection.otherMeta;
+
+  // Because keys might come from either side of the m2m relationship, build
+  // a list of both `foo_id=2,bar_id=3` and `bar_id=3,foo_id=2` to make the
+  // final return value just a map of `Set.has`.
+  const found = new Set(
+    rows.flatMap((dbRow) => {
+      const a = `${column1}=${tagId(meta1, dbRow[column1] as number)}`;
+      const b = `${column2}=${tagId(meta2, dbRow[column2] as number)}`;
+      return [`${a},${b}`, `${b},${a}`];
+    }),
+  );
+
+  return keys.map((key) => found.has(key));
+}

--- a/packages/orm/src/dataloaders/oneToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyDataLoader.ts
@@ -1,5 +1,5 @@
 import DataLoader from "dataloader";
-import { Entity, EntityManager, getMetadata } from "../EntityManager";
+import { Entity, EntityManager } from "../EntityManager";
 import { assertIdsAreTagged, deTagIds, getEm, maybeResolveReferenceToId, OneToManyCollection } from "../index";
 import { getOrSet, groupBy } from "../utils";
 
@@ -8,8 +8,8 @@ export function oneToManyDataLoader<T extends Entity, U extends Entity>(
   collection: OneToManyCollection<T, U>,
 ): DataLoader<string, U[]> {
   // The metadata for the entity that contains the collection
-  const meta = getMetadata(collection.entity);
-  const loaderName = `${meta.tableName}.${collection.fieldName}`;
+  const { meta, fieldName } = collection;
+  const loaderName = `${meta.tableName}.${fieldName}`;
   return getOrSet(em.loadLoaders, loaderName, () => {
     return new DataLoader<string, U[]>(async (_keys) => {
       const { otherMeta } = collection;

--- a/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
@@ -1,0 +1,26 @@
+import DataLoader from "dataloader";
+import { Entity, EntityManager, IdOf } from "../EntityManager";
+import { getEm, OneToManyCollection } from "../index";
+import { getOrSet } from "../utils";
+
+/** Batches o2m.find/include calls (i.e. that don't fully load the o2m relation). */
+export function oneToManyFindDataLoader<T extends Entity, U extends Entity>(
+  em: EntityManager,
+  collection: OneToManyCollection<T, U>,
+): DataLoader<string, U | undefined> {
+  const { meta, fieldName } = collection;
+  const loaderName = `find-${meta.tableName}.${collection.fieldName}`;
+  return getOrSet(em.loadLoaders, loaderName, () => {
+    return new DataLoader<string, U | undefined>(async (keys) => {
+      const em = getEm(collection.entity);
+      const rows = await em.driver.findOneToMany(em, collection, keys);
+      const entities = rows.map((row) => em.hydrate(collection.otherMeta.cstr, row, { overwriteExisting: false }));
+      // Decode `id=a:1,book_id=b:2`
+      return keys.map((k) => {
+        const [key1] = k.split(",");
+        const [, id1] = key1.split("=");
+        return em.getEntity(id1 as IdOf<U>);
+      });
+    });
+  });
+}

--- a/packages/orm/src/drivers/driver.ts
+++ b/packages/orm/src/drivers/driver.ts
@@ -14,15 +14,32 @@ export interface Driver {
     untaggedIds: readonly string[],
   ): Promise<unknown[]>;
 
+  /** Loads a given m2m relation for potentially multiple entities. */
   loadManyToMany<T extends Entity, U extends Entity>(
     em: EntityManager,
     collection: ManyToManyCollection<T, U>,
+    // encoded tuples of `foo_id=2`, `bar_id=3`
+    keys: readonly string[],
+  ): Promise<JoinRow[]>;
+
+  /** Just finds presence in a m2m w/o loading the full relation. */
+  findManyToMany<T extends Entity, U extends Entity>(
+    em: EntityManager,
+    collection: ManyToManyCollection<T, U>,
+    // encoded tuples of `foo_id=2,bar_id=3`, `bar_id=4,foo_id=5`
     keys: readonly string[],
   ): Promise<JoinRow[]>;
 
   loadOneToMany<T extends Entity, U extends Entity>(
     em: EntityManager,
     collection: OneToManyCollection<T, U>,
+    untaggedIds: readonly string[],
+  ): Promise<unknown[]>;
+
+  findOneToMany<T extends Entity, U extends Entity>(
+    em: EntityManager,
+    collection: OneToManyCollection<T, U>,
+    // encoded tuples of `id=2,bar_id=3`
     untaggedIds: readonly string[],
   ): Promise<unknown[]>;
 

--- a/packages/orm/src/relations/Collection.ts
+++ b/packages/orm/src/relations/Collection.ts
@@ -8,7 +8,11 @@ import { Relation } from "./Relation";
 export interface Collection<T extends Entity, U extends Entity> extends Relation<T, U> {
   load(opts?: { withDeleted: boolean }): Promise<ReadonlyArray<U>>;
 
+  /** Looks up the specific `id` without fully loading the collection. */
   find(id: IdOf<U>): Promise<U | undefined>;
+
+  /** Looks up the specific `other` without fully loading the collection. */
+  includes(other: U): Promise<boolean>;
 
   add(other: U): void;
 

--- a/packages/orm/src/relations/CustomCollection.ts
+++ b/packages/orm/src/relations/CustomCollection.ts
@@ -104,6 +104,10 @@ export class CustomCollection<T extends Entity, U extends Entity>
     }
   }
 
+  async includes(other: U): Promise<boolean> {
+    throw new Error("Not implemented");
+  }
+
   add(other: U): void {
     ensureNewOrLoaded(this);
     const { add } = this.opts;


### PR DESCRIPTION
Fixes #244

This also re-implements this existing `Collection.find` to not trigger a full load of the collection.

My assumption is that we implemented that as a "most pragmatic / easiest impl", but I believe as we have more and more large collections, being strict / more precise about what `.find` does is better.