### PR TITLE
fix: Polish toMatchEntity.

### DIFF
--- a/packages/integration-tests/src/alignedAnsiStyleSerializer.ts
+++ b/packages/integration-tests/src/alignedAnsiStyleSerializer.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ansiRegex = require("ansi-regex");
+import style = require("ansi-styles");
+import type { NewPlugin } from "pretty-format";
+
+export const alignedAnsiStyleSerializer: NewPlugin = {
+  serialize(val: string): string {
+    // Return the string itself, not escaped nor enclosed in double quote marks.
+    return val.replace(ansiRegex(), (match) => {
+      switch (match) {
+        case style.inverse.open:
+          return "<i>";
+        case style.inverse.close:
+          return "</i>";
+
+        case style.bold.open:
+          return "<b>";
+        case style.dim.open:
+          return "<d>";
+        case style.green.open:
+          return "<g>";
+        case style.red.open:
+          return "<r>";
+        case style.yellow.open:
+          return "<y>";
+        case style.bgYellow.open:
+          return "<Y>";
+
+        case style.bold.close:
+        case style.dim.close:
+        case style.green.close:
+        case style.red.close:
+        case style.yellow.close:
+        case style.bgYellow.close:
+          return "</>";
+
+        default:
+          return match; // unexpected escape sequence
+      }
+    });
+  },
+  test(val: unknown): val is string {
+    return typeof val === "string";
+  },
+};

--- a/packages/integration-tests/src/toMatchEntity.test.ts
+++ b/packages/integration-tests/src/toMatchEntity.test.ts
@@ -1,5 +1,8 @@
+import { alignedAnsiStyleSerializer } from "@src/alignedAnsiStyleSerializer";
 import { newAuthor, newBook, newPublisher } from "@src/entities";
 import { newEntityManager } from "./setupDbTests";
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer as any);
 
 describe("toMatchEntity", () => {
   it("can match primitive fields", async () => {
@@ -24,6 +27,25 @@ describe("toMatchEntity", () => {
     await expect(b1).toMatchEntity({ author: a1 });
   });
 
+  it("can fail match reference with wrong entity", async () => {
+    const em = newEntityManager();
+    const a1 = newAuthor(em);
+    const a2 = newAuthor(em);
+    const b1 = newBook(em, { author: a1 });
+    await em.flush();
+    await expect(expect(b1).toMatchEntity({ author: a2 })).rejects.toThrowErrorMatchingInlineSnapshot(`
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "author": "a:2",</>
+<r>+   "author": "a:1",</>
+<d>  }</>
+`);
+  });
+
   it("can match collections", async () => {
     const em = newEntityManager();
     const a1 = newAuthor(em, { books: [{}, {}] });
@@ -41,5 +63,94 @@ describe("toMatchEntity", () => {
     await expect(a1).toMatchEntity({
       books: [b1, { title: "title" }],
     });
+  });
+
+  it("can fail with missing entity in collection", async () => {
+    const em = newEntityManager();
+    // Given an author with two books
+    const a1 = newAuthor(em, { books: [{}, {}] });
+    const b2 = a1.books.get[1];
+    await em.flush();
+    // Then it fails if we assert against only one
+    await expect(expect(a1).toMatchEntity({ books: [b2] })).rejects.toThrowErrorMatchingInlineSnapshot(`
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+
+<g>- Expected  - 0</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<d>    "books": Array [</>
+<r>+     "b:1",</>
+<d>      "b:2",</>
+<d>    ],</>
+<d>  }</>
+`);
+  });
+
+  it("can fail with extra entity in collection", async () => {
+    const em = newEntityManager();
+    // Given an author with one book
+    const a1 = newAuthor(em, { books: [{}] });
+    const b1 = a1.books.get[0];
+    // And an extra book
+    const b2 = newBook(em, { author: {} });
+    await em.flush();
+    // Then it fails if we include the extra book
+    await expect(expect(a1).toMatchEntity({ books: [b1, b2] })).rejects.toThrowErrorMatchingInlineSnapshot(`
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 0</>
+
+<d>  Object {</>
+<d>    "books": Array [</>
+<d>      "b:1",</>
+<g>-     "b:2",</>
+<d>    ],</>
+<d>  }</>
+`);
+  });
+
+  it("can fail with missing new entity in collection", async () => {
+    const em = newEntityManager();
+    // Given an author with two books
+    const a1 = newAuthor(em, { books: [{}, {}] });
+    const b2 = a1.books.get[1];
+    // And we don't flush
+    // Then it fails if we assert against only one
+    await expect(expect(a1).toMatchEntity({ books: [b2] })).rejects.toThrowErrorMatchingInlineSnapshot(`
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+
+<g>- Expected  - 0</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<d>    "books": Array [</>
+<r>+     "b#1",</>
+<d>      "b#2",</>
+<d>    ],</>
+<d>  }</>
+`);
+  });
+
+  it("is strongly typed", async () => {
+    const em = newEntityManager();
+    const p1 = newPublisher(em);
+    // @ts-expect-error
+    await expect(expect(p1).toMatchEntity({ name2: "name" })).rejects.toThrow();
+  });
+
+  it("is strongly typed within collections", async () => {
+    const em = newEntityManager();
+    const a1 = newAuthor(em);
+    // @ts-expect-error
+    await expect(expect(a1).toMatchEntity({ books: [{ title2: "name" }] })).rejects.toThrow();
+  });
+
+  it("is strongly typed within references", async () => {
+    const em = newEntityManager();
+    const b1 = newBook(em);
+    // @ts-expect-error
+    await expect(expect(b1).toMatchEntity({ author: { firstName2: "name" } })).rejects.toThrow();
   });
 });

--- a/packages/test-utils/jest.config.js
+++ b/packages/test-utils/jest.config.js
@@ -3,7 +3,6 @@ module.exports = {
   moduleNameMapper: {
     "^@src/(.*)": "<rootDir>/src/$1",
   },
-  // globalSetup: "<rootDir>/src/setupTestEnv.js",
   testMatch: ["<rootDir>/src/**/*.test.(ts|tsx)"],
   testEnvironment: "node",
   maxConcurrency: 1,


### PR DESCRIPTION
Fixes #256 . We already had `toMatchEntity` upstreamed, but this adds some tests/polish, and then will follow up with removing the internal copy.