### PR TITLE
feat: Loosen restrictions on timestamp columns.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,17 @@ jobs:
             docker-compose build db
             docker-compose up db-wait
       - run:
-          name: Run migrations
+          name: Run migrations & codegen
           command: |
             cd packages/integration-tests
             ./run.sh ../migration-utils/build/index.js
-            cd ../tests/uuid-ids
+            ./run.sh ../codegen/build/index.js
+            cd ../tests/schema-misc
+            yarn migrate
+            ./run.sh ../../codegen/build/index.js
+            cd ../uuid-ids
             ./run.sh ../../migration-utils/build/index.js
+            ./run.sh ../../codegen/build/index.js
       - run:
           name: Run integration-tests
           command: |
@@ -55,6 +60,14 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT_DIR: /tmp/reports/junit/
             JEST_JUNIT_OUTPUT_NAME: junit-uuid-ids.xml
+      - run:
+          name: Run schema-misc tests
+          command: |
+            cd packages/tests/schema-misc
+            yarn test --reporters=default --reporters=jest-junit
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: /tmp/reports/junit/
+            JEST_JUNIT_OUTPUT_NAME: junit-schema-misc.xml
       - store_test_results:
           path: /tmp/reports/junit/
       - store_artifacts:

--- a/docs/docs/features/fast-database-resets.md
+++ b/docs/docs/features/fast-database-resets.md
@@ -9,7 +9,7 @@ To reset the database between each unit test, Joist generates a `flush_database`
 await knex.select(knex.raw("flush_database()"));
 ```
 
-This is generated at the end of the `joist-migation-utils` set only if `ADD_FLUSH_DATABASE` environment variable is set, i.e. this function should never exist in your production database. It is only for local testing.
+This is generated at the end of the `joist-codegen`, which should only be invoked against local development databases, i.e. this function should never exist in your production database. It is only for local testing.
 
 ### What About Per-Test Transactions?
 

--- a/docs/docs/getting-started/adding-to-your-project.md
+++ b/docs/docs/getting-started/adding-to-your-project.md
@@ -47,7 +47,7 @@ If you do use `node-pg-migrate`, the `joist-migration-utils` package has some he
 ./run.sh joist-migration-utils
 ```
 
-This will apply any `node-pg-migrate` migrations located in your `./migrations/` directory, and then, if `ADD_FLUSH_DATABASE` is set, add the `flush_database()` function for your tests to use.
+This will apply any `node-pg-migrate` migrations located in your `./migrations/` directory.
 
 Note that usually `joist-migration-utils` / your migration library of choice is run first, i.e. a flow would be:
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "packages/orm",
     "packages/utils",
     "packages/test-utils",
-    "packages/tests/uuid-ids"
+    "packages/tests/uuid-ids",
+    "packages/tests/schema-misc"
   ],
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",

--- a/packages/codegen/src/generateFlushFunction.ts
+++ b/packages/codegen/src/generateFlushFunction.ts
@@ -1,0 +1,30 @@
+import { Client } from "pg";
+import { Db } from "pg-structure";
+import { Config } from "./config";
+import { isEntityTable, isJoinTable } from "./utils";
+
+/** Creates a `flush_database` stored procedure to truncate all of the tables between tests. */
+export async function createFlushFunction(db: Db, client: Client, config: Config): Promise<void> {
+  await client.query(generateFlushFunction(config, db));
+}
+
+function generateFlushFunction(config: Config, db: Db): string {
+  const tables = db.tables.filter((t) => isEntityTable(config, t) || isJoinTable(config, t)).map((t) => t.name);
+  // Note that, for whatever reason, doing DELETEs + ALTER SEQUENCEs is dramatically faster than TRUNCATEs.
+  // On even a 40-table schema, TRUNCATEs (either 1 per table or even a single TRUNCATE with all tables) takes
+  // 100s of milliseconds, where as DELETEs takes single-digit milliseconds and DELETEs + ALTER SEQUENCEs is
+  // 10s of milliseconds.
+  //
+  // One cute idea would be to use a single sequence for all tables when running locally. That would
+  // mean our flush_database function could reset a single sequence. Plus it would reduce bugs where
+  // something "works" but only b/c in the test database, all entities have id = 1.
+  const statements = tables
+    .map((t) => `DELETE FROM "${t}"; ALTER SEQUENCE IF EXISTS "${t}_id_seq" RESTART WITH 1 INCREMENT BY 1;`)
+    .join("\n");
+  return `CREATE OR REPLACE FUNCTION flush_database() RETURNS void AS $$
+    BEGIN
+    ${statements}
+    END;
+   $$ LANGUAGE
+    'plpgsql'`;
+}

--- a/packages/codegen/src/generateMetadataFile.ts
+++ b/packages/codegen/src/generateMetadataFile.ts
@@ -1,3 +1,4 @@
+import { DbMetadata } from "index";
 import { code, Code, imp } from "ts-poet";
 import { Config } from "./config";
 import { EntityDbMetadata } from "./EntityDbMetadata";
@@ -11,11 +12,12 @@ import {
   PrimitiveSerde,
   SuperstructSerde,
 } from "./symbols";
+import { q } from "./utils";
 
-export function generateMetadataFile(config: Config, dbMetadata: EntityDbMetadata): Code {
-  const { entity } = dbMetadata;
+export function generateMetadataFile(config: Config, dbMeta: DbMetadata, meta: EntityDbMetadata): Code {
+  const { entity, createdAt, updatedAt } = meta;
 
-  const fields = generateFields(config, dbMetadata);
+  const fields = generateFields(config, meta);
 
   Object.values(fields).forEach((code) => code.asOneline());
 
@@ -23,10 +25,11 @@ export function generateMetadataFile(config: Config, dbMetadata: EntityDbMetadat
     export const ${entity.metaName}: ${EntityMetadata}<${entity.type}> = {
       cstr: ${entity.type},
       type: "${entity.name}",
-      idType: "${dbMetadata.idDbType}",
-      tagName: "${dbMetadata.tagName}",
-      tableName: "${dbMetadata.tableName}",
+      idType: "${meta.idDbType}",
+      tagName: "${meta.tagName}",
+      tableName: "${meta.tableName}",
       fields: ${fields},
+      timestampFields: { createdAt: ${q(createdAt?.fieldName)}, updatedAt: ${q(updatedAt?.fieldName)} },
       config: ${entity.configConst},
       factory: ${imp(`new${entity.name}@./entities`)},
     };

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -2,24 +2,48 @@ import { pascalCase } from "change-case";
 import isPlainObject from "is-plain-object";
 import { Table } from "pg-structure";
 import pluralize from "pluralize";
-import { Config } from "./config";
+import { Config, getTimestampConfig } from "./config";
 import { DatabaseColumnType, PrimitiveTypescriptType } from "./EntityDbMetadata";
 
 export function assertNever(x: never): never {
   throw new Error("Unexpected object: " + x);
 }
 
-export function isEntityTable(t: Table): boolean {
+export function isEntityTable(config: Config, t: Table): boolean {
+  if (isIgnored(config, t) || isJoinTable(config, t)) {
+    return false;
+  }
+
+  // Depending on the config settings, we may/may not require the presence of timestamp
+  // fields to determine whether a table is an entity.
   const columnNames = t.columns.map((c) => c.name);
-  return includesAllOf(columnNames, ["id", "created_at", "updated_at"]);
+  const { updatedAtConf, createdAtConf } = getTimestampConfig(config);
+  const hasCreatedAt = createdAtConf.names.some((c) => columnNames.includes(c));
+  const hasUpdatedAt = updatedAtConf.names.some((c) => columnNames.includes(c));
+
+  // If we have no timestamp columns, but do have `name` and `code`, we're probably an enum.
+  const idMatch = columnNames.includes("id");
+  if (idMatch && !hasCreatedAt && !hasUpdatedAt) {
+    if (["name", "code"].every((c) => columnNames.includes(c))) {
+      return false;
+    }
+  }
+
+  return idMatch && (hasCreatedAt || createdAtConf.optional) && (hasUpdatedAt || updatedAtConf.optional);
 }
 
-export function isEnumTable(t: Table): boolean {
+export function isEnumTable(config: Config, t: Table): boolean {
+  if (isIgnored(config, t)) {
+    return false;
+  }
   const columnNames = t.columns.map((c) => c.name);
-  return includesAllOf(columnNames, ["id", "code", "name"]) && !isEntityTable(t);
+  return ["id", "code", "name"].every((c) => columnNames.includes(c)) && !isEntityTable(config, t);
 }
 
-export function isJoinTable(t: Table): boolean {
+export function isJoinTable(config: Config, t: Table): boolean {
+  if (isIgnored(config, t)) {
+    return false;
+  }
   const { columns } = t;
   const hasOnePk = columns.filter((c) => c.isPrimaryKey).length === 1;
   const hasTwoFks = columns.filter((c) => c.isForeignKey).length === 2;
@@ -27,10 +51,6 @@ export function isJoinTable(t: Table): boolean {
   const hasFourColumnsOneIsCreatedAt =
     columns.length === 4 && columns.filter((c) => c.name === "created_at").length === 1;
   return hasOnePk && hasTwoFks && (hasThreeColumns || hasFourColumnsOneIsCreatedAt);
-}
-
-function includesAllOf(set: string[], subset: string[]): boolean {
-  return subset.find((e) => !set.includes(e)) === undefined;
 }
 
 /** Converts `projects` to `Project`. */
@@ -61,6 +81,7 @@ export function mapSimpleDbTypeToTypescriptType(dbType: DatabaseColumnType): Pri
     case "uuid":
       return "string";
     case "timestamp with time zone":
+    case "timestamp without time zone":
     case "date":
       return "Date";
     case "jsonb":
@@ -95,4 +116,12 @@ export function sortKeys<T extends object>(o: T): T {
       acc[key as keyof T] = newValue as any;
       return acc;
     }, {} as any as T);
+}
+
+export function q(s: string | undefined): string | undefined {
+  return s === undefined ? undefined : `"${s}"`;
+}
+
+function isIgnored(config: Config, t: Table): boolean {
+  return (config.ignoredTables || ["migrations", "pgmigrations"]).includes(t.name);
 }

--- a/packages/graphql-codegen/src/generateGraphqlSchemaFiles.test.ts
+++ b/packages/graphql-codegen/src/generateGraphqlSchemaFiles.test.ts
@@ -371,6 +371,8 @@ function newEntityMetadata(name: string, opts: Partial<EntityDbMetadata> = {}): 
     polymorphics: [],
     tableName: snakeCase(plural(name)),
     tagName: name,
+    updatedAt: undefined,
+    createdAt: undefined,
     ...opts,
   };
 }

--- a/packages/integration-tests/db.dockerfile
+++ b/packages/integration-tests/db.dockerfile
@@ -10,8 +10,10 @@ RUN echo "#!/bin/bash" > /init.sh && \
   echo "  CREATE USER ${APP_USERNAME} PASSWORD '${APP_PASSWORD}';" >> /init.sh && \
   echo "  CREATE DATABASE ${APP_DBNAME};" >> /init.sh && \
   echo "  CREATE DATABASE uuid_ids;" >> /init.sh && \
+  echo "  CREATE DATABASE schema_misc;" >> /init.sh && \
   echo "  GRANT ALL PRIVILEGES ON DATABASE ${APP_DBNAME} TO ${APP_USERNAME};" >> /init.sh && \
   echo "  GRANT ALL PRIVILEGES ON DATABASE uuid_ids TO ${APP_USERNAME};" >> /init.sh && \
+  echo "  GRANT ALL PRIVILEGES ON DATABASE schema_misc TO ${APP_USERNAME};" >> /init.sh && \
   echo "EOSQL" >> /init.sh && \
   chmod u+x /init.sh && \
   mv /init.sh /docker-entrypoint-initdb.d/
@@ -26,6 +28,9 @@ RUN echo "#!/bin/bash" > /reset.sh && \
   echo "  DROP DATABASE IF EXISTS uuid_ids;" >> /reset.sh && \
   echo "  CREATE DATABASE uuid_ids;" >> /reset.sh && \
   echo "  GRANT ALL PRIVILEGES ON DATABASE uuid_ids TO ${APP_USERNAME};" >> /reset.sh && \
+  echo "  DROP DATABASE IF EXISTS schema_misc;" >> /reset.sh && \
+  echo "  CREATE DATABASE schema_misc;" >> /reset.sh && \
+  echo "  GRANT ALL PRIVILEGES ON DATABASE schema_misc TO ${APP_USERNAME};" >> /reset.sh && \
   echo "EOSQL" >> /reset.sh && \
   chmod u+x /reset.sh
 

--- a/packages/integration-tests/local.env
+++ b/packages/integration-tests/local.env
@@ -1,2 +1,1 @@
 DATABASE_URL=postgres://joist:local@localhost:5435/joist
-ADD_FLUSH_DATABASE=true

--- a/packages/integration-tests/src/ReactiveHints.test.ts
+++ b/packages/integration-tests/src/ReactiveHints.test.ts
@@ -1,0 +1,8 @@
+describe("ReactiveHints", () => {
+  it("can type-check", () => {
+    // author hint that reruns on book review changes
+    const hint = {
+      "book:rx": { "reviews:rx": ["title:rx"] },
+    };
+  });
+});

--- a/packages/integration-tests/src/entities/metadata.ts
+++ b/packages/integration-tests/src/entities/metadata.ts
@@ -37,6 +37,7 @@ export const authorMeta: EntityMetadata<Author> = {
     tags: { kind: "m2m", fieldName: "tags", fieldIdName: "tagIds", required: false, otherMetadata: () => tagMeta, otherFieldName: "authors", serde: undefined },
     image: { kind: "o2o", fieldName: "image", fieldIdName: "imageId", required: false, otherMetadata: () => imageMeta, otherFieldName: "author", serde: undefined },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: authorConfig,
   factory: newAuthor,
 };
@@ -62,6 +63,7 @@ export const bookMeta: EntityMetadata<Book> = {
     tags: { kind: "m2m", fieldName: "tags", fieldIdName: "tagIds", required: false, otherMetadata: () => tagMeta, otherFieldName: "books", serde: undefined },
     image: { kind: "o2o", fieldName: "image", fieldIdName: "imageId", required: false, otherMetadata: () => imageMeta, otherFieldName: "book", serde: undefined },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: bookConfig,
   factory: newBook,
 };
@@ -82,6 +84,7 @@ export const bookAdvanceMeta: EntityMetadata<BookAdvance> = {
     book: { kind: "m2o", fieldName: "book", fieldIdName: "bookId", required: true, otherMetadata: () => bookMeta, otherFieldName: "advances", serde: new KeySerde("b", "book", "book_id", "int") },
     publisher: { kind: "m2o", fieldName: "publisher", fieldIdName: "publisherId", required: true, otherMetadata: () => publisherMeta, otherFieldName: "bookAdvances", serde: new KeySerde("p", "publisher", "publisher_id", "int") },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: bookAdvanceConfig,
   factory: newBookAdvance,
 };
@@ -103,6 +106,7 @@ export const bookReviewMeta: EntityMetadata<BookReview> = {
     book: { kind: "m2o", fieldName: "book", fieldIdName: "bookId", required: true, otherMetadata: () => bookMeta, otherFieldName: "reviews", serde: new KeySerde("b", "book", "book_id", "int") },
     comment: { kind: "o2o", fieldName: "comment", fieldIdName: "commentId", required: false, otherMetadata: () => commentMeta, otherFieldName: "parent", serde: undefined },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: bookReviewConfig,
   factory: newBookReview,
 };
@@ -132,6 +136,7 @@ export const commentMeta: EntityMetadata<Comment> = {
       serde: new PolymorphicKeySerde(() => commentMeta, "parent"),
     },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: commentConfig,
   factory: newComment,
 };
@@ -151,6 +156,7 @@ export const criticMeta: EntityMetadata<Critic> = {
     updatedAt: { kind: "primitive", fieldName: "updatedAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("updatedAt", "updated_at", "timestamp with time zone") },
     criticColumn: { kind: "o2o", fieldName: "criticColumn", fieldIdName: "criticColumnId", required: false, otherMetadata: () => criticColumnMeta, otherFieldName: "critic", serde: undefined },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: criticConfig,
   factory: newCritic,
 };
@@ -170,6 +176,7 @@ export const criticColumnMeta: EntityMetadata<CriticColumn> = {
     updatedAt: { kind: "primitive", fieldName: "updatedAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("updatedAt", "updated_at", "timestamp with time zone") },
     critic: { kind: "m2o", fieldName: "critic", fieldIdName: "criticId", required: true, otherMetadata: () => criticMeta, otherFieldName: "criticColumn", serde: new KeySerde("c", "critic", "critic_id", "int") },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: criticColumnConfig,
   factory: newCriticColumn,
 };
@@ -192,6 +199,7 @@ export const imageMeta: EntityMetadata<Image> = {
     book: { kind: "m2o", fieldName: "book", fieldIdName: "bookId", required: false, otherMetadata: () => bookMeta, otherFieldName: "image", serde: new KeySerde("b", "book", "book_id", "int") },
     publisher: { kind: "m2o", fieldName: "publisher", fieldIdName: "publisherId", required: false, otherMetadata: () => publisherMeta, otherFieldName: "images", serde: new KeySerde("p", "publisher", "publisher_id", "int") },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: imageConfig,
   factory: newImage,
 };
@@ -219,6 +227,7 @@ export const publisherMeta: EntityMetadata<Publisher> = {
     bookAdvances: { kind: "o2m", fieldName: "bookAdvances", fieldIdName: "bookAdvanceIds", required: false, otherMetadata: () => bookAdvanceMeta, otherFieldName: "publisher", serde: undefined },
     images: { kind: "o2m", fieldName: "images", fieldIdName: "imageIds", required: false, otherMetadata: () => imageMeta, otherFieldName: "publisher", serde: undefined },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: publisherConfig,
   factory: newPublisher,
 };
@@ -239,6 +248,7 @@ export const tagMeta: EntityMetadata<Tag> = {
     publishers: { kind: "lo2m", fieldName: "publishers", fieldIdName: "publisherIds", required: false, otherMetadata: () => publisherMeta, otherFieldName: "tag", serde: undefined },
     books: { kind: "m2m", fieldName: "books", fieldIdName: "bookIds", required: false, otherMetadata: () => bookMeta, otherFieldName: "tags", serde: undefined },
   },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
   config: tagConfig,
   factory: newTag,
 };

--- a/packages/migration-utils/src/index.ts
+++ b/packages/migration-utils/src/index.ts
@@ -1,14 +1,26 @@
+import { newPgConnectionConfig } from "joist-utils";
+import { Client } from "pg";
 import { runMigrationsIfNeeded } from "./migrate";
 
 export * from "./migrate";
 export * from "./utils";
+
+async function main(): Promise<void> {
+  const client = new Client(newPgConnectionConfig());
+  await client.connect();
+  try {
+    await runMigrationsIfNeeded(client, "./migrations");
+  } finally {
+    await client.end();
+  }
+}
 
 // If we're being run locally.
 if (require.main === module) {
   if (Object.fromEntries === undefined) {
     throw new Error("Joist requires Node v12.4.0+");
   }
-  runMigrationsIfNeeded("./migrations").catch((err) => {
+  main().catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/packages/migration-utils/src/migrate.ts
+++ b/packages/migration-utils/src/migrate.ts
@@ -1,76 +1,16 @@
-import { newPgConnectionConfig } from "joist-utils";
 import pgMigrate from "node-pg-migrate";
 import { Client } from "pg";
-import pgStructure, { Db, Table } from "pg-structure";
 
 const productionDirectory = "/home/node/app/migrations";
 
-export async function runMigrationsIfNeeded(dir: string = productionDirectory): Promise<void> {
-  const client = new Client(newPgConnectionConfig());
-  await client.connect();
-
-  try {
-    await pgMigrate({
-      dbClient: client,
-      migrationsTable: "migrations",
-      dir,
-      count: undefined as any as number,
-      direction: "up",
-      ignorePattern: "(.*.d.ts)|(.*utils.[jt]s)|(migrate.[jt]s)|(migrate.test.[jt]s)",
-      decamelize: true,
-    });
-
-    const db = await pgStructure(newPgConnectionConfig());
-
-    if (process.env.ADD_FLUSH_DATABASE === "true") {
-      console.log("Creating flush_database() function");
-      await createFlushDbFunction(db, client);
-    }
-  } finally {
-    await client.end();
-  }
-}
-/** Creates a `flush_database` stored procedure to truncate all of the tables between tests. */
-async function createFlushDbFunction(db: Db, client: Client): Promise<void> {
-  await client.query(generateFlushFunction(db));
-}
-
-function generateFlushFunction(db: Db): string {
-  const tables = db.tables.filter((t) => isEntityTable(t) || isJoinTable(t)).map((t) => t.name);
-  // Note that, for whatever reason, doing DELETEs + ALTER SEQUENCEs is dramatically faster than TRUNCATEs.
-  // On even a 40-table schema, TRUNCATEs (either 1 per table or even a single TRUNCATE with all tables) takes
-  // 100s of milliseconds, where as DELETEs takes single-digit milliseconds and DELETEs + ALTER SEQUENCEs is
-  // 10s of milliseconds.
-  //
-  // One cute idea would be to use a single sequence for all tables when running locally. That would
-  // mean our flush_database function could reset a single sequence. Plus it would reduce bugs where
-  // something "works" but only b/c in the test database, all entities have id = 1.
-  const statements = tables
-    .map((t) => `DELETE FROM "${t}"; ALTER SEQUENCE IF EXISTS "${t}_id_seq" RESTART WITH 1 INCREMENT BY 1;`)
-    .join("\n");
-  return `CREATE OR REPLACE FUNCTION flush_database() RETURNS void AS $$
-    BEGIN
-    ${statements}
-    END;
-   $$ LANGUAGE
-    'plpgsql'`;
-}
-
-export function isEntityTable(t: Table): boolean {
-  const columnNames = t.columns.map((c) => c.name);
-  return includesAllOf(columnNames, ["id", "created_at", "updated_at"]);
-}
-
-export function isJoinTable(t: Table): boolean {
-  const { columns } = t;
-  const hasOnePk = columns.filter((c) => c.isPrimaryKey).length === 1;
-  const hasTwoFks = columns.filter((c) => c.isForeignKey).length === 2;
-  const hasThreeColumns = columns.length === 3;
-  const hasFourColumnsOneIsCreatedAt =
-    columns.length === 4 && columns.filter((c) => c.name === "created_at").length === 1;
-  return hasOnePk && hasTwoFks && (hasThreeColumns || hasFourColumnsOneIsCreatedAt);
-}
-
-function includesAllOf(set: string[], subset: string[]): boolean {
-  return subset.find((e) => !set.includes(e)) === undefined;
+export async function runMigrationsIfNeeded(client: Client, dir: string = productionDirectory): Promise<void> {
+  await pgMigrate({
+    dbClient: client,
+    migrationsTable: "migrations",
+    dir,
+    count: undefined as any as number,
+    direction: "up",
+    ignorePattern: "(.*.d.ts)|(.*utils.[jt]s)|(migrate.[jt]s)|(migrate.test.[jt]s)",
+    decamelize: true,
+  });
 }

--- a/packages/tests/schema-misc/Makefile
+++ b/packages/tests/schema-misc/Makefile
@@ -1,0 +1,13 @@
+.PHONY: db psql test
+
+db:
+	docker-compose -f ../../integration-tests/docker-compose.yml up db-wait
+	docker-compose -f ../../integration-tests/docker-compose.yml exec db ./reset.sh
+	npm run migrate
+	npm run codegen
+
+psql:
+	docker-compose -f ../../integration-tests/docker-compose.yml exec db ./console.sh
+
+test:
+	npm run test

--- a/packages/tests/schema-misc/jest.config.js
+++ b/packages/tests/schema-misc/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  transform: { "^.+\\.tsx?$": "@swc/jest" },
+  moduleNameMapper: {
+    "^@src/(.*)": "<rootDir>/src/$1",
+    "^src/(.*)": "<rootDir>/src/$1",
+  },
+  setupFilesAfterEnv: ["<rootDir>/src/setupDbTests.ts"],
+  testMatch: ["<rootDir>/src/**/*.test.(ts|tsx)"],
+  testEnvironment: "node",
+  maxConcurrency: 1,
+  resetMocks: true,
+};

--- a/packages/tests/schema-misc/joist-codegen.json
+++ b/packages/tests/schema-misc/joist-codegen.json
@@ -1,0 +1,11 @@
+{
+  "codegenPlugins": [],
+  "contextType": "Context@src/context",
+  "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
+  "entitiesDirectory": "./src/entities",
+  "ignoredTables": ["pgmigrations"],
+  "timestampColumns": {
+    "createdAt": { "names": ["created_at", "createdAt"], "optional": true },
+    "updatedAt": { "names": ["updated_at", "updatedAt"], "optional": true }
+  }
+}

--- a/packages/tests/schema-misc/local.env
+++ b/packages/tests/schema-misc/local.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://joist:local@localhost:5435/schema_misc

--- a/packages/tests/schema-misc/migrations/1580658856631_author.js
+++ b/packages/tests/schema-misc/migrations/1580658856631_author.js
@@ -1,0 +1,17 @@
+exports.up = (b) => {
+  // Create a table with createAt and updatedAt
+  b.createTable("authors", {
+    id: { type: "id", primaryKey: true },
+    firstName: { type: "varchar(255)", notNull: true },
+    lastName: { type: "varchar(255)", notNull: false },
+    createdAt: { type: "timestamptz", notNull: true },
+    updatedAt: { type: "timestamptz", notNull: true },
+  });
+
+  // Create a single table with no created/updated
+  b.createTable("book", {
+    id: { type: "id", primaryKey: true },
+    title: { type: "varchar(255)", notNull: true },
+    authorId: { type: "int", references: "authors", notNull: true, deferrable: true, deferred: true },
+  });
+};

--- a/packages/tests/schema-misc/package.json
+++ b/packages/tests/schema-misc/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "joist-tests-schema-misc",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stephenh/joist-ts.git",
+    "directory": "packages/tests/schema-misc"
+  },
+  "scripts": {
+    "migrate": "DATABASE_URL=postgres://joist:local@localhost:5435/schema_misc node-pg-migrate up --decamelize=false --migrations-dir=./migrations",
+    "test": "jest --runInBand --detectOpenHandles --logHeapUsage",
+    "format": "prettier --write '{schema,migrations,src}/**/*.{ts,js,tsx,jsx,graphql}'",
+    "codegen": "./run.sh ../../codegen"
+  },
+  "dependencies": {
+    "joist-orm": "workspace:*",
+    "node-pg-migrate": "^5.0.0"
+  },
+  "devDependencies": {
+    "@swc/core": "^1.2.124",
+    "@swc/jest": "^0.2.16",
+    "@types/jest": "^26.0.24",
+    "@types/node": "^16.4.10",
+    "dotenv": "^8.2.0",
+    "jest": "^27.0.6",
+    "jest-junit": "^12.2.0",
+    "joist-codegen": "workspace:*",
+    "joist-migration-utils": "workspace:*",
+    "joist-test-utils": "workspace:*",
+    "prettier": "^2.5.1",
+    "prettier-plugin-organize-imports": "^2.3.4",
+    "superstruct": "^0.15.2",
+    "ts-node": "^10.1.0",
+    "tsconfig-paths": "^3.10.1",
+    "typescript": "^4.5.2"
+  }
+}

--- a/packages/tests/schema-misc/run.sh
+++ b/packages/tests/schema-misc/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export $(grep -v '^#' local.env | sed 's/\"/\\\"/g' | xargs)
+
+../../.././node_modules/.bin/ts-node "$@"

--- a/packages/tests/schema-misc/src/context.ts
+++ b/packages/tests/schema-misc/src/context.ts
@@ -1,0 +1,7 @@
+import { EntityManager } from "joist-orm";
+import { Knex } from "knex";
+
+export interface Context {
+  knex: Knex;
+  em: EntityManager;
+}

--- a/packages/tests/schema-misc/src/entities/Author.factories.ts
+++ b/packages/tests/schema-misc/src/entities/Author.factories.ts
@@ -1,0 +1,7 @@
+import { FactoryOpts, New, newTestInstance } from "joist-orm";
+import { EntityManager } from "src/entities";
+import { Author } from "./entities";
+
+export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): New<Author> {
+  return newTestInstance(em, Author, opts);
+}

--- a/packages/tests/schema-misc/src/entities/Author.test.ts
+++ b/packages/tests/schema-misc/src/entities/Author.test.ts
@@ -1,0 +1,24 @@
+import { newAuthor } from "@src/entities";
+import { newEntityManager, queries } from "@src/setupDbTests";
+
+describe("Author", () => {
+  it.withCtx("can save", async () => {
+    const em = newEntityManager();
+    // Given we create an author
+    const a = newAuthor(em);
+    // Then we auto-set the createdAt and updatedAt
+    expect(a.createdAt).toBeDefined();
+    expect(a.updatedAt).toBeDefined();
+    // And when we flush
+    await em.flush();
+    // Then we generate an insert
+    expect(queries).toMatchInlineSnapshot(`
+Array [
+  "BEGIN;",
+  "select nextval('authors_id_seq') from generate_series(1, 1)",
+  "INSERT INTO authors (\\"id\\", \\"firstName\\", \\"lastName\\", \\"createdAt\\", \\"updatedAt\\") VALUES ($1, $2, $3, $4, $5)",
+  "COMMIT;",
+]
+`);
+  });
+});

--- a/packages/tests/schema-misc/src/entities/Author.ts
+++ b/packages/tests/schema-misc/src/entities/Author.ts
@@ -1,0 +1,6 @@
+import { AuthorCodegen, authorConfig as config } from "./entities";
+
+export class Author extends AuthorCodegen {}
+
+// remove once you have actual rules/hooks
+config.placeholder();

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -1,0 +1,140 @@
+import {
+  BaseEntity,
+  Changes,
+  Collection,
+  ConfigApi,
+  EntityOrmField,
+  Flavor,
+  hasMany,
+  isLoaded,
+  Lens,
+  Loaded,
+  LoadHint,
+  loadLens,
+  newChangesProxy,
+  newRequiredRule,
+  OptsOf,
+  OrderBy,
+  PartialOrNull,
+  setField,
+  setOpts,
+  ValueFilter,
+  ValueGraphQLFilter,
+} from "joist-orm";
+import { Context } from "src/context";
+import { EntityManager } from "src/entities";
+import { Author, authorMeta, Book, BookId, bookMeta, newAuthor } from "./entities";
+
+export type AuthorId = Flavor<string, "Author">;
+
+export interface AuthorOpts {
+  firstName: string;
+  lastName?: string | null;
+  books?: Book[];
+}
+
+export interface AuthorIdsOpts {
+  bookIds?: BookId[] | null;
+}
+
+export interface AuthorFilter {
+  id?: ValueFilter<AuthorId, never>;
+  firstName?: ValueFilter<string, never>;
+  lastName?: ValueFilter<string, null | undefined>;
+  createdAt?: ValueFilter<Date, never>;
+  updatedAt?: ValueFilter<Date, never>;
+}
+
+export interface AuthorGraphQLFilter {
+  id?: ValueGraphQLFilter<AuthorId>;
+  firstName?: ValueGraphQLFilter<string>;
+  lastName?: ValueGraphQLFilter<string>;
+  createdAt?: ValueGraphQLFilter<Date>;
+  updatedAt?: ValueGraphQLFilter<Date>;
+}
+
+export interface AuthorOrder {
+  id?: OrderBy;
+  firstName?: OrderBy;
+  lastName?: OrderBy;
+  createdAt?: OrderBy;
+  updatedAt?: OrderBy;
+}
+
+export const authorConfig = new ConfigApi<Author, Context>();
+
+authorConfig.addRule(newRequiredRule("firstName"));
+authorConfig.addRule(newRequiredRule("createdAt"));
+authorConfig.addRule(newRequiredRule("updatedAt"));
+
+export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
+  static defaultValues: object = {};
+
+  readonly __orm!: EntityOrmField & {
+    filterType: AuthorFilter;
+    gqlFilterType: AuthorGraphQLFilter;
+    orderType: AuthorOrder;
+    optsType: AuthorOpts;
+    optIdsType: AuthorIdsOpts;
+    factoryOptsType: Parameters<typeof newAuthor>[1];
+  };
+
+  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "authorId", "authorId");
+
+  constructor(em: EntityManager, opts: AuthorOpts) {
+    super(em, authorMeta, AuthorCodegen.defaultValues, opts);
+    setOpts(this as any as Author, opts, { calledFromConstructor: true });
+  }
+
+  get id(): AuthorId | undefined {
+    return this.__orm.data["id"];
+  }
+
+  get firstName(): string {
+    return this.__orm.data["firstName"];
+  }
+
+  set firstName(firstName: string) {
+    setField(this, "firstName", firstName);
+  }
+
+  get lastName(): string | undefined {
+    return this.__orm.data["lastName"];
+  }
+
+  set lastName(lastName: string | undefined) {
+    setField(this, "lastName", lastName);
+  }
+
+  get createdAt(): Date {
+    return this.__orm.data["createdAt"];
+  }
+
+  get updatedAt(): Date {
+    return this.__orm.data["updatedAt"];
+  }
+
+  set(opts: Partial<AuthorOpts>): void {
+    setOpts(this as any as Author, opts);
+  }
+
+  setPartial(opts: PartialOrNull<AuthorOpts>): void {
+    setOpts(this as any as Author, opts as OptsOf<Author>, { partial: true });
+  }
+
+  get changes(): Changes<Author> {
+    return newChangesProxy(this as any as Author);
+  }
+
+  async load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>): Promise<V> {
+    return loadLens(this as any as Author, fn);
+  }
+
+  async populate<H extends LoadHint<Author>>(hint: H): Promise<Loaded<Author, H>> {
+    return this.em.populate(this as any as Author, hint);
+  }
+
+  isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {
+    return isLoaded(this as any as Author, hint);
+  }
+}

--- a/packages/tests/schema-misc/src/entities/Book.factories.ts
+++ b/packages/tests/schema-misc/src/entities/Book.factories.ts
@@ -1,0 +1,7 @@
+import { FactoryOpts, New, newTestInstance } from "joist-orm";
+import { EntityManager } from "src/entities";
+import { Book } from "./entities";
+
+export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): New<Book> {
+  return newTestInstance(em, Book, opts);
+}

--- a/packages/tests/schema-misc/src/entities/Book.test.ts
+++ b/packages/tests/schema-misc/src/entities/Book.test.ts
@@ -1,0 +1,42 @@
+import { newBook } from "@src/entities";
+import { newEntityManager, queries } from "@src/setupDbTests";
+
+describe("Book", () => {
+  it.withCtx("can save", async () => {
+    const em = newEntityManager();
+    // Given we make a book
+    const b = newBook(em);
+    // Then we did not set any updatedAt/createdAt values
+    expect(b.__orm.data).toEqual({
+      authorId: expect.anything(),
+      title: "title",
+    });
+    // And after we flush
+    await em.flush();
+    expect(queries).toMatchInlineSnapshot(`
+Array [
+  "BEGIN;",
+  "select nextval('authors_id_seq') from generate_series(1, 1) UNION ALL select nextval('book_id_seq') from generate_series(1, 1)",
+  "INSERT INTO authors (\\"id\\", \\"firstName\\", \\"lastName\\", \\"createdAt\\", \\"updatedAt\\") VALUES ($1, $2, $3, $4, $5)",
+  "INSERT INTO book (\\"id\\", \\"title\\", \\"authorId\\") VALUES ($1, $2, $3)",
+  "COMMIT;",
+]
+`);
+    // Then we still don't see any values
+    expect(b.__orm.data).toEqual({
+      id: "b:1",
+      authorId: expect.anything(),
+      title: "title",
+    });
+  });
+
+  it.withCtx("can update", async () => {
+    const em = newEntityManager();
+    // Given we make a book
+    const b = newBook(em);
+    await em.flush();
+    // When we update it
+    b.title = "title2";
+    await em.flush();
+  });
+});

--- a/packages/tests/schema-misc/src/entities/Book.ts
+++ b/packages/tests/schema-misc/src/entities/Book.ts
@@ -1,0 +1,6 @@
+import { BookCodegen, bookConfig as config } from "./entities";
+
+export class Book extends BookCodegen {}
+
+// remove once you have actual rules/hooks
+config.placeholder();

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -1,0 +1,120 @@
+import {
+  BaseEntity,
+  Changes,
+  ConfigApi,
+  EntityFilter,
+  EntityGraphQLFilter,
+  EntityOrmField,
+  FilterOf,
+  Flavor,
+  GraphQLFilterOf,
+  hasOne,
+  isLoaded,
+  Lens,
+  Loaded,
+  LoadHint,
+  loadLens,
+  ManyToOneReference,
+  newChangesProxy,
+  newRequiredRule,
+  OptsOf,
+  OrderBy,
+  PartialOrNull,
+  setField,
+  setOpts,
+  ValueFilter,
+  ValueGraphQLFilter,
+} from "joist-orm";
+import { Context } from "src/context";
+import { EntityManager } from "src/entities";
+import { Author, AuthorId, authorMeta, AuthorOrder, Book, bookMeta, newBook } from "./entities";
+
+export type BookId = Flavor<string, "Book">;
+
+export interface BookOpts {
+  title: string;
+  authorId: Author;
+}
+
+export interface BookIdsOpts {
+  authorIdId?: AuthorId | null;
+}
+
+export interface BookFilter {
+  id?: ValueFilter<BookId, never>;
+  title?: ValueFilter<string, never>;
+  authorId?: EntityFilter<Author, AuthorId, FilterOf<Author>, never>;
+}
+
+export interface BookGraphQLFilter {
+  id?: ValueGraphQLFilter<BookId>;
+  title?: ValueGraphQLFilter<string>;
+  authorId?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>>;
+}
+
+export interface BookOrder {
+  id?: OrderBy;
+  title?: OrderBy;
+  authorId?: AuthorOrder;
+}
+
+export const bookConfig = new ConfigApi<Book, Context>();
+
+bookConfig.addRule(newRequiredRule("title"));
+bookConfig.addRule(newRequiredRule("authorId"));
+
+export abstract class BookCodegen extends BaseEntity<EntityManager> {
+  static defaultValues: object = {};
+
+  readonly __orm!: EntityOrmField & {
+    filterType: BookFilter;
+    gqlFilterType: BookGraphQLFilter;
+    orderType: BookOrder;
+    optsType: BookOpts;
+    optIdsType: BookIdsOpts;
+    factoryOptsType: Parameters<typeof newBook>[1];
+  };
+
+  readonly authorId: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "authorId", "books");
+
+  constructor(em: EntityManager, opts: BookOpts) {
+    super(em, bookMeta, BookCodegen.defaultValues, opts);
+    setOpts(this as any as Book, opts, { calledFromConstructor: true });
+  }
+
+  get id(): BookId | undefined {
+    return this.__orm.data["id"];
+  }
+
+  get title(): string {
+    return this.__orm.data["title"];
+  }
+
+  set title(title: string) {
+    setField(this, "title", title);
+  }
+
+  set(opts: Partial<BookOpts>): void {
+    setOpts(this as any as Book, opts);
+  }
+
+  setPartial(opts: PartialOrNull<BookOpts>): void {
+    setOpts(this as any as Book, opts as OptsOf<Book>, { partial: true });
+  }
+
+  get changes(): Changes<Book> {
+    return newChangesProxy(this as any as Book);
+  }
+
+  async load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>): Promise<V> {
+    return loadLens(this as any as Book, fn);
+  }
+
+  async populate<H extends LoadHint<Book>>(hint: H): Promise<Loaded<Book, H>> {
+    return this.em.populate(this as any as Book, hint);
+  }
+
+  isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {
+    return isLoaded(this as any as Book, hint);
+  }
+}

--- a/packages/tests/schema-misc/src/entities/entities.ts
+++ b/packages/tests/schema-misc/src/entities/entities.ts
@@ -1,0 +1,13 @@
+// organize-imports-ignore
+
+// This file drives our import order to avoid undefined errors
+// when the subclasses extend the base classes, see:
+// https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de
+
+export * from "./AuthorCodegen";
+export * from "./BookCodegen";
+export * from "./Author";
+export * from "./Book";
+
+export * from "./factories";
+export * from "./metadata";

--- a/packages/tests/schema-misc/src/entities/factories.ts
+++ b/packages/tests/schema-misc/src/entities/factories.ts
@@ -1,0 +1,2 @@
+export * from "./Author.factories";
+export * from "./Book.factories";

--- a/packages/tests/schema-misc/src/entities/index.ts
+++ b/packages/tests/schema-misc/src/entities/index.ts
@@ -1,0 +1,1 @@
+export * from "./entities";

--- a/packages/tests/schema-misc/src/entities/metadata.ts
+++ b/packages/tests/schema-misc/src/entities/metadata.ts
@@ -1,0 +1,51 @@
+import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadata, KeySerde, PrimitiveSerde } from "joist-orm";
+import { Context } from "src/context";
+import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
+
+export class EntityManager extends EntityManager1<Context> {}
+
+export function getEm(e: BaseEntity): EntityManager {
+  return e.em as EntityManager;
+}
+
+export const authorMeta: EntityMetadata<Author> = {
+  cstr: Author,
+  type: "Author",
+  idType: "int",
+  tagName: "a",
+  tableName: "authors",
+  fields: {
+    id: { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("a", "id", "id", "int") },
+    firstName: { kind: "primitive", fieldName: "firstName", fieldIdName: undefined, derived: false, required: true, protected: false, type: "string", serde: new PrimitiveSerde("firstName", "firstName", "character varying") },
+    lastName: { kind: "primitive", fieldName: "lastName", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PrimitiveSerde("lastName", "lastName", "character varying") },
+    createdAt: { kind: "primitive", fieldName: "createdAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("createdAt", "createdAt", "timestamp with time zone") },
+    updatedAt: { kind: "primitive", fieldName: "updatedAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("updatedAt", "updatedAt", "timestamp with time zone") },
+    books: { kind: "o2m", fieldName: "books", fieldIdName: "bookIds", required: false, otherMetadata: () => bookMeta, otherFieldName: "authorId", serde: undefined },
+  },
+  timestampFields: { createdAt: "createdAt", updatedAt: "updatedAt" },
+  config: authorConfig,
+  factory: newAuthor,
+};
+
+(Author as any).metadata = authorMeta;
+
+export const bookMeta: EntityMetadata<Book> = {
+  cstr: Book,
+  type: "Book",
+  idType: "int",
+  tagName: "b",
+  tableName: "book",
+  fields: {
+    id: { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("b", "id", "id", "int") },
+    title: { kind: "primitive", fieldName: "title", fieldIdName: undefined, derived: false, required: true, protected: false, type: "string", serde: new PrimitiveSerde("title", "title", "character varying") },
+    authorId: { kind: "m2o", fieldName: "authorId", fieldIdName: "authorIdId", required: true, otherMetadata: () => authorMeta, otherFieldName: "books", serde: new KeySerde("a", "authorId", "authorId", "int") },
+  },
+  timestampFields: { createdAt: undefined, updatedAt: undefined },
+  config: bookConfig,
+  factory: newBook,
+};
+
+(Book as any).metadata = bookMeta;
+
+export const allMetadata = [authorMeta, bookMeta];
+configureMetadata(allMetadata);

--- a/packages/tests/schema-misc/src/jest.d.ts
+++ b/packages/tests/schema-misc/src/jest.d.ts
@@ -1,0 +1,12 @@
+// These imports are gross, but typescript won't compile if they're just coded normally
+type ContextOpts = Partial<import("./context").Context & import("./context").AppContext> & {
+  enableAuditTrail?: boolean;
+};
+type itWithCtxFn = (context: import("./context").Context) => Promise<void>;
+
+declare namespace jest {
+  interface It {
+    withCtx(name: string, fn: itWithCtxFn);
+    withCtx(name: string, opts: ContextOpts, fn: itWithCtxFn);
+  }
+}

--- a/packages/tests/schema-misc/src/setupDbTests.ts
+++ b/packages/tests/schema-misc/src/setupDbTests.ts
@@ -1,0 +1,63 @@
+import { Context } from "@src/context";
+import { EntityManager } from "@src/entities";
+import { config } from "dotenv";
+import { PostgresDriver, PostgresDriverOpts } from "joist-orm";
+import { toMatchEntity } from "joist-test-utils";
+import { newPgConnectionConfig } from "joist-utils";
+import { knex as createKnex, Knex } from "knex";
+
+if (process.env.DATABASE_URL === undefined) {
+  config({ path: "./local.env" });
+}
+
+// Create a shared test context that tests can use and also we'll use to auto-flush the db between tests.
+export let knex: Knex;
+
+export function newEntityManager(opts?: PostgresDriverOpts) {
+  const ctx = { knex };
+  const em = new EntityManager(
+    ctx as any,
+    new PostgresDriver(knex, {
+      ...opts,
+    }),
+  );
+  Object.assign(ctx, { em });
+  return em;
+}
+
+export let numberOfQueries = 0;
+export let queries: string[] = [];
+
+expect.extend({ toMatchEntity });
+
+beforeAll(async () => {
+  knex = createKnex({
+    client: "pg",
+    connection: newPgConnectionConfig(),
+    debug: false,
+    asyncStackTraces: true,
+  }).on("query", (e: any) => {
+    numberOfQueries++;
+    queries.push(e.sql);
+  });
+});
+
+beforeEach(async () => {
+  await knex.select(knex.raw("flush_database()"));
+  resetQueryCount();
+});
+
+afterAll(async () => {
+  await knex.destroy();
+});
+
+export function resetQueryCount() {
+  numberOfQueries = 0;
+  queries = [];
+}
+
+type itWithCtxFn = (ctx: Context) => Promise<void>;
+it.withCtx = (name: string, fnOrOpts: itWithCtxFn | ContextOpts, maybeFn?: itWithCtxFn) => {
+  const fn: itWithCtxFn = typeof fnOrOpts === "function" ? fnOrOpts : maybeFn!;
+  it(name, async () => fn({ em: newEntityManager(), knex }));
+};

--- a/packages/tests/schema-misc/src/utils.ts
+++ b/packages/tests/schema-misc/src/utils.ts
@@ -1,0 +1,7 @@
+export function fail(message?: string): never {
+  throw new Error(message || "Failed");
+}
+
+export function zeroTo(n: number): number[] {
+  return [...Array(n).keys()];
+}

--- a/packages/tests/schema-misc/tsconfig.json
+++ b/packages/tests/schema-misc/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "strict": true,
+    "types": ["jest", "node"],
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "composite": true,
+    "sourceMap": true,
+    "outDir": "./build",
+    "rootDir": "./",
+    "baseUrl": "./",
+    "paths": {
+      "joist-codegen": ["../../codegen"],
+      "joist-graphql-codegen": ["../../graphql-codegen"],
+      "joist-migration-utils": ["../../migration-utils"],
+      "joist-test-utils": ["../../test-utils"],
+      "joist-orm": ["../../orm"],
+      "joist-utils": ["../../utils"],
+      "@src/*": ["src/*"]
+    }
+  },
+  "references": [
+    { "path": "../../codegen" },
+    { "path": "../../graphql-codegen" },
+    { "path": "../../migration-utils" },
+    { "path": "../../orm" },
+    { "path": "../../utils" },
+    { "path": "../../test-utils" }
+  ]
+}

--- a/packages/tests/uuid-ids/local.env
+++ b/packages/tests/uuid-ids/local.env
@@ -1,2 +1,1 @@
 DATABASE_URL=postgres://joist:local@localhost:5435/uuid_ids
-ADD_FLUSH_DATABASE=true

--- a/yarn.lock
+++ b/yarn.lock
@@ -12118,6 +12118,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"joist-tests-schema-misc@workspace:packages/tests/schema-misc":
+  version: 0.0.0-use.local
+  resolution: "joist-tests-schema-misc@workspace:packages/tests/schema-misc"
+  dependencies:
+    "@swc/core": ^1.2.124
+    "@swc/jest": ^0.2.16
+    "@types/jest": ^26.0.24
+    "@types/node": ^16.4.10
+    dotenv: ^8.2.0
+    jest: ^27.0.6
+    jest-junit: ^12.2.0
+    joist-codegen: "workspace:*"
+    joist-migration-utils: "workspace:*"
+    joist-orm: "workspace:*"
+    joist-test-utils: "workspace:*"
+    node-pg-migrate: ^5.0.0
+    prettier: ^2.5.1
+    prettier-plugin-organize-imports: ^2.3.4
+    superstruct: ^0.15.2
+    ts-node: ^10.1.0
+    tsconfig-paths: ^3.10.1
+    typescript: ^4.5.2
+  languageName: unknown
+  linkType: soft
+
 "joist-tests-uuid-ids@workspace:packages/tests/uuid-ids":
   version: 0.0.0-use.local
   resolution: "joist-tests-uuid-ids@workspace:packages/tests/uuid-ids"


### PR DESCRIPTION
This PR:

* Changes the default behavior for `isEntityTable` to (with the default config) be any table with an `id` column (that is not also a code table)
* Adds a `joist-codegen.json` `timestampColumns` config for projects (like ours) to explicitly opt in to either differently-named timestamp columns, or to make timestamp columns required for entity tables
* Adds a new `schema-misc` project for testing tables w/different conventions, i.e. an `authors` table with `createdAt` and `updatedAt` columns (note not snake case) and a `book` table with no timestamp columns at all

Fixes #288 