### PR TITLE
fix: Make the root workspace private

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "tsc --build",
     "semantic-release": "semantic-release"
   },
+  "private": true,
   "workspaces": [
     "docs",
     "packages/codegen",


### PR DESCRIPTION
Root package.json was missing `private: true`