### PR TITLE
feat: Implement custom inspect method.

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -687,7 +687,7 @@ describe("EntityManager", () => {
     const flushPromise = em.flush();
     await delay(0);
     expect(() => p1.authors.add(a1)).toThrow(
-      "Cannot set 'publisher' on Author:new during a flush outside of a entity hook or from afterCommit",
+      "Cannot set 'publisher' on Author#1 during a flush outside of a entity hook or from afterCommit",
     );
     await flushPromise;
   });
@@ -928,7 +928,7 @@ describe("EntityManager", () => {
     expect(a1.toJSON()).toMatchObject({
       id: "a:1",
       firstName: "a1",
-      publisher: "Publisher:new",
+      publisher: "Publisher#1",
     });
   });
 

--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -6,6 +6,8 @@ import { Author, Book, BookId, BookReview, newAuthor, newPublisher, Publisher } 
 import { makeApiCall, newEntityManager } from "../setupDbTests";
 import { zeroTo } from "../utils";
 
+const inspect = Symbol.for("nodejs.util.inspect.custom");
+
 describe("Author", () => {
   it("can have business logic methods", async () => {
     await insertAuthor({ first_name: "a1" });
@@ -527,5 +529,22 @@ describe("Author", () => {
     const em = newEntityManager();
     const a1 = newAuthor(em);
     expect(a1.em).toEqual(em);
+  });
+
+  it("implements inspect for new entities", async () => {
+    const em = newEntityManager();
+    const [a1, a2] = [newAuthor(em), newAuthor(em)];
+    expect((a1 as any)[inspect]()).toEqual("Author#1");
+    expect((a2 as any)[inspect]()).toEqual("Author#2");
+  });
+
+  it("implements inspect for saved entities", async () => {
+    const em = newEntityManager();
+    const [a1, a2] = [newAuthor(em), newAuthor(em)];
+    await em.flush();
+    const a3 = newAuthor(em);
+    expect((a1 as any)[inspect]()).toEqual("Author:1");
+    expect((a2 as any)[inspect]()).toEqual("Author:2");
+    expect((a3 as any)[inspect]()).toEqual("Author#3");
   });
 });

--- a/packages/integration-tests/src/relations/PolymorphicReference.test.ts
+++ b/packages/integration-tests/src/relations/PolymorphicReference.test.ts
@@ -89,7 +89,7 @@ describe("PolymorphicReference", () => {
     const c1 = em.createPartial(Comment, {});
     const c2 = em.createPartial(Comment, {});
 
-    expect(() => c1.parent.set(c2 as any)).toThrow("Comment:new cannot be set as 'parent' on Comment:new");
+    expect(() => c1.parent.set(c2 as any)).toThrow("Comment#2 cannot be set as 'parent' on Comment#1");
   });
 
   it("removes deleted entities", async () => {


### PR DESCRIPTION
So that `console.log(anEntity)` doesn't output a ton of noise about the entity's internal state.

We could eventually have it return the internal state, like if depth is zero...but this is simplest for now.