### PR TITLE
feat: Make clone smarter.

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1109,14 +1109,14 @@ describe("EntityManager", () => {
 
     // When we clone that entity and its reference
     const a2 = await em.clone(a1, "books");
-    const [b2] = a2.books.get;
     await em.flush();
 
     // Then we expect the cloned entity to have a cloned copy of the original's reference
     expect(a2.books.get[0].title).toEqual(b1.title);
     // But the book is a different book
+    const [b2] = a2.books.get;
     expect(b2).not.toBe(b1);
-    // But a2 got updated to point to the cloned book
+    // And a2 got updated to point to its cloned book
     expect(a2.currentDraftBook.get).toBe(b2);
   });
 
@@ -1152,8 +1152,8 @@ describe("EntityManager", () => {
     // Then we expect the cloned entity to have cloned copies of all its nested references
     const b2 = (await a2.books.load())[0];
     const i2 = await b2.image.load();
-    expect(i2).toBeTruthy();
-    expect(i2?.id).not.toEqual(i1.id);
+    expect(i2).toBeDefined();
+    expect(i2).not.toEqual(i1);
     expect(i2?.fileName).toEqual(i1.fileName);
     expect(i2?.type).toEqual(i1.type);
     expect(await numberOf(em, Author, Book, Image)).toEqual([2, 2, 2]);

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1230,18 +1230,7 @@ async function followReverseHint(entities: Entity[], reverseHint: string[]): Pro
   return current;
 }
 
-function adaptHint<T extends Entity>(hint: LoadHint<T> | undefined): NestedLoadHint<T> {
-  if ((typeof hint as any) === "string") {
-    return { [hint as any]: {} } as any;
-  } else if (Array.isArray(hint)) {
-    return Object.fromEntries(hint.map((relation) => [relation, {}]));
-  } else if (hint) {
-    return hint as NestedLoadHint<T>;
-  } else {
-    return {};
-  }
-}
-
+/** Recursively crawls through `entity`, with the given populate `hint`, and adds anything found to `found`. */
 async function crawl<T extends Entity>(found: Entity[], entity: T, hint: LoadHint<T>): Promise<void> {
   found.push(entity);
   await Promise.all(
@@ -1265,4 +1254,17 @@ async function crawl<T extends Entity>(found: Entity[], entity: T, hint: LoadHin
       }
     }),
   );
+}
+
+/** Takes our flexible string or array or hash load hint and makes it always a hash. */
+function adaptHint<T extends Entity>(hint: LoadHint<T> | undefined): NestedLoadHint<T> {
+  if ((typeof hint as any) === "string") {
+    return { [hint as any]: {} } as any;
+  } else if (Array.isArray(hint)) {
+    return Object.fromEntries(hint.map((relation) => [relation, {}]));
+  } else if (hint) {
+    return hint as NestedLoadHint<T>;
+  } else {
+    return {};
+  }
 }


### PR DESCRIPTION
Previously clone would both find + fixup entities in a single pass.

This made it hard/impossible for clone to go back and update
already-cloned entities to point to new downstream clones.

I.e. when cloning author -> book, author has a currentDraftBook field,
but we've not even cloned it's books yet, so would not fix up the
relation, and leave a newly cloned author pointing to the original
author's book.

This PR breaks up clone into three distinct phases of 1) find, 2)
clone, and 3) fixup.

The upshot is that the fixup phase now knows about all clones, i.e.
we can point `author.currentDraftBook` to the new book.