### PR TITLE
feat: Implement DeepNew for factories and tests

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -410,8 +410,8 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
       populate<H extends ${LoadHint}<${entityName}>>(opts: { hint: H, forceReload?: boolean }): Promise<${Loaded}<${entityName}, H>>;
       populate<H extends ${LoadHint}<${entityName}>, V>(hint: H, fn: (${tagName}: Loaded<${entityName}, H>) => V): Promise<V>;
       populate<H extends ${LoadHint}<${entityName}>, V>(opts: { hint: H, forceReload?: boolean }, fn: (${tagName}: Loaded<${entityName}, H>) => V): Promise<V>;
-      populate<H extends ${LoadHint}<${entityName}>, V>(hint: H, fn?: (${tagName}: Loaded<${entityName}, H>) => V): Promise<${Loaded}<${entityName}, H> | V> {
-        return this.em.populate(this as any as ${entityName}, hint as any, fn);
+      populate<H extends ${LoadHint}<${entityName}>, V>(hintOrOpts: any, fn?: (${tagName}: Loaded<${entityName}, H>) => V): Promise<${Loaded}<${entityName}, H> | V> {
+        return this.em.populate(this as any as ${entityName}, hintOrOpts, fn);
       }
 
       isLoaded<H extends ${LoadHint}<${entityName}>>(hint: H): this is ${Loaded}<${entityName}, H> {

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -407,9 +407,11 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
       }
 
       populate<H extends ${LoadHint}<${entityName}>>(hint: H): Promise<${Loaded}<${entityName}, H>>;
+      populate<H extends ${LoadHint}<${entityName}>>(opts: { hint: H, forceReload?: boolean }): Promise<${Loaded}<${entityName}, H>>;
       populate<H extends ${LoadHint}<${entityName}>, V>(hint: H, fn: (${tagName}: Loaded<${entityName}, H>) => V): Promise<V>;
+      populate<H extends ${LoadHint}<${entityName}>, V>(opts: { hint: H, forceReload?: boolean }, fn: (${tagName}: Loaded<${entityName}, H>) => V): Promise<V>;
       populate<H extends ${LoadHint}<${entityName}>, V>(hint: H, fn?: (${tagName}: Loaded<${entityName}, H>) => V): Promise<${Loaded}<${entityName}, H> | V> {
-        return this.em.populate(this as any as ${entityName}, hint, fn);
+        return this.em.populate(this as any as ${entityName}, hint as any, fn);
       }
 
       isLoaded<H extends ${LoadHint}<${entityName}>>(hint: H): this is ${Loaded}<${entityName}, H> {

--- a/packages/codegen/src/generateFactoriesFiles.ts
+++ b/packages/codegen/src/generateFactoriesFiles.ts
@@ -2,7 +2,7 @@ import { pascalCase } from "change-case";
 import { code } from "ts-poet";
 import { EntityDbMetadata } from "./EntityDbMetadata";
 import { CodeGenFile } from "./index";
-import { EntityManager, FactoryOpts, New, newTestInstance } from "./symbols";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "./symbols";
 
 export function generateFactoriesFiles(entities: EntityDbMetadata[]): CodeGenFile[] {
   // One-time create an Author.factories.ts for each entity
@@ -12,7 +12,7 @@ export function generateFactoriesFiles(entities: EntityDbMetadata[]): CodeGenFil
       export function new${name}(
         em: ${EntityManager},
         opts: ${FactoryOpts}<${entity.type}> = {},
-      ): ${New}<${entity.type}> {
+      ): ${DeepNew}<${entity.type}> {
         return ${newTestInstance}(em, ${entity.type}, opts);
       }`;
     return { name: `./${entity.name}.factories.ts`, contents, overwrite: false };

--- a/packages/codegen/src/symbols.ts
+++ b/packages/codegen/src/symbols.ts
@@ -60,6 +60,7 @@ export const hasManyToMany = imp("hasManyToMany@joist-orm");
 export const hasLargeManyToMany = imp("hasLargeManyToMany@joist-orm");
 export const newTestInstance = imp("newTestInstance@joist-orm");
 export const New = imp("New@joist-orm");
+export const DeepNew = imp("DeepNew@joist-orm");
 export const FactoryOpts = imp("FactoryOpts@joist-orm");
 export const SSAssert = imp("assert@superstruct");
 export const EntityConstructor = imp("EntityConstructor@joist-orm");

--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -21,8 +21,6 @@ import {
 import { maybeNew, maybeNewPoly, New, newTestInstance } from "joist-orm";
 import { newEntityManager } from "./setupDbTests";
 
-jest.setTimeout(100_000);
-
 describe("EntityManager.factories", () => {
   it("can create a single top-level entity", async () => {
     const em = newEntityManager();

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -422,6 +422,7 @@ describe("EntityManager", () => {
     expect(p1.name).toEqual("p2");
   });
 
+  jest.setTimeout(100_000);
   it("refresh an entity with a loaded o2m collection", async () => {
     await insertPublisher({ name: "p1" });
     await insertAuthor({ first_name: "a1", publisher_id: 1 });

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -422,7 +422,6 @@ describe("EntityManager", () => {
     expect(p1.name).toEqual("p2");
   });
 
-  jest.setTimeout(100_000);
   it("refresh an entity with a loaded o2m collection", async () => {
     await insertPublisher({ name: "p1" });
     await insertAuthor({ first_name: "a1", publisher_id: 1 });

--- a/packages/integration-tests/src/entities/Author.factories.ts
+++ b/packages/integration-tests/src/entities/Author.factories.ts
@@ -1,10 +1,10 @@
-import { EntityManager, FactoryOpts, New, newTestInstance, testIndex } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance, testIndex } from "joist-orm";
 import { Author } from "./entities";
 
 // for testing factories
 export let lastAuthorFactoryOpts: any = null;
 
-export function newAuthor(em: EntityManager, opts?: FactoryOpts<Author>): New<Author> {
+export function newAuthor(em: EntityManager, opts?: FactoryOpts<Author>): DeepNew<Author> {
   lastAuthorFactoryOpts = opts;
   return newTestInstance(em, Author, {
     firstName: `a${testIndex}`,

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -363,8 +363,11 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     opts: { hint: H; forceReload?: boolean },
     fn: (a: Loaded<Author, H>) => V,
   ): Promise<V>;
-  populate<H extends LoadHint<Author>, V>(hint: H, fn?: (a: Loaded<Author, H>) => V): Promise<Loaded<Author, H> | V> {
-    return this.em.populate(this as any as Author, hint as any, fn);
+  populate<H extends LoadHint<Author>, V>(
+    hintOrOpts: any,
+    fn?: (a: Loaded<Author, H>) => V,
+  ): Promise<Loaded<Author, H> | V> {
+    return this.em.populate(this as any as Author, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -357,9 +357,14 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Author>>(hint: H): Promise<Loaded<Author, H>>;
+  populate<H extends LoadHint<Author>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Author, H>>;
   populate<H extends LoadHint<Author>, V>(hint: H, fn: (a: Loaded<Author, H>) => V): Promise<V>;
+  populate<H extends LoadHint<Author>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (a: Loaded<Author, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<Author>, V>(hint: H, fn?: (a: Loaded<Author, H>) => V): Promise<Loaded<Author, H> | V> {
-    return this.em.populate(this as any as Author, hint, fn);
+    return this.em.populate(this as any as Author, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {

--- a/packages/integration-tests/src/entities/Book.factories.ts
+++ b/packages/integration-tests/src/entities/Book.factories.ts
@@ -1,10 +1,10 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { Book } from "./entities";
 
 // for testing factories
 export let lastBookFactoryOpts: any = null;
 
-export function newBook(em: EntityManager, opts?: FactoryOpts<Book>): New<Book> {
+export function newBook(em: EntityManager, opts?: FactoryOpts<Book>): DeepNew<Book> {
   lastBookFactoryOpts = opts;
   return newTestInstance(em, Book, opts);
 }

--- a/packages/integration-tests/src/entities/BookAdvance.factories.ts
+++ b/packages/integration-tests/src/entities/BookAdvance.factories.ts
@@ -1,6 +1,6 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { BookAdvance } from "./entities";
 
-export function newBookAdvance(em: EntityManager, opts?: FactoryOpts<BookAdvance>): New<BookAdvance> {
+export function newBookAdvance(em: EntityManager, opts?: FactoryOpts<BookAdvance>): DeepNew<BookAdvance> {
   return newTestInstance(em, BookAdvance, opts);
 }

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -183,10 +183,10 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager> {
     fn: (ba: Loaded<BookAdvance, H>) => V,
   ): Promise<V>;
   populate<H extends LoadHint<BookAdvance>, V>(
-    hint: H,
+    hintOrOpts: any,
     fn?: (ba: Loaded<BookAdvance, H>) => V,
   ): Promise<Loaded<BookAdvance, H> | V> {
-    return this.em.populate(this as any as BookAdvance, hint as any, fn);
+    return this.em.populate(this as any as BookAdvance, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<BookAdvance>>(hint: H): this is Loaded<BookAdvance, H> {

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -176,12 +176,17 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<BookAdvance>>(hint: H): Promise<Loaded<BookAdvance, H>>;
+  populate<H extends LoadHint<BookAdvance>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<BookAdvance, H>>;
   populate<H extends LoadHint<BookAdvance>, V>(hint: H, fn: (ba: Loaded<BookAdvance, H>) => V): Promise<V>;
+  populate<H extends LoadHint<BookAdvance>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (ba: Loaded<BookAdvance, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<BookAdvance>, V>(
     hint: H,
     fn?: (ba: Loaded<BookAdvance, H>) => V,
   ): Promise<Loaded<BookAdvance, H> | V> {
-    return this.em.populate(this as any as BookAdvance, hint, fn);
+    return this.em.populate(this as any as BookAdvance, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<BookAdvance>>(hint: H): this is Loaded<BookAdvance, H> {

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -208,9 +208,14 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Book>>(hint: H): Promise<Loaded<Book, H>>;
+  populate<H extends LoadHint<Book>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Book, H>>;
   populate<H extends LoadHint<Book>, V>(hint: H, fn: (b: Loaded<Book, H>) => V): Promise<V>;
+  populate<H extends LoadHint<Book>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (b: Loaded<Book, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<Book>, V>(hint: H, fn?: (b: Loaded<Book, H>) => V): Promise<Loaded<Book, H> | V> {
-    return this.em.populate(this as any as Book, hint, fn);
+    return this.em.populate(this as any as Book, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -214,8 +214,8 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     opts: { hint: H; forceReload?: boolean },
     fn: (b: Loaded<Book, H>) => V,
   ): Promise<V>;
-  populate<H extends LoadHint<Book>, V>(hint: H, fn?: (b: Loaded<Book, H>) => V): Promise<Loaded<Book, H> | V> {
-    return this.em.populate(this as any as Book, hint as any, fn);
+  populate<H extends LoadHint<Book>, V>(hintOrOpts: any, fn?: (b: Loaded<Book, H>) => V): Promise<Loaded<Book, H> | V> {
+    return this.em.populate(this as any as Book, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {

--- a/packages/integration-tests/src/entities/BookReview.factories.ts
+++ b/packages/integration-tests/src/entities/BookReview.factories.ts
@@ -1,6 +1,6 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { BookReview } from "./entities";
 
-export function newBookReview(em: EntityManager, opts?: FactoryOpts<BookReview>): New<BookReview> {
+export function newBookReview(em: EntityManager, opts?: FactoryOpts<BookReview>): DeepNew<BookReview> {
   return newTestInstance(em, BookReview, opts);
 }

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -169,12 +169,17 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<BookReview>>(hint: H): Promise<Loaded<BookReview, H>>;
+  populate<H extends LoadHint<BookReview>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<BookReview, H>>;
   populate<H extends LoadHint<BookReview>, V>(hint: H, fn: (br: Loaded<BookReview, H>) => V): Promise<V>;
+  populate<H extends LoadHint<BookReview>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (br: Loaded<BookReview, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<BookReview>, V>(
     hint: H,
     fn?: (br: Loaded<BookReview, H>) => V,
   ): Promise<Loaded<BookReview, H> | V> {
-    return this.em.populate(this as any as BookReview, hint, fn);
+    return this.em.populate(this as any as BookReview, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<BookReview>>(hint: H): this is Loaded<BookReview, H> {

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -176,10 +176,10 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager> {
     fn: (br: Loaded<BookReview, H>) => V,
   ): Promise<V>;
   populate<H extends LoadHint<BookReview>, V>(
-    hint: H,
+    hintOrOpts: any,
     fn?: (br: Loaded<BookReview, H>) => V,
   ): Promise<Loaded<BookReview, H> | V> {
-    return this.em.populate(this as any as BookReview, hint as any, fn);
+    return this.em.populate(this as any as BookReview, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<BookReview>>(hint: H): this is Loaded<BookReview, H> {

--- a/packages/integration-tests/src/entities/Comment.factories.ts
+++ b/packages/integration-tests/src/entities/Comment.factories.ts
@@ -1,6 +1,6 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { Comment } from "./entities";
 
-export function newComment(em: EntityManager, opts?: FactoryOpts<Comment>): New<Comment> {
+export function newComment(em: EntityManager, opts?: FactoryOpts<Comment>): DeepNew<Comment> {
   return newTestInstance(em, Comment, opts);
 }

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -143,12 +143,17 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Comment>>(hint: H): Promise<Loaded<Comment, H>>;
+  populate<H extends LoadHint<Comment>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Comment, H>>;
   populate<H extends LoadHint<Comment>, V>(hint: H, fn: (comment: Loaded<Comment, H>) => V): Promise<V>;
+  populate<H extends LoadHint<Comment>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (comment: Loaded<Comment, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<Comment>, V>(
     hint: H,
     fn?: (comment: Loaded<Comment, H>) => V,
   ): Promise<Loaded<Comment, H> | V> {
-    return this.em.populate(this as any as Comment, hint, fn);
+    return this.em.populate(this as any as Comment, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<Comment>>(hint: H): this is Loaded<Comment, H> {

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -150,10 +150,10 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager> {
     fn: (comment: Loaded<Comment, H>) => V,
   ): Promise<V>;
   populate<H extends LoadHint<Comment>, V>(
-    hint: H,
+    hintOrOpts: any,
     fn?: (comment: Loaded<Comment, H>) => V,
   ): Promise<Loaded<Comment, H> | V> {
-    return this.em.populate(this as any as Comment, hint as any, fn);
+    return this.em.populate(this as any as Comment, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Comment>>(hint: H): this is Loaded<Comment, H> {

--- a/packages/integration-tests/src/entities/Critic.factories.ts
+++ b/packages/integration-tests/src/entities/Critic.factories.ts
@@ -1,10 +1,10 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { Critic } from "./entities";
 
 // for testing factories
 export let lastCriticFactory: any = null;
 
-export function newCritic(em: EntityManager, opts: FactoryOpts<Critic> = {}): New<Critic> {
+export function newCritic(em: EntityManager, opts: FactoryOpts<Critic> = {}): DeepNew<Critic> {
   lastCriticFactory = opts;
   return newTestInstance(em, Critic, opts);
 }

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -141,8 +141,11 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager> {
     opts: { hint: H; forceReload?: boolean },
     fn: (c: Loaded<Critic, H>) => V,
   ): Promise<V>;
-  populate<H extends LoadHint<Critic>, V>(hint: H, fn?: (c: Loaded<Critic, H>) => V): Promise<Loaded<Critic, H> | V> {
-    return this.em.populate(this as any as Critic, hint as any, fn);
+  populate<H extends LoadHint<Critic>, V>(
+    hintOrOpts: any,
+    fn?: (c: Loaded<Critic, H>) => V,
+  ): Promise<Loaded<Critic, H> | V> {
+    return this.em.populate(this as any as Critic, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Critic>>(hint: H): this is Loaded<Critic, H> {

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -135,9 +135,14 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Critic>>(hint: H): Promise<Loaded<Critic, H>>;
+  populate<H extends LoadHint<Critic>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Critic, H>>;
   populate<H extends LoadHint<Critic>, V>(hint: H, fn: (c: Loaded<Critic, H>) => V): Promise<V>;
+  populate<H extends LoadHint<Critic>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (c: Loaded<Critic, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<Critic>, V>(hint: H, fn?: (c: Loaded<Critic, H>) => V): Promise<Loaded<Critic, H> | V> {
-    return this.em.populate(this as any as Critic, hint, fn);
+    return this.em.populate(this as any as Critic, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<Critic>>(hint: H): this is Loaded<Critic, H> {

--- a/packages/integration-tests/src/entities/CriticColumn.factories.ts
+++ b/packages/integration-tests/src/entities/CriticColumn.factories.ts
@@ -1,6 +1,6 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { CriticColumn } from "./entities";
 
-export function newCriticColumn(em: EntityManager, opts: FactoryOpts<CriticColumn> = {}): New<CriticColumn> {
+export function newCriticColumn(em: EntityManager, opts: FactoryOpts<CriticColumn> = {}): DeepNew<CriticColumn> {
   return newTestInstance(em, CriticColumn, opts);
 }

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -142,10 +142,10 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager> {
     fn: (cc: Loaded<CriticColumn, H>) => V,
   ): Promise<V>;
   populate<H extends LoadHint<CriticColumn>, V>(
-    hint: H,
+    hintOrOpts: any,
     fn?: (cc: Loaded<CriticColumn, H>) => V,
   ): Promise<Loaded<CriticColumn, H> | V> {
-    return this.em.populate(this as any as CriticColumn, hint as any, fn);
+    return this.em.populate(this as any as CriticColumn, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<CriticColumn>>(hint: H): this is Loaded<CriticColumn, H> {

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -132,12 +132,20 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<CriticColumn>>(hint: H): Promise<Loaded<CriticColumn, H>>;
+  populate<H extends LoadHint<CriticColumn>>(opts: {
+    hint: H;
+    forceReload?: boolean;
+  }): Promise<Loaded<CriticColumn, H>>;
   populate<H extends LoadHint<CriticColumn>, V>(hint: H, fn: (cc: Loaded<CriticColumn, H>) => V): Promise<V>;
+  populate<H extends LoadHint<CriticColumn>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (cc: Loaded<CriticColumn, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<CriticColumn>, V>(
     hint: H,
     fn?: (cc: Loaded<CriticColumn, H>) => V,
   ): Promise<Loaded<CriticColumn, H> | V> {
-    return this.em.populate(this as any as CriticColumn, hint, fn);
+    return this.em.populate(this as any as CriticColumn, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<CriticColumn>>(hint: H): this is Loaded<CriticColumn, H> {

--- a/packages/integration-tests/src/entities/Image.factories.ts
+++ b/packages/integration-tests/src/entities/Image.factories.ts
@@ -1,6 +1,6 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { Image } from "./entities";
 
-export function newImage(em: EntityManager, opts?: FactoryOpts<Image>): New<Image> {
+export function newImage(em: EntityManager, opts?: FactoryOpts<Image>): DeepNew<Image> {
   return newTestInstance(em, Image, opts);
 }

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -200,8 +200,11 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager> {
     opts: { hint: H; forceReload?: boolean },
     fn: (i: Loaded<Image, H>) => V,
   ): Promise<V>;
-  populate<H extends LoadHint<Image>, V>(hint: H, fn?: (i: Loaded<Image, H>) => V): Promise<Loaded<Image, H> | V> {
-    return this.em.populate(this as any as Image, hint as any, fn);
+  populate<H extends LoadHint<Image>, V>(
+    hintOrOpts: any,
+    fn?: (i: Loaded<Image, H>) => V,
+  ): Promise<Loaded<Image, H> | V> {
+    return this.em.populate(this as any as Image, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Image>>(hint: H): this is Loaded<Image, H> {

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -194,9 +194,14 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Image>>(hint: H): Promise<Loaded<Image, H>>;
+  populate<H extends LoadHint<Image>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Image, H>>;
   populate<H extends LoadHint<Image>, V>(hint: H, fn: (i: Loaded<Image, H>) => V): Promise<V>;
+  populate<H extends LoadHint<Image>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (i: Loaded<Image, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<Image>, V>(hint: H, fn?: (i: Loaded<Image, H>) => V): Promise<Loaded<Image, H> | V> {
-    return this.em.populate(this as any as Image, hint, fn);
+    return this.em.populate(this as any as Image, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<Image>>(hint: H): this is Loaded<Image, H> {

--- a/packages/integration-tests/src/entities/Publisher.factories.ts
+++ b/packages/integration-tests/src/entities/Publisher.factories.ts
@@ -1,6 +1,6 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { Publisher } from "./entities";
 
-export function newPublisher(em: EntityManager, opts: FactoryOpts<Publisher> = {}): New<Publisher> {
+export function newPublisher(em: EntityManager, opts: FactoryOpts<Publisher> = {}): DeepNew<Publisher> {
   return newTestInstance(em, Publisher, opts);
 }

--- a/packages/integration-tests/src/entities/Publisher.ts
+++ b/packages/integration-tests/src/entities/Publisher.ts
@@ -5,7 +5,7 @@ const allImagesHint = { images: [], authors: { image: [], books: "image" } } as 
 
 export class Publisher extends PublisherCodegen {
   readonly allImages: Collection<Publisher, Image> = new CustomCollection(this, {
-    load: (entity) => entity.populate(allImagesHint),
+    load: (entity, opts) => entity.populate({ hint: allImagesHint, ...opts }),
     get: (entity) => {
       const loaded = entity as Loaded<Publisher, typeof allImagesHint>;
 

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -268,12 +268,17 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Publisher>>(hint: H): Promise<Loaded<Publisher, H>>;
+  populate<H extends LoadHint<Publisher>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Publisher, H>>;
   populate<H extends LoadHint<Publisher>, V>(hint: H, fn: (p: Loaded<Publisher, H>) => V): Promise<V>;
+  populate<H extends LoadHint<Publisher>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (p: Loaded<Publisher, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<Publisher>, V>(
     hint: H,
     fn?: (p: Loaded<Publisher, H>) => V,
   ): Promise<Loaded<Publisher, H> | V> {
-    return this.em.populate(this as any as Publisher, hint, fn);
+    return this.em.populate(this as any as Publisher, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<Publisher>>(hint: H): this is Loaded<Publisher, H> {

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -275,10 +275,10 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager> {
     fn: (p: Loaded<Publisher, H>) => V,
   ): Promise<V>;
   populate<H extends LoadHint<Publisher>, V>(
-    hint: H,
+    hintOrOpts: any,
     fn?: (p: Loaded<Publisher, H>) => V,
   ): Promise<Loaded<Publisher, H> | V> {
-    return this.em.populate(this as any as Publisher, hint as any, fn);
+    return this.em.populate(this as any as Publisher, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Publisher>>(hint: H): this is Loaded<Publisher, H> {

--- a/packages/integration-tests/src/entities/Tag.factories.ts
+++ b/packages/integration-tests/src/entities/Tag.factories.ts
@@ -1,8 +1,8 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { Tag } from "./entities";
 
 // Example of using a completely different opts type. Use number so that the type isn't a string/look like a tagged id.
-export function newTag(em: EntityManager, name: number | FactoryOpts<Tag>): New<Tag> {
+export function newTag(em: EntityManager, name: number | FactoryOpts<Tag>): DeepNew<Tag> {
   if (typeof name === "number") {
     return newTestInstance(em, Tag, { name: String(name) });
   } else {

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -151,8 +151,8 @@ export abstract class TagCodegen extends BaseEntity<EntityManager> {
     opts: { hint: H; forceReload?: boolean },
     fn: (t: Loaded<Tag, H>) => V,
   ): Promise<V>;
-  populate<H extends LoadHint<Tag>, V>(hint: H, fn?: (t: Loaded<Tag, H>) => V): Promise<Loaded<Tag, H> | V> {
-    return this.em.populate(this as any as Tag, hint as any, fn);
+  populate<H extends LoadHint<Tag>, V>(hintOrOpts: any, fn?: (t: Loaded<Tag, H>) => V): Promise<Loaded<Tag, H> | V> {
+    return this.em.populate(this as any as Tag, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Tag>>(hint: H): this is Loaded<Tag, H> {

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -145,9 +145,14 @@ export abstract class TagCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Tag>>(hint: H): Promise<Loaded<Tag, H>>;
+  populate<H extends LoadHint<Tag>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Tag, H>>;
   populate<H extends LoadHint<Tag>, V>(hint: H, fn: (t: Loaded<Tag, H>) => V): Promise<V>;
+  populate<H extends LoadHint<Tag>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (t: Loaded<Tag, H>) => V,
+  ): Promise<V>;
   populate<H extends LoadHint<Tag>, V>(hint: H, fn?: (t: Loaded<Tag, H>) => V): Promise<Loaded<Tag, H> | V> {
-    return this.em.populate(this as any as Tag, hint, fn);
+    return this.em.populate(this as any as Tag, hint as any, fn);
   }
 
   isLoaded<H extends LoadHint<Tag>>(hint: H): this is Loaded<Tag, H> {

--- a/packages/integration-tests/src/relations/OneToOneReference.test.ts
+++ b/packages/integration-tests/src/relations/OneToOneReference.test.ts
@@ -137,7 +137,6 @@ describe("OneToOneReference", () => {
     await insertAuthor({ first_name: "a1" });
     const em = newEntityManager();
     const a1 = await em.load(Author, "1");
-    await em.refresh();
     expect(() => (a1.image as any).isSet).toThrow("Author:1.image was not loaded");
   });
 });

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -30,6 +30,7 @@ export * from "./EntityManager";
 export * from "./getProperties";
 export * from "./keys";
 export {
+  DeepNew,
   ensureLoaded,
   ensureLoadedThen,
   isLoaded,

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -17,7 +17,7 @@ import {
   PolymorphicField,
   PrimitiveField,
 } from "./EntityManager";
-import { isManyToOneField, isOneToOneField, New } from "./index";
+import { DeepNew, isManyToOneField, isOneToOneField, New } from "./index";
 import { tagId } from "./keys";
 import { assertNever, fail } from "./utils";
 
@@ -43,7 +43,7 @@ export function newTestInstance<T extends Entity>(
   em: EntityManager,
   cstr: EntityConstructor<T>,
   opts: FactoryOpts<T> = {},
-): New<T> {
+): DeepNew<T> {
   const meta = getMetadata(cstr);
   // We share a single `use` map for a given `newEntity` factory call
   const use = useMap(opts);
@@ -150,7 +150,7 @@ export function newTestInstance<T extends Entity>(
 
   entity.set(Object.fromEntries(additionalOpts.filter((t) => t.length > 0)));
 
-  return entity;
+  return entity as DeepNew<T>;
 }
 
 /**

--- a/packages/orm/src/relations/AbstractRelationImpl.ts
+++ b/packages/orm/src/relations/AbstractRelationImpl.ts
@@ -11,8 +11,11 @@ export abstract class AbstractRelationImpl<U> {
   /** Similar to setFromOpts, but called post-construction. */
   abstract set(value: U): void;
 
-  /** Called on `EntityManager.refresh()` to reload the collection from the latest db values. */
-  abstract refreshIfLoaded(): Promise<void>;
+  /** Whether this relation is loaded. */
+  abstract get isLoaded(): boolean;
+
+  /** Loads the other side of this relation. */
+  abstract load(opts?: { forceReload?: boolean }): Promise<any>;
 
   /**
    * Called when our entity has been `EntityManager.delete`'d _and_ `EntityManager.flush` is being called,

--- a/packages/orm/src/relations/CustomReference.ts
+++ b/packages/orm/src/relations/CustomReference.ts
@@ -7,7 +7,7 @@ import { RelationT, RelationU } from "./Relation";
 export type CustomReferenceOpts<T extends Entity, U extends Entity, N extends never | undefined> = {
   // We purposefully don't capture the return value of `load` b/c we want `get` to re-calc from `entity`
   // each time it's invoked so that it reflects any changed values.
-  load: (entity: T) => Promise<void>;
+  load: (entity: T, opts: { forceReload?: boolean }) => Promise<void>;
   get: (entity: T) => U | N;
   set?: (entity: T, other: U) => void;
 };
@@ -52,7 +52,7 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
     ensureNotDeleted(this.entity, { ignore: "pending" });
     if (!this.isLoaded || opts.forceReload) {
       if (this.loadPromise === undefined) {
-        this.loadPromise = this.opts.load(this.entity);
+        this.loadPromise = this.opts.load(this.entity, opts);
         await this.loadPromise;
         this.loadPromise = undefined;
         this._isLoaded = true;

--- a/packages/orm/src/relations/CustomReference.ts
+++ b/packages/orm/src/relations/CustomReference.ts
@@ -48,9 +48,9 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
     return this._isLoaded;
   }
 
-  async load(opts?: { withDeleted?: boolean }): Promise<U | N> {
+  async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<U | N> {
     ensureNotDeleted(this.entity, { ignore: "pending" });
-    if (!this.isLoaded) {
+    if (!this.isLoaded || opts.forceReload) {
       if (this.loadPromise === undefined) {
         this.loadPromise = this.opts.load(this.entity);
         await this.loadPromise;
@@ -60,7 +60,6 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
         await this.loadPromise;
       }
     }
-
     return this.doGet(opts);
   }
 
@@ -111,7 +110,6 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
   // these callbacks should be no-ops as they ought to be handled by the underlying relations
   async cleanupOnEntityDeleted(): Promise<void> {}
   maybeCascadeDelete(): void {}
-  async refreshIfLoaded(): Promise<void> {}
 
   /** Finds this CustomReferences field name by looking in the entity for the key that we're assigned to. */
   get fieldName(): string {

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -65,9 +65,9 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     return opts?.withDeleted === true ? [...entities] : entities.filter((e) => !e.isDeletedEntity);
   }
 
-  async load(opts?: { withDeleted?: boolean }): Promise<ReadonlyArray<U>> {
+  async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<ReadonlyArray<U>> {
     ensureNotDeleted(this.entity, { ignore: "pending" });
-    if (this.loaded === undefined) {
+    if (this.loaded === undefined || opts.forceReload) {
       const key = `${this.columnName}=${this.entity.id}`;
       this.loaded = await manyToManyDataLoader(this.entity.em, this).load(key);
       this.maybeApplyAddedAndRemovedBeforeLoaded();
@@ -232,15 +232,6 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     // Don't overwrite any opts values
     if (this.loaded === undefined) {
       this.loaded = [];
-    }
-  }
-
-  async refreshIfLoaded(): Promise<void> {
-    ensureNotDeleted(this.entity);
-    // TODO We should remember what load hints have been applied to this collection and re-apply them.
-    if (this.loaded !== undefined && this.entity.id !== undefined) {
-      const key = `${this.columnName}=${this.entity.id}`;
-      this.loaded = await manyToManyDataLoader(this.entity.em, this).load(key);
     }
   }
 

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -79,7 +79,7 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
 
   async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<U | N> {
     ensureNotDeleted(this.entity, { ignore: "pending" });
-    if (this._isLoaded && this.loaded) {
+    if (this._isLoaded && this.loaded && !opts.forceReload) {
       return this.loaded;
     }
     const current = this.current();

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -77,7 +77,7 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     this.isCascadeDelete = otherMeta.config.__data.cascadeDeleteFields.includes(fieldName as any);
   }
 
-  async load(opts?: { withDeleted?: boolean }): Promise<U | N> {
+  async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<U | N> {
     ensureNotDeleted(this.entity, { ignore: "pending" });
     if (this._isLoaded && this.loaded) {
       return this.loaded;
@@ -169,18 +169,6 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
   initializeForNewEntity(): void {
     // Our codegen'd Opts type will ensure our field is inititalized if necessary/notNull
     this._isLoaded = true;
-  }
-
-  async refreshIfLoaded(): Promise<void> {
-    // TODO We should remember what load hints have been applied to this collection and re-apply them.
-    if (this._isLoaded) {
-      const current = this.current();
-      if (typeof current === "string") {
-        this.loaded = (await this.entity.em.load(this.otherMeta.cstr, current)) as any as U;
-      } else {
-        this.loaded = current;
-      }
-    }
   }
 
   maybeCascadeDelete(): void {

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -52,9 +52,9 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   }
 
   // opts is an internal parameter
-  async load(opts?: { withDeleted?: boolean }): Promise<readonly U[]> {
+  async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<readonly U[]> {
     ensureNotDeleted(this.entity, { ignore: "pending" });
-    if (this.loaded === undefined) {
+    if (this.loaded === undefined || opts.forceReload) {
       if (this.entity.id === undefined) {
         this.loaded = [];
       } else {
@@ -185,13 +185,6 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
       remove(this.loaded, other);
     } else {
       remove(this.addedBeforeLoaded, other);
-    }
-  }
-
-  async refreshIfLoaded(): Promise<void> {
-    // TODO We should remember what load hints have been applied to this collection and re-apply them.
-    if (this.loaded !== undefined && this.entity.id !== undefined) {
-      this.loaded = await oneToManyDataLoader(this.entity.em, this).load(this.entity.id);
     }
   }
 

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -121,9 +121,9 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
   }
 
   // opts is an internal parameter
-  async load(opts?: { withDeleted?: boolean }): Promise<U | undefined> {
+  async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<U | undefined> {
     ensureNotDeleted(this.entity, { ignore: "pending" });
-    if (!this._isLoaded) {
+    if (!this._isLoaded || opts.forceReload) {
       if (!this.entity.isNewEntity) {
         this.loaded = await oneToOneDataLoader(this.entity.em, this).load(this.entity.idOrFail);
       }
@@ -179,13 +179,6 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
 
   initializeForNewEntity(): void {
     this._isLoaded = true;
-  }
-
-  async refreshIfLoaded(): Promise<void> {
-    if (this._isLoaded) {
-      this._isLoaded = false;
-      await this.load();
-    }
   }
 
   maybeCascadeDelete(): void {

--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -87,11 +87,11 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
     );
   }
 
-  async load(opts?: { withDeleted?: boolean }): Promise<U | N> {
+  async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<U | N> {
     ensureNotDeleted(this.entity, { ignore: "pending" });
     const current = this.current();
     // Resolve the id to an entity
-    if (!isEntity(current) && current !== undefined) {
+    if (!isEntity(current) && current !== undefined && (!this._isLoaded || opts.forceReload)) {
       this.loaded = (await this.entity.em.load(getConstructorFromTaggedId(current), current)) as any as U;
     }
     this._isLoaded = true;
@@ -161,18 +161,6 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
   initializeForNewEntity(): void {
     // Our codegened Opts type will ensure our field is initialized if necessary/notNull
     this._isLoaded = true;
-  }
-
-  async refreshIfLoaded(): Promise<void> {
-    // TODO We should remember what load hints have been applied to this collection and re-apply them.
-    if (this._isLoaded) {
-      const current = this.current();
-      if (typeof current === "string") {
-        this.loaded = (await this.entity.em.load(getConstructorFromTaggedId(current), current)) as any as U;
-      } else {
-        this.loaded = current;
-      }
-    }
   }
 
   maybeCascadeDelete(): void {

--- a/packages/orm/src/relations/hasManyThrough.ts
+++ b/packages/orm/src/relations/hasManyThrough.ts
@@ -12,8 +12,8 @@ export function hasManyThrough<T extends Entity, U extends Entity>(
 ): Collection<T, U> {
   const entity: T = currentlyInstantiatingEntity as T;
   return new CustomCollection<T, U>(entity, {
-    load: async (entity) => {
-      await loadLens(entity, lens);
+    load: async (entity, opts) => {
+      await loadLens(entity, lens, opts);
     },
     get: () => getLens(entity, lens),
   });

--- a/packages/orm/src/relations/hasOneDerived.ts
+++ b/packages/orm/src/relations/hasOneDerived.ts
@@ -20,8 +20,8 @@ export function hasOneDerived<
 >(loadHint: H, get: (entity: Loaded<T, H>) => V): Reference<T, U, N> {
   const entity: T = currentlyInstantiatingEntity as T;
   return new CustomReference<T, U, N>(entity, {
-    load: async (entity) => {
-      await entity.em.populate(entity, loadHint);
+    load: async (entity, opts) => {
+      await entity.em.populate(entity, { hint: loadHint, ...opts });
     },
     get: () => get(entity as Loaded<T, H>),
   });

--- a/packages/orm/src/relations/hasOneThrough.ts
+++ b/packages/orm/src/relations/hasOneThrough.ts
@@ -12,8 +12,8 @@ export function hasOneThrough<T extends Entity, U extends Entity, N extends neve
 ): Reference<T, U, N> {
   const entity: T = currentlyInstantiatingEntity as T;
   return new CustomReference<T, U, N>(entity, {
-    load: async (entity) => {
-      await loadLens(entity, lens);
+    load: async (entity, opts) => {
+      await loadLens(entity, lens, opts);
     },
     get: () => getLens(entity, lens),
   });

--- a/packages/tests/schema-misc/src/entities/Author.factories.ts
+++ b/packages/tests/schema-misc/src/entities/Author.factories.ts
@@ -1,7 +1,7 @@
-import { FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, FactoryOpts, newTestInstance } from "joist-orm";
 import { EntityManager } from "src/entities";
 import { Author } from "./entities";
 
-export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): New<Author> {
+export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): DeepNew<Author> {
   return newTestInstance(em, Author, opts);
 }

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -136,9 +136,17 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Author>>(hint: H): Promise<Loaded<Author, H>>;
+  populate<H extends LoadHint<Author>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Author, H>>;
   populate<H extends LoadHint<Author>, V>(hint: H, fn: (a: Loaded<Author, H>) => V): Promise<V>;
-  populate<H extends LoadHint<Author>, V>(hint: H, fn?: (a: Loaded<Author, H>) => V): Promise<Loaded<Author, H> | V> {
-    return this.em.populate(this as any as Author, hint, fn);
+  populate<H extends LoadHint<Author>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (a: Loaded<Author, H>) => V,
+  ): Promise<V>;
+  populate<H extends LoadHint<Author>, V>(
+    hintOrOpts: any,
+    fn?: (a: Loaded<Author, H>) => V,
+  ): Promise<Loaded<Author, H> | V> {
+    return this.em.populate(this as any as Author, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {

--- a/packages/tests/schema-misc/src/entities/Book.factories.ts
+++ b/packages/tests/schema-misc/src/entities/Book.factories.ts
@@ -1,7 +1,7 @@
-import { FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, FactoryOpts, newTestInstance } from "joist-orm";
 import { EntityManager } from "src/entities";
 import { Book } from "./entities";
 
-export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): New<Book> {
+export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): DeepNew<Book> {
   return newTestInstance(em, Book, opts);
 }

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -116,9 +116,14 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Book>>(hint: H): Promise<Loaded<Book, H>>;
+  populate<H extends LoadHint<Book>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Book, H>>;
   populate<H extends LoadHint<Book>, V>(hint: H, fn: (b: Loaded<Book, H>) => V): Promise<V>;
-  populate<H extends LoadHint<Book>, V>(hint: H, fn?: (b: Loaded<Book, H>) => V): Promise<Loaded<Book, H> | V> {
-    return this.em.populate(this as any as Book, hint, fn);
+  populate<H extends LoadHint<Book>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (b: Loaded<Book, H>) => V,
+  ): Promise<V>;
+  populate<H extends LoadHint<Book>, V>(hintOrOpts: any, fn?: (b: Loaded<Book, H>) => V): Promise<Loaded<Book, H> | V> {
+    return this.em.populate(this as any as Book, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {

--- a/packages/tests/uuid-ids/src/entities/Author.factories.ts
+++ b/packages/tests/uuid-ids/src/entities/Author.factories.ts
@@ -1,6 +1,6 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { Author } from "./entities";
 
-export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): New<Author> {
+export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): DeepNew<Author> {
   return newTestInstance(em, Author, opts);
 }

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -136,9 +136,17 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Author>>(hint: H): Promise<Loaded<Author, H>>;
+  populate<H extends LoadHint<Author>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Author, H>>;
   populate<H extends LoadHint<Author>, V>(hint: H, fn: (a: Loaded<Author, H>) => V): Promise<V>;
-  populate<H extends LoadHint<Author>, V>(hint: H, fn?: (a: Loaded<Author, H>) => V): Promise<Loaded<Author, H> | V> {
-    return this.em.populate(this as any as Author, hint, fn);
+  populate<H extends LoadHint<Author>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (a: Loaded<Author, H>) => V,
+  ): Promise<V>;
+  populate<H extends LoadHint<Author>, V>(
+    hintOrOpts: any,
+    fn?: (a: Loaded<Author, H>) => V,
+  ): Promise<Loaded<Author, H> | V> {
+    return this.em.populate(this as any as Author, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {

--- a/packages/tests/uuid-ids/src/entities/Book.factories.ts
+++ b/packages/tests/uuid-ids/src/entities/Book.factories.ts
@@ -1,6 +1,6 @@
-import { EntityManager, FactoryOpts, New, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
 import { Book } from "./entities";
 
-export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): New<Book> {
+export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): DeepNew<Book> {
   return newTestInstance(em, Book, opts);
 }

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -132,9 +132,14 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
   }
 
   populate<H extends LoadHint<Book>>(hint: H): Promise<Loaded<Book, H>>;
+  populate<H extends LoadHint<Book>>(opts: { hint: H; forceReload?: boolean }): Promise<Loaded<Book, H>>;
   populate<H extends LoadHint<Book>, V>(hint: H, fn: (b: Loaded<Book, H>) => V): Promise<V>;
-  populate<H extends LoadHint<Book>, V>(hint: H, fn?: (b: Loaded<Book, H>) => V): Promise<Loaded<Book, H> | V> {
-    return this.em.populate(this as any as Book, hint, fn);
+  populate<H extends LoadHint<Book>, V>(
+    opts: { hint: H; forceReload?: boolean },
+    fn: (b: Loaded<Book, H>) => V,
+  ): Promise<V>;
+  populate<H extends LoadHint<Book>, V>(hintOrOpts: any, fn?: (b: Loaded<Book, H>) => V): Promise<Loaded<Book, H> | V> {
+    return this.em.populate(this as any as Book, hintOrOpts, fn);
   }
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {


### PR DESCRIPTION
Fixes #255 by:

* Adding a `DeepNew<T>` type that marks all relations as recursively loaded
* Add an `EntityManager.refresh({ deepLoad?: true })` that will crawl existing entities and recursively fully load any relation/entity we find
* Updating factories to return a `DeepNew<T>` version of their entity

This allows tests to use a `DeepNew` and, as long as they're either:

a) Working within only a single test EM where all entities are new and defacto fully loaded, or
b) Using `em.refresh({ deepLoad: true })` either directly or inside a `run`-style utility method

Then they can have sync access to any relation within an entity that is reachable.

I suppose as a downside, doing `refresh({ deepLoad: true })` _all the time_ in a widely-used utility method like `run` will result in more work being done to fully load literally any reachable relation, vs. previously relations merely within the UoW. But I don't think it should result in that much more work.