### PR TITLE
chore: Simplify toMatchEntity test's ANSI output.

### DIFF
--- a/packages/integration-tests/src/alignedAnsiStyleSerializer.ts
+++ b/packages/integration-tests/src/alignedAnsiStyleSerializer.ts
@@ -1,49 +1,10 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import ansiRegex = require("ansi-regex");
-import style = require("ansi-styles");
 import type { NewPlugin } from "pretty-format";
 
+/** Drop the colorized ANSI chars b/c we're not trying to test Jest colorization itself. */
 export const alignedAnsiStyleSerializer: NewPlugin = {
   serialize(val: string): string {
-    // Return the string itself, not escaped nor enclosed in double quote marks.
-    return val.replace(ansiRegex(), (match) => {
-      switch (match) {
-        case style.inverse.open:
-          return "<i>";
-        case style.inverse.close:
-          return "</i>";
-
-        case style.bold.open:
-          return "<b>";
-        case style.dim.open:
-          return "<d>";
-        case style.green.open:
-          return "<g>";
-        case style.red.open:
-          return "<r>";
-        case style.yellow.open:
-          return "<y>";
-        case style.bgYellow.open:
-          return "<Y>";
-
-        case style.bold.close:
-        case style.dim.close:
-        case style.green.close:
-        case style.red.close:
-        case style.yellow.close:
-        case style.bgYellow.close:
-          return "</>";
-
-        default:
-          return match; // unexpected escape sequence
-      }
-    });
+    return val.replace(ansiRegex(), "");
   },
   test(val: unknown): val is string {
     return typeof val === "string";

--- a/packages/integration-tests/src/toMatchEntity.test.ts
+++ b/packages/integration-tests/src/toMatchEntity.test.ts
@@ -34,15 +34,15 @@ describe("toMatchEntity", () => {
     const b1 = newBook(em, { author: a1 });
     await em.flush();
     await expect(expect(b1).toMatchEntity({ author: a2 })).rejects.toThrowErrorMatchingInlineSnapshot(`
-<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+expect(received).toMatchObject(expected)
 
-<g>- Expected  - 1</>
-<r>+ Received  + 1</>
+- Expected  - 1
++ Received  + 1
 
-<d>  Object {</>
-<g>-   "author": "a:2",</>
-<r>+   "author": "a:1",</>
-<d>  }</>
+  Object {
+-   "author": "a:2",
++   "author": "a:1",
+  }
 `);
   });
 
@@ -73,17 +73,17 @@ describe("toMatchEntity", () => {
     await em.flush();
     // Then it fails if we assert against only one
     await expect(expect(a1).toMatchEntity({ books: [b2] })).rejects.toThrowErrorMatchingInlineSnapshot(`
-<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+expect(received).toMatchObject(expected)
 
-<g>- Expected  - 0</>
-<r>+ Received  + 1</>
+- Expected  - 0
++ Received  + 1
 
-<d>  Object {</>
-<d>    "books": Array [</>
-<r>+     "b:1",</>
-<d>      "b:2",</>
-<d>    ],</>
-<d>  }</>
+  Object {
+    "books": Array [
++     "b:1",
+      "b:2",
+    ],
+  }
 `);
   });
 
@@ -97,17 +97,17 @@ describe("toMatchEntity", () => {
     await em.flush();
     // Then it fails if we include the extra book
     await expect(expect(a1).toMatchEntity({ books: [b1, b2] })).rejects.toThrowErrorMatchingInlineSnapshot(`
-<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+expect(received).toMatchObject(expected)
 
-<g>- Expected  - 1</>
-<r>+ Received  + 0</>
+- Expected  - 1
++ Received  + 0
 
-<d>  Object {</>
-<d>    "books": Array [</>
-<d>      "b:1",</>
-<g>-     "b:2",</>
-<d>    ],</>
-<d>  }</>
+  Object {
+    "books": Array [
+      "b:1",
+-     "b:2",
+    ],
+  }
 `);
   });
 
@@ -119,17 +119,17 @@ describe("toMatchEntity", () => {
     // And we don't flush
     // Then it fails if we assert against only one
     await expect(expect(a1).toMatchEntity({ books: [b2] })).rejects.toThrowErrorMatchingInlineSnapshot(`
-<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+expect(received).toMatchObject(expected)
 
-<g>- Expected  - 0</>
-<r>+ Received  + 1</>
+- Expected  - 0
++ Received  + 1
 
-<d>  Object {</>
-<d>    "books": Array [</>
-<r>+     "b#1",</>
-<d>      "b#2",</>
-<d>    ],</>
-<d>  }</>
+  Object {
+    "books": Array [
++     "b#1",
+      "b#2",
+    ],
+  }
 `);
   });
 


### PR DESCRIPTION
Remove all ANSI chars b/c we don't really need to assert against them,
and also when running `yarn test` as a top-level command, the ANSI
chars are not output for some reason, so the snapshots would fail.