### PR TITLE
feat: Add entity to validation errors.

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -27,7 +27,7 @@ describe("Author", () => {
     const em = newEntityManager();
     new Author(em, { firstName: "NotAllowedLastName", lastName: "NotAllowedLastName" });
     await expect(em.flush()).rejects.toThrow(
-      "Validation errors (2): firstName and lastName must be different, lastName is invalid",
+      "Validation errors (2): Author#1 firstName and lastName must be different, lastName is invalid",
     );
   });
 
@@ -35,7 +35,9 @@ describe("Author", () => {
     const em = newEntityManager();
     const a1 = new Author(em, { firstName: "a1" });
     new Book(em, { title: "a1", author: a1 });
-    await expect(em.flush()).rejects.toThrow("Validation error: A book title cannot be the author's firstName");
+    await expect(em.flush()).rejects.toThrow(
+      "Validation error: Author#1 A book title cannot be the author's firstName",
+    );
   });
 
   it("can have reactive validation rules", async () => {
@@ -47,7 +49,9 @@ describe("Author", () => {
     // When the book name is later changed to collide with the author
     b1.title = "a1";
     // Then the validation rule is ran even though it's on the author entity
-    await expect(em.flush()).rejects.toThrow("Validation error: A book title cannot be the author's firstName");
+    await expect(em.flush()).rejects.toThrow(
+      "Validation error: Author:1 A book title cannot be the author's firstName",
+    );
   });
 
   it("can have reactive validation fired on new child", async () => {
@@ -59,7 +63,7 @@ describe("Author", () => {
     const a1 = await em.load(Author, "1");
     const b1 = new Book(em, { title: "b1", author: a1 });
     // Then the Author validation rule fails
-    await expect(em.flush()).rejects.toThrow("An author cannot have 13 books");
+    await expect(em.flush()).rejects.toThrow("Author:1 An author cannot have 13 books");
   });
 
   it("can have reactive validation fired on deleted child", async () => {
@@ -419,7 +423,7 @@ describe("Author", () => {
     const em = newEntityManager();
     const a1 = await em.load(Author, "1");
     a1.lastName = "l2";
-    await expect(em.flush()).rejects.toThrow("Validation error: lastName cannot be changed");
+    await expect(em.flush()).rejects.toThrow("Validation error: Author:1 lastName cannot be changed");
   });
 
   it("can set new opts", async () => {
@@ -472,7 +476,7 @@ describe("Author", () => {
   it("gets not-null validation rules for free", async () => {
     const em = newEntityManager();
     em.createPartial(Author, {});
-    await expect(em.flush()).rejects.toThrow("Validation error: firstName is required");
+    await expect(em.flush()).rejects.toThrow("Validation error: Author#1 firstName is required");
   });
 
   it("has an index on the publisher_id foreign key", async () => {

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -18,6 +18,7 @@ export interface Entity {
   idTagged: string | undefined;
   idTaggedOrFail: string;
   idOrFail: string;
+  /** Joist internal metadata, should be considered a private implementation detail. */
   __orm: EntityOrmField;
   readonly em: EntityManager<any>;
   readonly isNewEntity: boolean;
@@ -27,6 +28,13 @@ export interface Entity {
   readonly isPendingDelete: boolean;
   set(opts: Partial<OptsOf<this>>): void;
   setPartial(values: PartialOrNull<OptsOf<this>>): void;
+  /**
+   * Returns `type:id`, i.e. `Author:1` for persisted entities and `Author#1` for new entities.
+   *
+   * This is meant to be used for developer-facing logging and debugging, and not a user-facing
+   * name / display name.
+   */
+  toString(): string;
 }
 
 /** The `__orm` metadata field we track on each instance. */

--- a/packages/orm/src/rules.ts
+++ b/packages/orm/src/rules.ts
@@ -1,7 +1,7 @@
 import { capitalCase } from "change-case";
 import { Changes, EntityChanges } from "./changes";
 import { Entity } from "./Entity";
-import { MaybePromise, maybePromiseThen } from "./utils";
+import { groupBy, MaybePromise, maybePromiseThen } from "./utils";
 
 /**
  * The return type of `ValidationRule`.
@@ -58,8 +58,11 @@ export function cannotBeUpdated<T extends Entity & EntityChanges<T>, K extends k
 
 function errorMessage(errors: ValidationError[]): string {
   if (errors.length === 1) {
-    return `Validation error: ${errors[0].message}`;
+    return `Validation error: ${errors[0].entity.toString()} ${errors[0].message}`;
   } else {
-    return `Validation errors (${errors.length}): ${errors.map((e) => e.message).join(", ")}`;
+    const message = [...groupBy(errors, (e) => e.entity.toString()).entries()]
+      .map(([entityToString, errors]) => `${entityToString} ${errors.map((e) => e.message).join(", ")}`)
+      .join(", ");
+    return `Validation errors (${errors.length}): ${message}`;
   }
 }


### PR DESCRIPTION
To faciliate debugging "wtf entity did this fail on?".

Note that ValidationError.message is not meant to be a user-facing
message (where as ValidationRuleResult.message is), so including
the tagged id is fine.