### PR TITLE
fix: Don't capital case field name.

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -582,6 +582,6 @@ describe("Author", () => {
     const em = newEntityManager();
     const a1 = await em.load(Author, "a:1");
     a1.age = 101;
-    await expect(em.flush()).rejects.toThrow("Age cannot be updated");
+    await expect(em.flush()).rejects.toThrow("Author:1 age cannot be updated");
   });
 });

--- a/packages/orm/src/rules.ts
+++ b/packages/orm/src/rules.ts
@@ -1,4 +1,3 @@
-import { capitalCase } from "change-case";
 import { Changes, EntityChanges } from "./changes";
 import { Entity } from "./Entity";
 import { groupBy, MaybePromise, maybePromiseThen } from "./utils";
@@ -47,7 +46,7 @@ export function cannotBeUpdated<T extends Entity & EntityChanges<T>, K extends k
     if (entity.changes[field].hasUpdated) {
       return maybePromiseThen(unless ? unless(entity) : false, (result) => {
         if (!result) {
-          return `${capitalCase(field)} cannot be updated`;
+          return `${field} cannot be updated`;
         }
         return undefined;
       });


### PR DESCRIPTION
This is admittedly solely for backwards compatibility for now; maybe
we'll do something fancier later.