### PR TITLE
feat: em.findGql support passing { ne: null } to nullable foreign keys

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -646,14 +646,16 @@ function generateGraphQLFilterFields(meta: EntityDbMetadata): Code[] {
   const pgEnums = meta.pgEnums.map(({ fieldName, enumType }) => {
     return code`${fieldName}?: ${EnumGraphQLFilter}<${enumType}>;`;
   });
-  const m2o = meta.manyToOnes.map(({ fieldName, otherEntity }) => {
-    return code`${fieldName}?: ${EntityGraphQLFilter}<${otherEntity.type}, ${otherEntity.idType}, ${GraphQLFilterOf}<${otherEntity.type}>>;`;
+  const m2o = meta.manyToOnes.map(({ fieldName, otherEntity, notNull }) => {
+    return code`${fieldName}?: ${EntityGraphQLFilter}<${otherEntity.type}, ${otherEntity.idType}, ${GraphQLFilterOf}<${
+      otherEntity.type
+    }>, ${nullOrNever(notNull)}>;`;
   });
   const o2o = meta.oneToOnes.map(({ fieldName, otherEntity }) => {
-    return code`${fieldName}?: ${EntityGraphQLFilter}<${otherEntity.type}, ${otherEntity.idType}, ${GraphQLFilterOf}<${otherEntity.type}>>;`;
+    return code`${fieldName}?: ${EntityGraphQLFilter}<${otherEntity.type}, ${otherEntity.idType}, ${GraphQLFilterOf}<${otherEntity.type}>, null | undefined>;`;
   });
   const polys = meta.polymorphics.map(({ fieldName, fieldType }) => {
-    return code`${fieldName}?: ${EntityGraphQLFilter}<${fieldType}, ${IdOf}<${fieldType}>, never>;`;
+    return code`${fieldName}?: ${EntityGraphQLFilter}<${fieldType}, ${IdOf}<${fieldType}>, never, null | undefined>;`;
   });
   return [...primitives, ...enums, ...pgEnums, ...m2o, ...o2o, ...polys];
 }

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -544,6 +544,16 @@ describe("EntityManager.queries", () => {
     expect(authors[0].firstName).toEqual("a2");
   });
 
+  it("can findGql by foreign key is not null", async () => {
+    await insertPublisher({ id: 1, name: "p1" });
+    await insertAuthor({ id: 2, first_name: "a1" });
+    await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
+    const em = newEntityManager();
+    const authors = await em.findGql(Author, { publisher: { ne: null } });
+    expect(authors.length).toEqual(1);
+    expect(authors[0].firstName).toEqual("a2");
+  });
+
   it("can find with GQL filters but still use hash declaration", async () => {
     await insertAuthor({ first_name: "a1", age: 1 });
     await insertAuthor({ first_name: "a2", age: 2 });

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -149,10 +149,10 @@ export interface AuthorGraphQLFilter {
   updatedAt?: ValueGraphQLFilter<Date>;
   favoriteColors?: EnumGraphQLFilter<Color>;
   favoriteShape?: EnumGraphQLFilter<FavoriteShape>;
-  mentor?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>>;
-  currentDraftBook?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>>;
-  publisher?: EntityGraphQLFilter<Publisher, PublisherId, GraphQLFilterOf<Publisher>>;
-  image?: EntityGraphQLFilter<Image, ImageId, GraphQLFilterOf<Image>>;
+  mentor?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, null | undefined>;
+  currentDraftBook?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>, null | undefined>;
+  publisher?: EntityGraphQLFilter<Publisher, PublisherId, GraphQLFilterOf<Publisher>, null | undefined>;
+  image?: EntityGraphQLFilter<Image, ImageId, GraphQLFilterOf<Image>, null | undefined>;
 }
 
 export interface AuthorOrder {

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -79,8 +79,8 @@ export interface BookAdvanceGraphQLFilter {
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
   status?: EnumGraphQLFilter<AdvanceStatus>;
-  book?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>>;
-  publisher?: EntityGraphQLFilter<Publisher, PublisherId, GraphQLFilterOf<Publisher>>;
+  book?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>, never>;
+  publisher?: EntityGraphQLFilter<Publisher, PublisherId, GraphQLFilterOf<Publisher>, never>;
 }
 
 export interface BookAdvanceOrder {

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -105,9 +105,9 @@ export interface BookGraphQLFilter {
   order?: ValueGraphQLFilter<number>;
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
-  author?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>>;
-  currentDraftAuthor?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>>;
-  image?: EntityGraphQLFilter<Image, ImageId, GraphQLFilterOf<Image>>;
+  author?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, never>;
+  currentDraftAuthor?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, null | undefined>;
+  image?: EntityGraphQLFilter<Image, ImageId, GraphQLFilterOf<Image>, null | undefined>;
 }
 
 export interface BookOrder {

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -79,8 +79,8 @@ export interface BookReviewGraphQLFilter {
   isPublic?: BooleanGraphQLFilter;
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
-  book?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>>;
-  comment?: EntityGraphQLFilter<Comment, CommentId, GraphQLFilterOf<Comment>>;
+  book?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>, never>;
+  comment?: EntityGraphQLFilter<Comment, CommentId, GraphQLFilterOf<Comment>, null | undefined>;
 }
 
 export interface BookReviewOrder {

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -72,7 +72,7 @@ export interface CommentGraphQLFilter {
   text?: ValueGraphQLFilter<string>;
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
-  parent?: EntityGraphQLFilter<CommentParent, IdOf<CommentParent>, never>;
+  parent?: EntityGraphQLFilter<CommentParent, IdOf<CommentParent>, never, null | undefined>;
 }
 
 export interface CommentOrder {

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -58,7 +58,7 @@ export interface CriticGraphQLFilter {
   name?: ValueGraphQLFilter<string>;
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
-  criticColumn?: EntityGraphQLFilter<CriticColumn, CriticColumnId, GraphQLFilterOf<CriticColumn>>;
+  criticColumn?: EntityGraphQLFilter<CriticColumn, CriticColumnId, GraphQLFilterOf<CriticColumn>, null | undefined>;
 }
 
 export interface CriticOrder {

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -59,7 +59,7 @@ export interface CriticColumnGraphQLFilter {
   name?: ValueGraphQLFilter<string>;
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
-  critic?: EntityGraphQLFilter<Critic, CriticId, GraphQLFilterOf<Critic>>;
+  critic?: EntityGraphQLFilter<Critic, CriticId, GraphQLFilterOf<Critic>, never>;
 }
 
 export interface CriticColumnOrder {

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -91,9 +91,9 @@ export interface ImageGraphQLFilter {
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
   type?: EnumGraphQLFilter<ImageType>;
-  author?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>>;
-  book?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>>;
-  publisher?: EntityGraphQLFilter<Publisher, PublisherId, GraphQLFilterOf<Publisher>>;
+  author?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, null | undefined>;
+  book?: EntityGraphQLFilter<Book, BookId, GraphQLFilterOf<Book>, null | undefined>;
+  publisher?: EntityGraphQLFilter<Publisher, PublisherId, GraphQLFilterOf<Publisher>, null | undefined>;
 }
 
 export interface ImageOrder {

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -116,7 +116,7 @@ export interface PublisherGraphQLFilter {
   updatedAt?: ValueGraphQLFilter<Date>;
   size?: EnumGraphQLFilter<PublisherSize>;
   type?: EnumGraphQLFilter<PublisherType>;
-  tag?: EntityGraphQLFilter<Tag, TagId, GraphQLFilterOf<Tag>>;
+  tag?: EntityGraphQLFilter<Tag, TagId, GraphQLFilterOf<Tag>, null | undefined>;
 }
 
 export interface PublisherOrder {

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -155,7 +155,7 @@ export type ValueGraphQLFilter<V> =
 export type EnumGraphQLFilter<V> = V[] | null | undefined;
 
 /** A GraphQL version of EntityFilter. */
-export type EntityGraphQLFilter<T, I, F> = T | I | I[] | F | { ne: T | I } | null | undefined;
+export type EntityGraphQLFilter<T, I, F, N> = T | I | I[] | F | { ne: T | I | N } | null | undefined;
 
 const operators = ["eq", "gt", "gte", "ne", "lt", "lte", "like", "ilike", "in"] as const;
 export type Operator = typeof operators[number];


### PR DESCRIPTION
Ensures that code such as this passes type checking:
```
const authors = await em.findGql(Author, { publisher: { ne: null } });
```