### PR TITLE
feat: [SC-15953] em.clone enhancements

### DIFF
--- a/packages/integration-tests/src/EntityManager.clone.test.ts
+++ b/packages/integration-tests/src/EntityManager.clone.test.ts
@@ -1,0 +1,270 @@
+import { insertAuthor } from "@src/entities/inserts";
+import { EntityConstructor, EntityManager } from "joist-orm";
+import { Author, Book, Comment, Image, ImageType, newAuthor, newBook, newPublisher, Publisher, Tag } from "./entities";
+import { newEntityManager } from "./setupDbTests";
+
+describe("EntityManager", () => {
+  it("can clone entities", async () => {
+    const em = newEntityManager();
+
+    // Given an entity
+    const p1 = newPublisher(em, { name: "p1" });
+    const a1 = new Author(em, { firstName: "a1", publisher: p1 });
+    await em.flush();
+
+    // When we clone that entity
+    const a2 = await em.clone(a1);
+    await em.flush();
+
+    // Then we expect the cloned entity to have the same properties as the original
+    expect(a2.firstName).toEqual(a1.firstName);
+    expect(a2.publisher.idOrFail).toEqual(p1.id);
+    expect(a2.id).not.toEqual(a1.id);
+    expect(await numberOf(em, Author, Publisher)).toEqual([2, 1]);
+    expect(p1.authors.get).toEqual([a1, a2]);
+  });
+
+  it("can clone entities and referenced entities", async () => {
+    const em = newEntityManager();
+
+    // Given an entity with a reference to another entity
+    const a1 = newAuthor(em, { firstName: "a1" });
+    const b1 = newBook(em, { title: "b1", author: a1 });
+    // And the author itself points to the book we'll clone
+    a1.currentDraftBook.set(b1);
+    await em.flush();
+
+    // When we clone that entity and its reference
+    const a2 = await em.clone(a1, { hint: "books" });
+    await em.flush();
+
+    // Then we expect the cloned entity to have a cloned copy of the original's reference
+    expect(a2.books.get[0].title).toEqual(b1.title);
+    // But the book is a different book
+    const [b2] = a2.books.get;
+    expect(b2).not.toBe(b1);
+    // And a2 got updated to point to its cloned book
+    expect(a2.currentDraftBook.get).toBe(b2);
+  });
+
+  it("cannot clone many-to-many references", async () => {
+    const em = newEntityManager();
+
+    // Given an entity with a reference to another entity with a many-to-many reference
+    const a1 = new Author(em, { firstName: "a1" });
+    const b1 = new Book(em, { title: "b1", author: a1 });
+    const t1 = new Tag(em, { name: "t1", books: [b1] });
+    await em.flush();
+
+    // When we clone that entity and its nested references, which include a many-to-many reference
+    const promise = em.clone(a1, { hint: { books: "tags" } });
+
+    // Then we expect the cloning to fail
+    await expect(promise).rejects.toThrow("Uncloneable relation: tags");
+  });
+
+  it("can clone nested references", async () => {
+    const em = newEntityManager();
+
+    // Given an entity with a reference to another entity with a one-to-one
+    const a1 = new Author(em, { firstName: "a1" });
+    const b1 = new Book(em, { title: "b1", author: a1 });
+    const i1 = new Image(em, { fileName: "11", type: ImageType.BookImage, book: b1 });
+    await em.flush();
+
+    // When we clone that entity and its nested references
+    const a2 = await em.clone(a1, { hint: { books: "image" } });
+    await em.flush();
+
+    // Then we expect the cloned entity to have cloned copies of all its nested references
+    const b2 = (await a2.books.load())[0];
+    const i2 = await b2.image.load();
+    expect(i2).toBeDefined();
+    expect(i2).not.toEqual(i1);
+    expect(i2?.fileName).toEqual(i1.fileName);
+    expect(i2?.type).toEqual(i1.type);
+    expect(await numberOf(em, Author, Book, Image)).toEqual([2, 2, 2]);
+  });
+
+  it("should only clone referenced entities when specified", async () => {
+    const em = newEntityManager();
+
+    // Given an entity with a reference to another entity
+    const a1 = new Author(em, { firstName: "a1", books: [newBook(em)] });
+    await em.flush();
+
+    // When we clone that entity and don't pass a populate hint for the reference
+    const a2 = await em.clone(a1);
+    await em.flush();
+
+    // Then we expect the cloned entity to have no references
+    expect(await a2.books.load()).toHaveLength(0);
+  });
+
+  it("can clone entities and report what has changed", async () => {
+    const em = newEntityManager();
+    // Given an entity
+    const p1 = newPublisher(em, { name: "p1" });
+    const a1 = new Author(em, { firstName: "a1", publisher: p1 });
+    await em.flush();
+    // When we clone that entity
+    const a2 = await em.clone(a1);
+    // Then it is new
+    expect(a2.isNewEntity).toBe(true);
+    // And all the fields look changed
+    expect(a2.changes.fields).toEqual([
+      "createdAt",
+      "updatedAt",
+      "firstName",
+      "publisher",
+      "initials",
+      "numberOfBooks",
+    ]);
+    // And if we revert the publisher
+    a2.publisher.set(undefined);
+    // Then it is no longer changed
+    expect(a2.changes.publisher.hasChanged).toBe(false);
+    expect(a2.changes.publisher.hasUpdated).toBe(false);
+    expect(a2.changes.publisher.originalValue).toBe(undefined);
+  });
+
+  it("can clone entities and report what has changed w/undefined m2o", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    // Given we load an existing entity
+    const a1 = await em.load(Author, "a:1");
+    // When we clone that entity
+    const a2 = await em.clone(a1);
+    // Then it is new
+    expect(a2.isNewEntity).toBe(true);
+    // And only the currently set fields look changed
+    expect(a2.changes.fields).toEqual([
+      "createdAt",
+      "updatedAt",
+      "firstName",
+      "initials",
+      "numberOfBooks",
+      "favoriteColors",
+    ]);
+    // And specifically the publisher is not changed
+    expect(a2.changes.publisher.hasChanged).toBe(false);
+    expect(a2.changes.publisher.hasUpdated).toBe(false);
+    expect(a2.changes.publisher.originalValue).toBe(undefined);
+  });
+
+  it("can clone polymorphic references", async () => {
+    const em = newEntityManager();
+    // Given an entity that is a polymorphic parent of two children
+    const a1 = newAuthor(em, { comments: [{}, {}] });
+    await em.flush();
+    // When we clone the entity
+    const a2 = await em.clone(a1, { hint: "comments" });
+    await em.flush();
+    // Then we expect the cloned entity to have cloned copies of all its nested references
+    expect(a2.comments.get.length).toBe(2);
+    expect(a2.comments.get[0].id).toBe("comment:3");
+    expect(a2.comments.get[1].id).toBe("comment:4");
+    expect(a2.comments.get[0].parent.get).toBe(a2);
+  });
+
+  it("can clone a collection of entities", async () => {
+    const em = newEntityManager();
+
+    // Given an author with 2 books, both of which have comments
+    const a1 = newAuthor(em, {
+      firstName: "a1",
+      books: [
+        { title: "b1", comments: [{ text: "Great book!" }] },
+        { title: "b2", comments: [{ text: "Ok book" }] },
+      ],
+    });
+    await em.flush();
+
+    // When I ask to clone just the books
+    const [b3, b4] = await em.clone(a1.books.get, {
+      hint: "comments",
+    });
+    await em.flush();
+
+    // Then we expect the author to now have 4 books
+    expect(a1.books.get).toHaveLength(4);
+    // and b3/b4 have the same titles as b1/b2, but be different entities
+    const [b1, b2] = a1.books.get;
+    expect(b3.title).toEqual(b1.title);
+    expect(b3).not.toEqual(b1);
+    expect(b4.title).toEqual(b2.title);
+    expect(b4).not.toEqual(b2);
+    // And only one author exists, and comments were also cloned
+    expect(await numberOf(em, Author, Book, Comment)).toEqual([1, 4, 4]);
+  });
+
+  it("calls postClone for each cloned entity", async () => {
+    const em = newEntityManager();
+
+    // Given an author with 2 books, both of which have comments
+    const a1 = newAuthor(em, {
+      firstName: "a1",
+      books: [
+        { title: "b1", comments: [{ text: "Great book!" }] },
+        { title: "b2", comments: [{ text: "Ok book" }] },
+      ],
+    });
+    await em.flush();
+    // When we clone the author
+    const postClone = jest.fn();
+    await em.clone(a1, { hint: { books: "comments" }, postClone });
+    // Then I expect `postClone` was called once for each entity to be cloned
+    expect(postClone).toHaveBeenCalledTimes(5);
+  });
+
+  describe("skipIf", () => {
+    it("can skip the main entity you asked to clone", async () => {
+      const em = newEntityManager();
+      // Given an entity to clone
+      const p1 = newPublisher(em, { name: "p1" });
+      await em.flush();
+      // When I attempt to clone it, but ask to skip the entity
+      await expect(em.clone(p1, { skipIf: (e) => e === p1 }))
+        // Then I expect it to fail
+        .rejects.toThrow("no entities were cloned given the provided option");
+    });
+
+    it("can skip cloning child entity trees", async () => {
+      const em = newEntityManager();
+
+      // Given an author with 2 books, both of which have comments
+      const a1 = newAuthor(em, {
+        firstName: "a1",
+        books: [
+          { title: "b1", comments: [{ text: "Great book!" }] },
+          { title: "b2", comments: [{ text: "Ok book" }] },
+        ],
+      });
+      await em.flush();
+
+      // When we clone the book, but ask to skip `b2`
+      const a2 = await em.clone(a1, {
+        hint: { books: "comments" },
+        // Skip B2, it is only Ok
+        skipIf: (e) => e instanceof Book && e.title === "b2",
+      });
+      await em.flush();
+
+      // Then we expect the cloned entity to have a cloned copy of the `b1` only
+      expect(a2.books.get).toHaveLength(1);
+      // But the book is a different book
+      expect(a2.books.get[0]).not.toBe(a1.books.get[0]);
+      // And only one comment entity was cloned
+      expect(await numberOf(em, Author, Book, Comment)).toEqual([2, 3, 3]);
+    });
+  });
+});
+
+async function numberOf(em: EntityManager, ...args: EntityConstructor<any>[]): Promise<number[]> {
+  return Promise.all(
+    args.map(async (ec) => {
+      const entities = await em.find(ec, {});
+      return entities.length;
+    }),
+  );
+}

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1,7 +1,6 @@
 import { AsyncLocalStorage } from "async_hooks";
 import DataLoader from "dataloader";
 import { Knex } from "knex";
-import { util } from "prettier";
 import { createOrUpdatePartial } from "./createOrUpdatePartial";
 import { findDataLoader } from "./dataloaders/findDataLoader";
 import { loadDataLoader } from "./dataloaders/loadDataLoader";
@@ -36,7 +35,6 @@ import { ManyToOneReferenceImpl, OneToOneReferenceImpl } from "./relations";
 import { JoinRow } from "./relations/ManyToManyCollection";
 import { combineJoinRows, createTodos, getTodo, Todo } from "./Todo";
 import { fail, MaybePromise, toArray } from "./utils";
-import skip = util.skip;
 
 export interface EntityConstructor<T> {
   new (em: EntityManager<any>, opts: any): T;


### PR DESCRIPTION
Enhancements to `em.clone` to allow for:
1) Optional `skipIf` function to avoid cloning an entity deep in the object graph if desired (ex: don't clone soft-deleted entities)
2) Optional `postClone` function to be called for each `original/clone` pair
3) Optional ability to pass an array of objects to be clones, instead of just 1