### PR TITLE
feat: Recalc all async derived fields on touch.

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -253,9 +253,25 @@ describe("Author", () => {
     // When we change the book
     b1.title = "b12";
     await em.flush();
-    // Then the author derived value is didn't change
+    // Then the author derived value didn't change
     expect(a1.numberOfBooks).toEqual(1);
     expect(a1.numberOfBooksCalcInvoked).toBe(1);
+  });
+
+  it("can force async derived values to recalc on touch", async () => {
+    const em = newEntityManager();
+    // Given an author with a book
+    const a1 = newAuthor(em, { firstName: "a1" });
+    await em.flush();
+    expect(a1.numberOfBooks).toEqual(0);
+    expect(a1.numberOfBooksCalcInvoked).toBe(1);
+    // When we touch the author
+    em.touch(a1);
+    await em.flush();
+    // Then the author derived value didn't change
+    expect(a1.numberOfBooks).toEqual(0);
+    // But it was called again
+    expect(a1.numberOfBooksCalcInvoked).toBe(2);
   });
 
   it("has async derived values triggered on both old and new value", async () => {

--- a/packages/orm/src/Todo.ts
+++ b/packages/orm/src/Todo.ts
@@ -29,6 +29,15 @@ export function createTodos(entities: Entity[]): Record<string, Todo> {
       } else {
         todo.updates.push(entity);
       }
+      // Force recalc all async fields if the user called em.touch
+      if (entity.__orm.isTouched) {
+        const { asyncFields } = todo;
+        if (!asyncFields.has(entity)) {
+          asyncFields.set(entity, new Set());
+        }
+        const set = asyncFields.get(entity)!;
+        Object.values(getMetadata(entity).config.__data.asyncDerivedFields).forEach(({ fn }) => set.add(fn));
+      }
     }
   }
   return todos;


### PR DESCRIPTION
I.e. if you need to fix bugs in the derived logic.