### PR TITLE
fix: Fix async derived fields not triggering from hook changes.

### DIFF
--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -49,6 +49,7 @@ export class Author extends AuthorCodegen {
   public mentorRuleInvoked = 0;
   public ageRuleInvoked = 0;
   public numberOfBooksCalcInvoked = 0;
+  public graduatedRuleInvoked = 0;
 
   /** Example of using populate within an entity on itself. */
   get withLoadedBooks(): Promise<Loaded<Author, "books">> {
@@ -127,6 +128,11 @@ config.addRule("books", (a) => {
 // Example of rule that is always run even if the field is not set
 config.addRule("mentor", (a) => {
   a.entity.mentorRuleInvoked++;
+});
+
+// Example of rule that is run when set-via-hook field runs
+config.addRule("graduated", (a) => {
+  a.entity.graduatedRuleInvoked++;
 });
 
 // Example of cannotBeUpdated


### PR DESCRIPTION
We need to run the hooks first, to see if they have any side effects,
and then detect which rules & async derived fields we need re-calc.

...granted, this begs the question of what about hooks that want to
observe the latest derived value? This is probably where we need a
DAG of hook/value dependencies and invoke them in topo order instead
of fixed.