### PR TITLE
feat: Add accessors to enum details.

### DIFF
--- a/packages/integration-tests/src/entities/AdvanceStatus.ts
+++ b/packages/integration-tests/src/entities/AdvanceStatus.ts
@@ -4,15 +4,47 @@ export enum AdvanceStatus {
   Paid = "PAID",
 }
 
-export type AdvanceStatusDetails = { id: number; code: AdvanceStatus; name: string };
+export type AdvanceStatusDetails = {
+  id: number;
+  code: AdvanceStatus;
+  name: string;
+  isPending: boolean;
+  isSigned: boolean;
+  isPaid: boolean;
+};
 
 const details: Record<AdvanceStatus, AdvanceStatusDetails> = {
-  [AdvanceStatus.Pending]: { id: 1, code: AdvanceStatus.Pending, name: "Pending" },
-  [AdvanceStatus.Signed]: { id: 2, code: AdvanceStatus.Signed, name: "Signed" },
-  [AdvanceStatus.Paid]: { id: 3, code: AdvanceStatus.Paid, name: "Paid" },
+  [AdvanceStatus.Pending]: {
+    id: 1,
+    code: AdvanceStatus.Pending,
+    name: "Pending",
+    isPending: true,
+    isSigned: false,
+    isPaid: false,
+  },
+  [AdvanceStatus.Signed]: {
+    id: 2,
+    code: AdvanceStatus.Signed,
+    name: "Signed",
+    isPending: false,
+    isSigned: true,
+    isPaid: false,
+  },
+  [AdvanceStatus.Paid]: {
+    id: 3,
+    code: AdvanceStatus.Paid,
+    name: "Paid",
+    isPending: false,
+    isSigned: false,
+    isPaid: true,
+  },
 };
 
 export const AdvanceStatuses = {
+  Pending: details[AdvanceStatus.Pending],
+  Signed: details[AdvanceStatus.Signed],
+  Paid: details[AdvanceStatus.Paid],
+
   getByCode(code: AdvanceStatus): AdvanceStatusDetails {
     return details[code];
   },

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -150,16 +150,12 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager> {
     return this.__orm.data["updatedAt"];
   }
 
-  get status(): AdvanceStatus {
-    return this.__orm.data["status"];
+  get status(): AdvanceStatusDetails {
+    return AdvanceStatuses.findByCode(this.__orm.data["status"])!;
   }
 
-  get statusDetails(): AdvanceStatusDetails {
-    return AdvanceStatuses.getByCode(this.status);
-  }
-
-  set status(status: AdvanceStatus) {
-    setField(this, "status", status);
+  set status(status: AdvanceStatusDetails) {
+    setField(this, "status", status?.code);
   }
 
   get isPending(): boolean {

--- a/packages/integration-tests/src/entities/Color.ts
+++ b/packages/integration-tests/src/entities/Color.ts
@@ -4,15 +4,47 @@ export enum Color {
   Blue = "BLUE",
 }
 
-export type ColorDetails = { id: number; code: Color; name: string };
+export type ColorDetails = {
+  id: number;
+  code: Color;
+  name: string;
+  isRed: boolean;
+  isGreen: boolean;
+  isBlue: boolean;
+};
 
 const details: Record<Color, ColorDetails> = {
-  [Color.Red]: { id: 1, code: Color.Red, name: "Red" },
-  [Color.Green]: { id: 2, code: Color.Green, name: "Green" },
-  [Color.Blue]: { id: 3, code: Color.Blue, name: "Blue" },
+  [Color.Red]: {
+    id: 1,
+    code: Color.Red,
+    name: "Red",
+    isRed: true,
+    isGreen: false,
+    isBlue: false,
+  },
+  [Color.Green]: {
+    id: 2,
+    code: Color.Green,
+    name: "Green",
+    isRed: false,
+    isGreen: true,
+    isBlue: false,
+  },
+  [Color.Blue]: {
+    id: 3,
+    code: Color.Blue,
+    name: "Blue",
+    isRed: false,
+    isGreen: false,
+    isBlue: true,
+  },
 };
 
 export const Colors = {
+  Red: details[Color.Red],
+  Green: details[Color.Green],
+  Blue: details[Color.Blue],
+
   getByCode(code: Color): ColorDetails {
     return details[code];
   },

--- a/packages/integration-tests/src/entities/Image.ts
+++ b/packages/integration-tests/src/entities/Image.ts
@@ -22,7 +22,7 @@ export class Image extends ImageCodegen {
       [ImageType.AuthorImage]: this.author,
       [ImageType.BookImage]: this.book,
       [ImageType.PublisherImage]: this.publisher,
-    }[this.type];
+    }[this.type.code];
   }
 }
 

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -170,16 +170,12 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager> {
     return this.__orm.data["updatedAt"];
   }
 
-  get type(): ImageType {
-    return this.__orm.data["type"];
+  get type(): ImageTypeDetails {
+    return ImageTypes.findByCode(this.__orm.data["type"])!;
   }
 
-  get typeDetails(): ImageTypeDetails {
-    return ImageTypes.getByCode(this.type);
-  }
-
-  set type(type: ImageType) {
-    setField(this, "type", type);
+  set type(type: ImageTypeDetails) {
+    setField(this, "type", type?.code);
   }
 
   get isBookImage(): boolean {

--- a/packages/integration-tests/src/entities/ImageType.ts
+++ b/packages/integration-tests/src/entities/ImageType.ts
@@ -11,6 +11,9 @@ export type ImageTypeDetails = {
   sortOrder: 100 | 200 | 300;
   visible: boolean;
   nickname: "book_image" | "author_image" | "publisher_image";
+  isBookImage: boolean;
+  isAuthorImage: boolean;
+  isPublisherImage: boolean;
 };
 
 const details: Record<ImageType, ImageTypeDetails> = {
@@ -18,6 +21,9 @@ const details: Record<ImageType, ImageTypeDetails> = {
     id: 1,
     code: ImageType.BookImage,
     name: "Book Image",
+    isBookImage: true,
+    isAuthorImage: false,
+    isPublisherImage: false,
     sortOrder: 100,
     visible: true,
     nickname: "book_image",
@@ -26,6 +32,9 @@ const details: Record<ImageType, ImageTypeDetails> = {
     id: 2,
     code: ImageType.AuthorImage,
     name: "Author Image",
+    isBookImage: false,
+    isAuthorImage: true,
+    isPublisherImage: false,
     sortOrder: 200,
     visible: true,
     nickname: "author_image",
@@ -34,6 +43,9 @@ const details: Record<ImageType, ImageTypeDetails> = {
     id: 3,
     code: ImageType.PublisherImage,
     name: "Publisher Image",
+    isBookImage: false,
+    isAuthorImage: false,
+    isPublisherImage: true,
     sortOrder: 300,
     visible: true,
     nickname: "publisher_image",
@@ -41,6 +53,10 @@ const details: Record<ImageType, ImageTypeDetails> = {
 };
 
 export const ImageTypes = {
+  BookImage: details[ImageType.BookImage],
+  AuthorImage: details[ImageType.AuthorImage],
+  PublisherImage: details[ImageType.PublisherImage],
+
   getByCode(code: ImageType): ImageTypeDetails {
     return details[code];
   },

--- a/packages/integration-tests/src/entities/Publisher.ts
+++ b/packages/integration-tests/src/entities/Publisher.ts
@@ -1,5 +1,5 @@
 import { Collection, CustomCollection, getEm, Loaded } from "joist-orm";
-import { Image, ImageType, ImageTypes, PublisherCodegen, publisherConfig as config } from "./entities";
+import { Image, ImageTypes, PublisherCodegen, publisherConfig as config } from "./entities";
 
 const allImagesHint = { images: [], authors: { image: [], books: "image" } } as const;
 
@@ -19,12 +19,12 @@ export class Publisher extends PublisherCodegen {
           [...loaded.images.get],
         )
         .filter((imageOrUndefined) => imageOrUndefined !== undefined)
-        .sort((a, b) => ImageTypes.findByCode(a.type)!.sortOrder - ImageTypes.findByCode(b.type)!.sortOrder);
+        .sort((a, b) => a.type.sortOrder - b.type.sortOrder);
     },
     add: (entity, value) => {
       const allImages = (entity as Loaded<Publisher, "allImages">).allImages;
       if (!allImages.get.includes(value)) {
-        value.type = ImageType.PublisherImage;
+        value.type = ImageTypes.PublisherImage;
         value.author.set(undefined);
         value.book.set(undefined);
         value.publisher.set(entity);

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -230,16 +230,12 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager> {
     return this.__orm.data["updatedAt"];
   }
 
-  get size(): PublisherSize | undefined {
-    return this.__orm.data["size"];
+  get size(): PublisherSizeDetails | undefined {
+    return PublisherSizes.findByCode(this.__orm.data["size"]);
   }
 
-  get sizeDetails(): PublisherSizeDetails | undefined {
-    return this.size ? PublisherSizes.getByCode(this.size) : undefined;
-  }
-
-  set size(size: PublisherSize | undefined) {
-    setField(this, "size", size);
+  set size(size: PublisherSizeDetails | undefined) {
+    setField(this, "size", size?.code);
   }
 
   get isSizeSmall(): boolean {
@@ -250,16 +246,12 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager> {
     return this.__orm.data["size"] === PublisherSize.Large;
   }
 
-  get type(): PublisherType {
-    return this.__orm.data["type"];
+  get type(): PublisherTypeDetails {
+    return PublisherTypes.findByCode(this.__orm.data["type"])!;
   }
 
-  get typeDetails(): PublisherTypeDetails {
-    return PublisherTypes.getByCode(this.type);
-  }
-
-  set type(type: PublisherType) {
-    setField(this, "type", type);
+  set type(type: PublisherTypeDetails) {
+    setField(this, "type", type?.code);
   }
 
   get isTypeSmall(): boolean {

--- a/packages/integration-tests/src/entities/PublisherSize.ts
+++ b/packages/integration-tests/src/entities/PublisherSize.ts
@@ -3,14 +3,35 @@ export enum PublisherSize {
   Large = "LARGE",
 }
 
-export type PublisherSizeDetails = { id: number; code: PublisherSize; name: string };
+export type PublisherSizeDetails = {
+  id: number;
+  code: PublisherSize;
+  name: string;
+  isSmall: boolean;
+  isLarge: boolean;
+};
 
 const details: Record<PublisherSize, PublisherSizeDetails> = {
-  [PublisherSize.Small]: { id: 1, code: PublisherSize.Small, name: "Small" },
-  [PublisherSize.Large]: { id: 2, code: PublisherSize.Large, name: "Large" },
+  [PublisherSize.Small]: {
+    id: 1,
+    code: PublisherSize.Small,
+    name: "Small",
+    isSmall: true,
+    isLarge: false,
+  },
+  [PublisherSize.Large]: {
+    id: 2,
+    code: PublisherSize.Large,
+    name: "Large",
+    isSmall: false,
+    isLarge: true,
+  },
 };
 
 export const PublisherSizes = {
+  Small: details[PublisherSize.Small],
+  Large: details[PublisherSize.Large],
+
   getByCode(code: PublisherSize): PublisherSizeDetails {
     return details[code];
   },

--- a/packages/integration-tests/src/entities/PublisherType.ts
+++ b/packages/integration-tests/src/entities/PublisherType.ts
@@ -3,14 +3,35 @@ export enum PublisherType {
   Big = "BIG",
 }
 
-export type PublisherTypeDetails = { id: number; code: PublisherType; name: string };
+export type PublisherTypeDetails = {
+  id: number;
+  code: PublisherType;
+  name: string;
+  isSmall: boolean;
+  isBig: boolean;
+};
 
 const details: Record<PublisherType, PublisherTypeDetails> = {
-  [PublisherType.Small]: { id: 1, code: PublisherType.Small, name: "Small" },
-  [PublisherType.Big]: { id: 2, code: PublisherType.Big, name: "Big" },
+  [PublisherType.Small]: {
+    id: 1,
+    code: PublisherType.Small,
+    name: "Small",
+    isSmall: true,
+    isBig: false,
+  },
+  [PublisherType.Big]: {
+    id: 2,
+    code: PublisherType.Big,
+    name: "Big",
+    isSmall: false,
+    isBig: true,
+  },
 };
 
 export const PublisherTypes = {
+  Small: details[PublisherType.Small],
+  Big: details[PublisherType.Big],
+
   getByCode(code: PublisherType): PublisherTypeDetails {
     return details[code];
   },

--- a/packages/integration-tests/src/toMatchEntity.test.ts
+++ b/packages/integration-tests/src/toMatchEntity.test.ts
@@ -1,5 +1,5 @@
 import { alignedAnsiStyleSerializer } from "@src/alignedAnsiStyleSerializer";
-import { newAuthor, newBook, newPublisher } from "@src/entities";
+import { AdvanceStatus, newAuthor, newBook, newBookAdvance, newPublisher } from "@src/entities";
 import { newEntityManager } from "./setupDbTests";
 
 expect.addSnapshotSerializer(alignedAnsiStyleSerializer as any);
@@ -10,6 +10,13 @@ describe("toMatchEntity", () => {
     const p1 = newPublisher(em);
     await em.flush();
     await expect(p1).toMatchEntity({ name: "Publisher 1" });
+  });
+
+  it("can match enum fields", async () => {
+    const em = newEntityManager();
+    const ba = newBookAdvance(em, { status: AdvanceStatus.Pending });
+    await em.flush();
+    await expect(ba).toMatchEntity({ status: AdvanceStatus.Pending });
   });
 
   it("can match references", async () => {

--- a/packages/orm/src/EntityMetadata.ts
+++ b/packages/orm/src/EntityMetadata.ts
@@ -66,7 +66,11 @@ export type EnumField = {
   fieldName: string;
   fieldIdName: undefined;
   required: boolean;
-  enumDetailType: { getValues(): ReadonlyArray<unknown> };
+  enumDetailType: {
+    getValues(): ReadonlyArray<unknown>;
+    getDetails(): ReadonlyArray<unknown>;
+    getByCode(code: string): unknown;
+  };
   serde: FieldSerde;
   immutable: boolean;
 };

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -106,7 +106,10 @@ export function newTestInstance<T extends Entity>(
         }
       } else if (field.kind === "enum" && field.required) {
         const codegenDefault = (cstr as any).defaultValues[field.fieldName];
-        return [fieldName, codegenDefault ?? field.enumDetailType.getValues()[0]];
+        return [
+          fieldName,
+          codegenDefault ? field.enumDetailType.getByCode(codegenDefault) : field.enumDetailType.getDetails()[0],
+        ];
       }
       return [];
     })
@@ -323,12 +326,15 @@ export function defaultValue<T>(): T {
  * ```typescript
  * export function newAuthor(em: Entity, opts: FactoryOpts<Author>) {
  *   return newTestInstance(em, Author, {
- *     // publisher is not technically required, but make one
+ *     // publisher is not technically required, but make one unless an "obvious default"
+ *     // instance already exists (either a `use` or one-and-only-one instance in the EM)
  *     publisher: maybeNew<Publisher>({}),
  *     ...opts,
  *   });
  * }
  * ```
+ *
+ * Vs. just doing `publisher: {}` which _always_ creates a new entity.
  */
 export function maybeNew<T extends Entity>(opts?: ActualFactoryOpts<T>): FactoryEntityOpt<T> {
   // Return a marker that resolveFactoryOpt will look for

--- a/packages/orm/src/rules.ts
+++ b/packages/orm/src/rules.ts
@@ -45,7 +45,9 @@ export class ValidationErrors extends Error {
  * This is added automatically by codegen to entities based on FK not-nulls.
  */
 export function newRequiredRule<T extends Entity>(key: keyof T & string): ValidationRule<T> {
-  return (entity) => (entity.__orm.data[key] === undefined ? `${key} is required` : undefined);
+  return (entity) => {
+    return entity.__orm.data[key] === undefined ? `${key} is required` : undefined;
+  };
 }
 
 /**

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -66,6 +66,9 @@ export async function toMatchEntity<T>(actual: Entity, expected: MatchedEntity<T
             clean[key] = maybeTestId(em, loaded);
           }
         }
+      } else if (isEnumDetails(value)) {
+        clean[key] = value?.code;
+        expected[key] = expected[key]?.code;
       } else {
         // Otherwise assume it's regular data. Probably need to handle getters/promises?
         clean[key] = value;
@@ -75,6 +78,10 @@ export async function toMatchEntity<T>(actual: Entity, expected: MatchedEntity<T
 
   // @ts-ignore
   return matchers.toMatchObject.call(this, clean, expected);
+}
+
+function isEnumDetails(value: any): boolean {
+  return value && typeof value === "object" && "code" in value && "name" in value;
 }
 
 function maybeTestId(em: EntityManager, maybeEntity: any): any {
@@ -102,5 +109,7 @@ export type MatchedEntity<T> = {
     ? MatchedEntity<U> | U
     : T[K] extends Collection<any, infer U>
     ? Array<MatchedEntity<U> | U>
+    : T[K] extends { code: infer C; name: string }
+    ? T[K] | C
     : T[K];
 };


### PR DESCRIPTION
And return the enum details from getters, so that
`task.status.isApproved` will work in field-level reactive
lambdas (i.e. because `task.isApproved` is not visible).