### PR TITLE
fix: Correct clearing of o2m/m2o fks when entity data references the entity instead of ids

### DIFF
--- a/packages/integration-tests/src/relations/OneToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/OneToManyCollection.test.ts
@@ -182,6 +182,22 @@ describe("OneToManyCollection", () => {
     expect(p1.authors.get.length).toEqual(0);
   });
 
+  it("removes deleted entities from other foreign key", async () => {
+    // Given an author with a publisher
+    await insertPublisher({ name: "p1" });
+    await insertAuthor({ first_name: "a1", publisher_id: 1 });
+    const em = newEntityManager();
+    // And the a1.publishers collection is loaded
+    const p1 = await em.load(Publisher, "1", "authors");
+    const a1 = p1.authors.get[0];
+    expect(p1.authors.get.length).toEqual(1);
+    // When we delete the publisher
+    em.delete(p1);
+    await em.flush();
+    // Then the author.publisher is cleared
+    expect(a1.publisher.isSet).toEqual(false);
+  });
+
   it("respects deleted entities before the collection loaded", async () => {
     // Given an author with a publisher
     await insertPublisher({ name: "p1" });

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -153,7 +153,7 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
   // Internal method used by OneToManyCollection
   setImpl(other: U | IdOf<U> | N): void {
     ensureNotDeleted(this.entity, { ignore: "pending" });
-    if (sameEntity(other, this.otherMeta, this.current())) {
+    if (sameEntity(other, this.otherMeta, this.current({ withDeleted: true }))) {
       return;
     }
 

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -199,7 +199,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     const current = await this.load({ withDeleted: true });
     current.forEach((other) => {
       const m2o = this.getOtherRelation(other);
-      if (maybeResolveReferenceToId(m2o.current()) === this.entity.id) {
+      if (maybeResolveReferenceToId(m2o.current({ withDeleted: true })) === this.entity.id) {
         // TODO What if other.otherFieldName is required/not-null?
         m2o.set(undefined);
       }


### PR DESCRIPTION
I've traced this down to the scenario when `this.entity.__orm.data[this.fieldName]` returns an actual entity instance, as opposed to just the ID of the referenced entity.

![image](https://user-images.githubusercontent.com/24765506/179326773-a6634e8f-8543-4c26-9edf-68bddb4fe8aa.png)
