### PR TITLE
fix: Check the other side's readonly for o2m/o2o reactive hints.

### DIFF
--- a/packages/integration-tests/src/entities/Book.ts
+++ b/packages/integration-tests/src/entities/Book.ts
@@ -4,6 +4,7 @@ export class Book extends BookCodegen {
   rulesInvoked = 0;
   firstNameRuleInvoked = 0;
   favoriteColorsRuleInvoked = 0;
+  reviewsRuleInvoked = 0;
 }
 
 config.addRule((book) => {
@@ -21,6 +22,11 @@ config.addRule({ author: ["favoriteColors", "firstName:ro"] }, (b) => {
     return `${b.author.get.firstName} has too many colors`;
   }
   b.entity.favoriteColorsRuleInvoked++;
+});
+
+// Example of a rule on reviews, where the BookReview.book is cannotBeUpdated
+config.addRule("reviews", (b) => {
+  b.entity.reviewsRuleInvoked++;
 });
 
 config.cascadeDelete("reviews");

--- a/packages/integration-tests/src/entities/BookReview.ts
+++ b/packages/integration-tests/src/entities/BookReview.ts
@@ -1,5 +1,5 @@
-import { hasOneDerived, hasOneThrough, Reference } from "joist-orm";
-import { Author, BookReviewCodegen, bookReviewConfig, Publisher } from "./entities";
+import { cannotBeUpdated, hasOneDerived, hasOneThrough, Reference } from "joist-orm";
+import { Author, BookReviewCodegen, bookReviewConfig as config, Publisher } from "./entities";
 
 export class BookReview extends BookReviewCodegen {
   // Currently this infers as Reference<BookReview, Author, undefined> --> it should be never...
@@ -14,7 +14,10 @@ export class BookReview extends BookReviewCodegen {
 }
 
 // Reviews are only public if the author is over the age of 21 and graduated (checking graduated b/c age is immutable)
-bookReviewConfig.setAsyncDerivedField("isPublic", { book: { author: ["age", "graduated"] } }, (review) => {
+config.setAsyncDerivedField("isPublic", { book: { author: ["age", "graduated"] } }, (review) => {
   const author = review.book.get.author.get;
   return !!author.age && author.age >= 21 && !!author.graduated;
 });
+
+// Example of cannotBeUpdated on a m2o so "it won't be reactive" (but really is b/c of creates & deletes)
+config.addRule(cannotBeUpdated("book"));

--- a/packages/integration-tests/src/getProperties.test.ts
+++ b/packages/integration-tests/src/getProperties.test.ts
@@ -15,6 +15,7 @@ describe("getProperties", () => {
       "rulesInvoked",
       "firstNameRuleInvoked",
       "favoriteColorsRuleInvoked",
+      "reviewsRuleInvoked",
     ]);
   });
 

--- a/packages/integration-tests/src/reactiveHints.test.ts
+++ b/packages/integration-tests/src/reactiveHints.test.ts
@@ -16,7 +16,7 @@ describe("reactiveHints", () => {
 
   it("can do grand-parent primitive field names", () => {
     expect(reverseReactiveHint(BookReview, { book: { author: ["firstName", "lastName"] } })).toEqual([
-      { entity: BookReview, fields: ["book"], path: [] },
+      { entity: BookReview, fields: [], path: [] },
       { entity: Book, fields: ["author"], path: ["reviews"] },
       { entity: Author, fields: ["firstName", "lastName"], path: ["books", "reviews"] },
     ]);
@@ -24,7 +24,7 @@ describe("reactiveHints", () => {
 
   it("can do parent and grand-parent primitive field names", () => {
     expect(reverseReactiveHint(BookReview, { book: { title: {}, author: ["firstName", "lastName"] } })).toEqual([
-      { entity: BookReview, fields: ["book"], path: [] },
+      { entity: BookReview, fields: [], path: [] },
       { entity: Book, fields: ["title", "author"], path: ["reviews"] },
       { entity: Author, fields: ["firstName", "lastName"], path: ["books", "reviews"] },
     ]);
@@ -79,7 +79,7 @@ describe("reactiveHints", () => {
       { entity: Author, fields: [], path: [] },
     ]);
     expect(reverseReactiveHint(BookReview, { book: "author:ro" })).toEqual([
-      { entity: BookReview, fields: ["book"], path: [] },
+      { entity: BookReview, fields: [], path: [] },
     ]);
   });
   describe("convertToLoadHint", () => {


### PR DESCRIPTION
The existing code was basically checking "is `Book.reviews` read only?" instead of checking "is `BookReviews.book` read only?"

This fixes that.

That said, we don't want these reactive hints for immutable fields to go _completely_ away, b/c they still need to fire on create & delete.

So really this PR is no change in semantics; b/c of the bug of checking the wrong read only, o2m/o2o reactive hints never took advantage of the immutable field optimization, but again we couldn't do that anyway b/c we need them for creates & deletes.

But, it's still nice to explicitly cover it, and drop the `book` field from the reactions file, just b/c it does stand out of "hey this field is immutable, so why am I reacting to it?".