### PR TITLE
feat: Rename TimestampConfig.optional to required.

### DIFF
--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -131,11 +131,11 @@ For example the following config looks for _only_ `updated_at` and `created_at` 
   "timestampFields": {
     "updatedAt": {
       "names": ["updated_at"],
-      "optional": false
+      "required": true
     },
     "createdAt": {
       "names": ["created_at"],
-      "optional": false
+      "required": true
     }
   }
 }
@@ -148,11 +148,11 @@ The default configuration is basically:
   "timestampFields": {
     "updatedAt": {
       "names": ["updated_at", "updatedAt"],
-      "optional": true
+      "required": false
     },
     "createdAt": {
       "names": ["created_at", "createdAt"],
-      "optional": true
+      "required": false
     }
   }
 }

--- a/docs/docs/getting-started/schema-assumptions.md
+++ b/docs/docs/getting-started/schema-assumptions.md
@@ -29,8 +29,8 @@ In `joist-codegen.json`, you can configure the names of the `timestampColumns`, 
 ```json
 {
   "timestampColumns": {
-    "createdAt": { "names": ["created_at", "createdAt"], "optional": true },
-    "updatedAt": { "names": ["updated_at", "updatedAt"], "optional": true }
+    "createdAt": { "names": ["created_at", "createdAt"], "required": false },
+    "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   }
 }
 ```
@@ -40,8 +40,8 @@ For example, if you want to strictly require `created_at` and `updated_at` on al
 ```json
 {
   "timestampColumns": {
-    "createdAt": { "names": ["created_at"], "optional": false },
-    "updatedAt": { "names": ["updated_at"], "optional": false }
+    "createdAt": { "names": ["created_at"], "required": true },
+    "updatedAt": { "names": ["updated_at"], "required": true }
   }
 }
 ```

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -27,7 +27,7 @@ export interface TimestampConfig {
   /** The names to check for this timestamp, i.e. `created_at` `created`, etc. */
   names: string[];
   /** Whether this timestamp column is required to consider a table an entity, defaults to `false`. */
-  optional?: boolean;
+  required?: boolean;
 }
 
 export interface Config {
@@ -146,12 +146,12 @@ export function getTimestampConfig(config: Config): {
   return {
     createdAtConf: {
       names: ["created_at", "createdAt"],
-      optional: true,
+      required: false,
       ...config?.timestampColumns?.createdAt,
     },
     updatedAtConf: {
       names: ["updated_at", "updatedAt"],
-      optional: true,
+      required: false,
       ...config?.timestampColumns?.updatedAt,
     },
   };

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -29,7 +29,7 @@ export function isEntityTable(config: Config, t: Table): boolean {
     }
   }
 
-  return idMatch && (hasCreatedAt || createdAtConf.optional) && (hasUpdatedAt || updatedAtConf.optional);
+  return idMatch && (hasCreatedAt || !createdAtConf.required) && (hasUpdatedAt || !updatedAtConf.required);
 }
 
 export function isEnumTable(config: Config, t: Table): boolean {

--- a/packages/tests/schema-misc/joist-codegen.json
+++ b/packages/tests/schema-misc/joist-codegen.json
@@ -10,7 +10,7 @@
   "entitiesDirectory": "./src/entities",
   "ignoredTables": ["pgmigrations"],
   "timestampColumns": {
-    "createdAt": { "names": ["created_at", "createdAt"], "optional": true },
-    "updatedAt": { "names": ["updated_at", "updatedAt"], "optional": true }
+    "createdAt": { "names": ["created_at", "createdAt"], "required": false },
+    "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   }
 }


### PR DESCRIPTION
It's more intuitive to read "required: true" than flip the double
native of "optional: false".