### PR TITLE
fix: Fix filtering on an entity list for IN.

### DIFF
--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -198,6 +198,17 @@ describe("EntityManager.queries", () => {
     expect(authors[0].firstName).toEqual("a2");
   });
 
+  it("can find by foreign key is entity list", async () => {
+    await insertPublisher({ id: 1, name: "p1" });
+    await insertAuthor({ id: 2, first_name: "a1" });
+    await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
+    const em = newEntityManager();
+    const publisher = await em.load(Publisher, "p:1");
+    const authors = await em.find(Author, { publisher: [publisher] });
+    expect(authors.length).toEqual(1);
+    expect(authors[0].firstName).toEqual("a2");
+  });
+
   it("can find by foreign key is tagged flavor", async () => {
     await insertPublisher({ id: 1, name: "p1" });
     await insertAuthor({ id: 2, first_name: "a1" });

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -94,7 +94,7 @@ export function parseValueFilter<V>(filter: ValueFilter<V, any>): ParsedValueFil
 }
 
 // For filtering by a foreign key T, i.e. either joining/recursing into with FilterQuery<T>, or matching it is null/not null/etc.
-export type EntityFilter<T, I, F, N> = T | I | I[] | F | N | { ne: T | I | N };
+export type EntityFilter<T, I, F, N> = T | T[] | I | I[] | F | N | { ne: T | I | N };
 
 export type ParsedEntityFilter =
   | { kind: "eq"; id: number | null }


### PR DESCRIPTION
The code already worked b/c of how `QueryBuilder` was calling `column.mapToDb(entity)`. 