### PR TITLE
feat: Allow passing Loaded to functions that accept Reacted.

### DIFF
--- a/packages/integration-tests/src/reactiveHints.test.ts
+++ b/packages/integration-tests/src/reactiveHints.test.ts
@@ -165,5 +165,24 @@ describe("reactiveHints", () => {
       const b3e: Reacted<Book, { author: { publisher: "name"; firstName_ro: {} } }> = null!;
       console.log(b3e.author.get.firstName, b3e.author.get.publisher.get!.name);
     }
+
+    function passLoadedToReacted() {
+      // Given a function that wants a Reacted subview of Author
+      function calcAuthor(author: Reacted<Author, { firstName: {}; books: "title" }>): void {}
+      // When we have a Loaded author
+      const a1: Loaded<Author, "books"> = null!;
+      // Then we can call it
+      calcAuthor(a1);
+    }
+
+    function cannotPassPartiallyLoadedToReacted() {
+      // Given a function that wants a Reacted subview of Author
+      function calcAuthor(author: Reacted<Author, { firstName: {}; books: "title" }>): void {}
+      // When we have a Loaded author, but books is not loaded
+      const a1: Loaded<Author, "publisher"> = null!;
+      // Then we cannot call it
+      // @ts-expect-error
+      calcAuthor(a1);
+    }
   });
 });

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -20,6 +20,10 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
   abstract id: string | undefined;
   abstract idTagged: string | undefined;
   readonly __orm: EntityOrmField;
+  // This gives rules a way to access the fully typed object instead of their Reacted view.
+  // And we make it public so that a function that takes Reacted<...> can accept a Loaded<...>
+  // that sufficiently overlaps.
+  readonly entity: this;
 
   protected constructor(em: EntityManager, metadata: any, defaultValues: object, opts: any) {
     this.__orm = { em, metadata, data: { ...defaultValues }, originalData: {}, isNew: true, isTouched: false };
@@ -29,8 +33,7 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
       this.__orm.isNew = false;
     }
     em.register(metadata, this);
-    // This gives rules a way to access the fully typed object instead of their Reacted view
-    (this as any).entity = this;
+    this.entity = this;
   }
 
   get idUntagged(): string | undefined {


### PR DESCRIPTION
The Reacted type is stricter than Loaded, b/c it is a field-level
subview of the entity, but that means since Loaded is a superset
of Reacted, we should be able to pass a Loaded entity to a function
that accepts Reacted.