### PR TITLE
feat: Add EntityManager.loadLens.

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -689,7 +689,7 @@ describe("EntityManager", () => {
     const flushPromise = em.flush();
     await delay(0);
     expect(() => p1.authors.add(a1)).toThrow(
-      "Cannot set 'publisher' on Author#1 during a flush outside of a entity hook or from afterCommit",
+      /Cannot set 'publisher' on Author[:#]1 during a flush outside of a entity hook or from afterCommit/,
     );
     await flushPromise;
   });
@@ -1305,9 +1305,9 @@ describe("EntityManager", () => {
     // Given two books with the same publisher
     const em = newEntityManager();
     const p = newPublisher(em);
-    const b1 = newBook(em, { author: { publisher: p } }) as Book;
-    const b2 = newBook(em, { author: { publisher: p } }) as Book;
-    const b3 = newBook(em, { author: {} }) as Book;
+    const b1 = newBook(em, { author: { publisher: p } });
+    const b2 = newBook(em, { author: { publisher: p } });
+    const b3 = newBook(em, { author: {} });
     // When we use loadLens to find publishers
     const publishers = await em.loadLens([b1, b2], (b) => b.author.publisher);
     // Then we got the publisher back
@@ -1318,6 +1318,7 @@ describe("EntityManager", () => {
     // Given two books with the same publisher
     const em = newEntityManager();
     const p = newPublisher(em);
+    // And we use `as Book` to get rid of DeepLoaded to ensure the `authors.get` is added by loadLens itself
     const b1 = newBook(em, { author: { publisher: p } }) as Book;
     const b2 = newBook(em, { author: { publisher: p } }) as Book;
     // When we use loadLens to find publishers
@@ -1325,7 +1326,7 @@ describe("EntityManager", () => {
     // Then we got the publisher back
     expect(publishers).toEqual([p]);
     // And we can get the authors
-    expect(publishers[0].authors.get.length).toBe(1);
+    expect(publishers[0].authors.get.length).toBe(2);
   });
 });
 

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -13,7 +13,17 @@ import {
   update,
 } from "@src/entities/inserts";
 import { Loaded, sameEntity, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
-import { Author, authorMeta, Book, Color, newAuthor, Publisher, PublisherSize } from "./entities";
+import {
+  Author,
+  authorMeta,
+  Book,
+  Color,
+  newAuthor,
+  newBook,
+  newPublisher,
+  Publisher,
+  PublisherSize,
+} from "./entities";
 import { knex, maybeBeginAndCommit, newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
 
 describe("EntityManager", () => {
@@ -1289,6 +1299,18 @@ describe("EntityManager", () => {
     expect(await countOfAuthors()).toBe(0);
     expect(await countOfBooks()).toBe(0);
     expect(await countOfBookReviews()).toBe(0);
+  });
+
+  it("can load via lens", async () => {
+    // Given two books with the same publisher
+    const em = newEntityManager();
+    const p = newPublisher(em);
+    const b1 = newBook(em, { author: { publisher: p } });
+    const b2 = newBook(em, { author: { publisher: p } });
+    // When we use loadLens to find publishers
+    const publishers = await em.loadLens([b1, b2], (b) => b.author.publisher);
+    // Then we got the publisher back
+    expect(publishers).toEqual([p]);
   });
 });
 

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1305,12 +1305,27 @@ describe("EntityManager", () => {
     // Given two books with the same publisher
     const em = newEntityManager();
     const p = newPublisher(em);
-    const b1 = newBook(em, { author: { publisher: p } });
-    const b2 = newBook(em, { author: { publisher: p } });
+    const b1 = newBook(em, { author: { publisher: p } }) as Book;
+    const b2 = newBook(em, { author: { publisher: p } }) as Book;
+    const b3 = newBook(em, { author: {} }) as Book;
     // When we use loadLens to find publishers
     const publishers = await em.loadLens([b1, b2], (b) => b.author.publisher);
     // Then we got the publisher back
     expect(publishers).toEqual([p]);
+  });
+
+  it("can load via lens and populate", async () => {
+    // Given two books with the same publisher
+    const em = newEntityManager();
+    const p = newPublisher(em);
+    const b1 = newBook(em, { author: { publisher: p } }) as Book;
+    const b2 = newBook(em, { author: { publisher: p } }) as Book;
+    // When we use loadLens to find publishers
+    const publishers = await em.loadLens([b1, b2], (b) => b.author.publisher, "authors");
+    // Then we got the publisher back
+    expect(publishers).toEqual([p]);
+    // And we can get the authors
+    expect(publishers[0].authors.get.length).toBe(1);
   });
 });
 

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -549,8 +549,22 @@ export class EntityManager<C = {}> {
    * Results are unique, i.e. if doing `em.loadLens([b1, b2], b => b.author.publisher)` point to the
    * same `Publisher`, it will only be returned as a single value.
    */
-  public async loadLens<T extends Entity, U, V>(entities: T[], fn: (lens: Lens<T>) => Lens<U, V>): Promise<V> {
-    return loadLens(entities, fn);
+  public async loadLens<T extends Entity, U, V>(entities: T[], fn: (lens: Lens<T>) => Lens<U, V>): Promise<U[]>;
+  public async loadLens<T extends Entity, U extends Entity, V, H extends LoadHint<U>>(
+    entities: T[],
+    fn: (lens: Lens<T>) => Lens<U, V>,
+    populate: Const<H>,
+  ): Promise<Loaded<U, H>[]>;
+  public async loadLens<T extends Entity, U, V>(
+    entities: T[],
+    fn: (lens: Lens<T>) => Lens<U, V>,
+    populate?: any,
+  ): Promise<V> {
+    const result = await loadLens(entities, fn);
+    if (populate) {
+      await this.populate(result as any as Entity[], populate);
+    }
+    return result;
   }
 
   /** Loads entities from a knex QueryBuilder. */

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -20,6 +20,8 @@ import {
   getMetadata,
   getRelations,
   keyToString,
+  Lens,
+  loadLens,
   ManyToOneFieldStatus,
   OneToManyCollection,
   PartialOrNull,
@@ -539,6 +541,16 @@ export class EntityManager<C = {}> {
       await this.populate(entities as T[], hint);
     }
     return entities as T[];
+  }
+
+  /**
+   * Loads entities found, when starting at `entities`, via the "path" given by the `fn` lens function.
+   *
+   * Results are unique, i.e. if doing `em.loadLens([b1, b2], b => b.author.publisher)` point to the
+   * same `Publisher`, it will only be returned as a single value.
+   */
+  public async loadLens<T extends Entity, U, V>(entities: T[], fn: (lens: Lens<T>) => Lens<U, V>): Promise<V> {
+    return loadLens(entities, fn);
   }
 
   /** Loads entities from a knex QueryBuilder. */

--- a/packages/orm/src/loadLens.ts
+++ b/packages/orm/src/loadLens.ts
@@ -50,7 +50,7 @@ export type Lens<T, R = T> = {
 // subclass itself, so we use the codegen hammer in our subclass to force the right Lens type
 // in a .load stub that just calls us for the implementation.
 export async function loadLens<T, U, V>(
-  start: T,
+  start: T | T[],
   fn: (lens: Lens<T>) => Lens<U, V>,
   opts: { forceReload?: boolean } = {},
 ): Promise<V> {


### PR DESCRIPTION
This allows applying a lens-based navigation to multiple starting
entities, instead of a single entity via `Entity.load`, i.e.:

```
const publishers = await em.loadLens(books, b => b.author.publisher);
```

Vs. today you can only use the `b => b.author.publisher` syntax if you're
starting at a single book and do `await book.load(b => ...)`.