### PR TITLE
feat: Add PersistedAsyncProperty for derived async fields.

### DIFF
--- a/docs/docs/modeling/derived-fields.md
+++ b/docs/docs/modeling/derived-fields.md
@@ -63,7 +63,7 @@ export class Author {
 
 This getter will be automatically called by Joist during any `INSERT` or `UPDATE` of `Author`, to determine the latest value.
 
-Because of this, synchronous persisted derived fields should be cheap to calculate. 
+Because of this, synchronous persisted derived fields should be cheap to calculate.
 
 ## Asynchronous, Unpersisted Fields
 
@@ -101,12 +101,18 @@ For async, persisted fields, there will be a column in the database to hold the 
 }
 ```
 
-And then configure it via a call to the `config` API:
+And then implement it in the `Author` domain model:
 
 ```typescript
-authorConfig.setAsyncDerivedField("numberOfBooks", "books", (author) => {
-  return author.books.get.length;
-});
+import { DerivedAsyncProperty, hasDerivedAsyncProperty } from "joist-orm";
+
+class Author extends AuthorCodegen {
+  readonly numberOfBooks: DerivedAsyncProperty<Author, number> = hasDerivedAsyncProperty(
+    "numberOfBooks",
+    "books",
+    (author) => author.books.get.length,
+  );
+}
 ```
 
 Joist will call this lambda:
@@ -121,4 +127,3 @@ For example, in this scenario:
 const a1 = await em.load(Author, "a:1");
 const a2 = await em.load(Author, "a:2");
 ```
-

--- a/docs/docs/modeling/derived-fields.md
+++ b/docs/docs/modeling/derived-fields.md
@@ -104,10 +104,10 @@ For async, persisted fields, there will be a column in the database to hold the 
 And then implement it in the `Author` domain model:
 
 ```typescript
-import { DerivedAsyncProperty, hasDerivedAsyncProperty } from "joist-orm";
+import { PersistedAsyncProperty, hasPersistedAsyncProperty } from "joist-orm";
 
 class Author extends AuthorCodegen {
-  readonly numberOfBooks: DerivedAsyncProperty<Author, number> = hasDerivedAsyncProperty(
+  readonly numberOfBooks: PersistedAsyncProperty<Author, number> = hasPersistedAsyncProperty(
     "numberOfBooks",
     "books",
     (author) => author.books.get.length,

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -9,6 +9,7 @@ import {
   Changes,
   Collection,
   ConfigApi,
+  DerivedAsyncProperty,
   deTagId,
   Entity,
   EntityConstructor,
@@ -67,12 +68,7 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
     let getter: Code;
     if (p.derived === "async") {
       getter = code`
-        get ${fieldName}(): ${fieldType}${maybeOptional} {
-          if (!("${fieldName}" in this.__orm.data)) {
-            throw new Error("${fieldName} has not been derived yet");
-          }
-          return this.__orm.data["${fieldName}"];
-        }
+        abstract readonly ${fieldName}: ${DerivedAsyncProperty}<${entity.name}, ${p.fieldType}>;
      `;
     } else if (p.derived === "sync") {
       getter = code`

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -9,7 +9,7 @@ import {
   Changes,
   Collection,
   ConfigApi,
-  DerivedAsyncProperty,
+  PersistedAsyncProperty,
   deTagId,
   Entity,
   EntityConstructor,
@@ -68,7 +68,7 @@ export function generateEntityCodegenFile(config: Config, meta: EntityDbMetadata
     let getter: Code;
     if (p.derived === "async") {
       getter = code`
-        abstract readonly ${fieldName}: ${DerivedAsyncProperty}<${entity.name}, ${p.fieldType}>;
+        abstract readonly ${fieldName}: ${PersistedAsyncProperty}<${entity.name}, ${p.fieldType}>;
      `;
     } else if (p.derived === "sync") {
       getter = code`

--- a/packages/codegen/src/symbols.ts
+++ b/packages/codegen/src/symbols.ts
@@ -65,3 +65,4 @@ export const FactoryOpts = imp("FactoryOpts@joist-orm");
 export const SSAssert = imp("assert@superstruct");
 export const EntityConstructor = imp("EntityConstructor@joist-orm");
 export const deTagId = imp("deTagId@joist-orm");
+export const DerivedAsyncProperty = imp("DerivedAsyncProperty@joist-orm");

--- a/packages/codegen/src/symbols.ts
+++ b/packages/codegen/src/symbols.ts
@@ -65,4 +65,4 @@ export const FactoryOpts = imp("FactoryOpts@joist-orm");
 export const SSAssert = imp("assert@superstruct");
 export const EntityConstructor = imp("EntityConstructor@joist-orm");
 export const deTagId = imp("deTagId@joist-orm");
-export const DerivedAsyncProperty = imp("DerivedAsyncProperty@joist-orm");
+export const PersistedAsyncProperty = imp("PersistedAsyncProperty@joist-orm");

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -2,13 +2,13 @@ import {
   AsyncProperty,
   cannotBeUpdated,
   Collection,
-  DerivedAsyncProperty,
   getEm,
   hasAsyncProperty,
-  hasDerivedAsyncProperty,
   hasManyDerived,
   hasManyThrough,
+  hasPersistedAsyncProperty,
   Loaded,
+  PersistedAsyncProperty,
 } from "joist-orm";
 import { AuthorCodegen, authorConfig as config, Book, BookReview } from "./entities";
 
@@ -88,7 +88,7 @@ export class Author extends AuthorCodegen {
   }
 
   /** Example of a derived async property that can be calculated via a populate hint. */
-  readonly numberOfBooks: DerivedAsyncProperty<Author, number> = hasDerivedAsyncProperty(
+  readonly numberOfBooks: PersistedAsyncProperty<Author, number> = hasPersistedAsyncProperty(
     "numberOfBooks",
     "books",
     (a) => {

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -5,7 +5,6 @@ import {
   Changes,
   Collection,
   ConfigApi,
-  DerivedAsyncProperty,
   EntityFilter,
   EntityGraphQLFilter,
   EntityOrmField,
@@ -30,6 +29,7 @@ import {
   OptsOf,
   OrderBy,
   PartialOrNull,
+  PersistedAsyncProperty,
   setField,
   setOpts,
   ValueFilter,
@@ -263,7 +263,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
 
   abstract get initials(): string;
 
-  abstract readonly numberOfBooks: DerivedAsyncProperty<Author, number>;
+  abstract readonly numberOfBooks: PersistedAsyncProperty<Author, number>;
 
   get isPopular(): boolean | undefined {
     return this.__orm.data["isPopular"];

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -5,6 +5,7 @@ import {
   Changes,
   Collection,
   ConfigApi,
+  DerivedAsyncProperty,
   EntityFilter,
   EntityGraphQLFilter,
   EntityOrmField,
@@ -262,12 +263,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
 
   abstract get initials(): string;
 
-  get numberOfBooks(): number {
-    if (!("numberOfBooks" in this.__orm.data)) {
-      throw new Error("numberOfBooks has not been derived yet");
-    }
-    return this.__orm.data["numberOfBooks"];
-  }
+  abstract readonly numberOfBooks: DerivedAsyncProperty<Author, number>;
 
   get isPopular(): boolean | undefined {
     return this.__orm.data["isPopular"];

--- a/packages/integration-tests/src/entities/BookReview.ts
+++ b/packages/integration-tests/src/entities/BookReview.ts
@@ -1,4 +1,11 @@
-import { cannotBeUpdated, hasOneDerived, hasOneThrough, Reference } from "joist-orm";
+import {
+  cannotBeUpdated,
+  DerivedAsyncProperty,
+  hasDerivedAsyncProperty,
+  hasOneDerived,
+  hasOneThrough,
+  Reference,
+} from "joist-orm";
 import { Author, BookReviewCodegen, bookReviewConfig as config, Publisher } from "./entities";
 
 export class BookReview extends BookReviewCodegen {
@@ -11,13 +18,17 @@ export class BookReview extends BookReviewCodegen {
     { book: { author: "publisher" } },
     (review) => review.book.get.author.get.publisher.get,
   );
-}
 
-// Reviews are only public if the author is over the age of 21 and graduated (checking graduated b/c age is immutable)
-config.setAsyncDerivedField("isPublic", { book: { author: ["age", "graduated"] } }, (review) => {
-  const author = review.book.get.author.get;
-  return !!author.age && author.age >= 21 && !!author.graduated;
-});
+  // Reviews are only public if the author is over the age of 21 and graduated (checking graduated b/c age is immutable)
+  readonly isPublic: DerivedAsyncProperty<BookReview, boolean> = hasDerivedAsyncProperty(
+    "isPublic",
+    { book: { author: ["age", "graduated"] } },
+    (review) => {
+      const author = review.book.get.author.get;
+      return !!author.age && author.age >= 21 && !!author.graduated;
+    },
+  );
+}
 
 // Example of cannotBeUpdated on a m2o so "it won't be reactive" (but really is b/c of creates & deletes)
 config.addRule(cannotBeUpdated("book"));

--- a/packages/integration-tests/src/entities/BookReview.ts
+++ b/packages/integration-tests/src/entities/BookReview.ts
@@ -1,9 +1,9 @@
 import {
   cannotBeUpdated,
-  DerivedAsyncProperty,
-  hasDerivedAsyncProperty,
   hasOneDerived,
   hasOneThrough,
+  hasPersistedAsyncProperty,
+  PersistedAsyncProperty,
   Reference,
 } from "joist-orm";
 import { Author, BookReviewCodegen, bookReviewConfig as config, Publisher } from "./entities";
@@ -20,7 +20,7 @@ export class BookReview extends BookReviewCodegen {
   );
 
   // Reviews are only public if the author is over the age of 21 and graduated (checking graduated b/c age is immutable)
-  readonly isPublic: DerivedAsyncProperty<BookReview, boolean> = hasDerivedAsyncProperty(
+  readonly isPublic: PersistedAsyncProperty<BookReview, boolean> = hasPersistedAsyncProperty(
     "isPublic",
     { book: { author: ["age", "graduated"] } },
     (review) => {

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -4,6 +4,7 @@ import {
   BooleanGraphQLFilter,
   Changes,
   ConfigApi,
+  DerivedAsyncProperty,
   EntityFilter,
   EntityGraphQLFilter,
   EntityOrmField,
@@ -151,12 +152,7 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager> {
     setField(this, "rating", rating);
   }
 
-  get isPublic(): boolean {
-    if (!("isPublic" in this.__orm.data)) {
-      throw new Error("isPublic has not been derived yet");
-    }
-    return this.__orm.data["isPublic"];
-  }
+  abstract readonly isPublic: DerivedAsyncProperty<BookReview, boolean>;
 
   get createdAt(): Date {
     return this.__orm.data["createdAt"];

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -4,7 +4,6 @@ import {
   BooleanGraphQLFilter,
   Changes,
   ConfigApi,
-  DerivedAsyncProperty,
   EntityFilter,
   EntityGraphQLFilter,
   EntityOrmField,
@@ -26,6 +25,7 @@ import {
   OptsOf,
   OrderBy,
   PartialOrNull,
+  PersistedAsyncProperty,
   setField,
   setOpts,
   ValueFilter,
@@ -152,7 +152,7 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager> {
     setField(this, "rating", rating);
   }
 
-  abstract readonly isPublic: DerivedAsyncProperty<BookReview, boolean>;
+  abstract readonly isPublic: PersistedAsyncProperty<BookReview, boolean>;
 
   get createdAt(): Date {
     return this.__orm.data["createdAt"];

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -116,7 +116,7 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
               return [[f.fieldName, (this as any)[f.fieldName] || null]];
             case "primitive":
               if (f.derived === "async") {
-                // Use the raw value instead of the DerivedAsyncProperty
+                // Use the raw value instead of the PersistedAsyncProperty
                 return [[f.fieldName, (this as any).__orm.data[f.fieldName] || null]];
               } else {
                 return [[f.fieldName, (this as any)[f.fieldName] || null]];

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -112,9 +112,15 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
         .map((f) => {
           switch (f.kind) {
             case "primaryKey":
-            case "primitive":
             case "enum":
               return [[f.fieldName, (this as any)[f.fieldName] || null]];
+            case "primitive":
+              if (f.derived === "async") {
+                // Use the raw value instead of the DerivedAsyncProperty
+                return [[f.fieldName, (this as any).__orm.data[f.fieldName] || null]];
+              } else {
+                return [[f.fieldName, (this as any)[f.fieldName] || null]];
+              }
             case "m2o":
               // Don't recurse into new entities b/c the point is to stay shallow
               const value = (this as any)[f.fieldName].current();

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1059,7 +1059,7 @@ async function addReactiveAsyncDerivedValues(todos: Record<string, Todo>): Promi
           if (!asyncFields.has(entity)) {
             asyncFields.set(entity, new Set());
           }
-          asyncFields.get(entity)!.add(field.fn);
+          asyncFields.get(entity)!.add(field.name);
         });
     });
   });
@@ -1213,8 +1213,8 @@ async function recalcAsyncDerivedFields(em: EntityManager, todos: Record<string,
   const p = Object.values(todos).flatMap(({ metadata, asyncFields }) => {
     return [...asyncFields.entries()]
       .filter(([e]) => !e.isDeletedEntity)
-      .flatMap(([entity, fns]) => {
-        return [...fns.values()].map((fn) => fn(entity));
+      .flatMap(([entity, fields]) => {
+        return [...fields.values()].map((fieldName) => (entity as any)[fieldName].load());
       });
   });
   await Promise.all(p);

--- a/packages/orm/src/Todo.ts
+++ b/packages/orm/src/Todo.ts
@@ -10,7 +10,7 @@ export class Todo {
   updates: Entity[] = [];
   deletes: Entity[] = [];
   validates: Map<Entity, Set<Function>> = new Map();
-  asyncFields: Map<Entity, Set<Function>> = new Map();
+  asyncFields: Map<Entity, Set<string>> = new Map();
   constructor(public metadata: EntityMetadata<any>) {}
 }
 
@@ -40,7 +40,9 @@ export function createTodos(entities: Entity[]): Record<string, Todo> {
           asyncFields.set(entity, new Set());
         }
         const set = asyncFields.get(entity)!;
-        Object.values(getMetadata(entity).config.__data.asyncDerivedFields).forEach(({ fn }) => set.add(fn));
+        Object.values(todo.metadata.fields)
+          .filter((f) => f.kind === "primitive" && f.derived === "async")
+          .forEach((field) => set.add(field.fieldName));
       }
     }
   }

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -6,7 +6,7 @@ import { maybeResolveReferenceToId, tagFromId } from "./keys";
 import { reverseReactiveHint } from "./reactiveHints";
 import { Reference } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
-import { DerivedAsyncPropertyImpl } from "./relations/hasDerivedAsyncProperty";
+import { PersistedAsyncPropertyImpl } from "./relations/hasPersistedAsyncProperty";
 import { isCannotBeUpdatedRule } from "./rules";
 import { fail } from "./utils";
 
@@ -253,7 +253,7 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
     Object.values(meta.fields)
       .filter((f) => f.kind === "primitive" && f.derived === "async")
       .forEach((field) => {
-        const asyncProperty = getFakeInstance(meta)[field.fieldName] as DerivedAsyncPropertyImpl<any, any, any>;
+        const asyncProperty = getFakeInstance(meta)[field.fieldName] as PersistedAsyncPropertyImpl<any, any, any>;
         const reversals = reverseReactiveHint(meta.cstr, asyncProperty.loadHint);
         reversals.forEach(({ entity, path, fields }) => {
           getMetadata(entity).config.__data.reactiveDerivedValues.push({ name: field.fieldName, path, fields });

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -1,10 +1,12 @@
 import { Entity, EntityOrmField, isEntity } from "./Entity";
 import { currentFlushSecret, EntityConstructor, EntityManager, OptsOf } from "./EntityManager";
 import { EntityMetadata, getMetadata } from "./EntityMetadata";
+import { getFakeInstance } from "./getProperties";
 import { maybeResolveReferenceToId, tagFromId } from "./keys";
 import { reverseReactiveHint } from "./reactiveHints";
 import { Reference } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
+import { DerivedAsyncPropertyImpl } from "./relations/hasDerivedAsyncProperty";
 import { isCannotBeUpdatedRule } from "./rules";
 import { fail } from "./utils";
 
@@ -248,12 +250,15 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
     });
 
     // Look for reactive async derived values rules to reverse
-    Object.values(meta.config.__data.asyncDerivedFields).forEach(({ name, hint, fn }) => {
-      const reversals = reverseReactiveHint(meta.cstr, hint);
-      reversals.forEach(({ entity, path, fields }) => {
-        getMetadata(entity).config.__data.reactiveDerivedValues.push({ name, path, fields, fn });
+    Object.values(meta.fields)
+      .filter((f) => f.kind === "primitive" && f.derived === "async")
+      .forEach((field) => {
+        const asyncProperty = getFakeInstance(meta)[field.fieldName] as DerivedAsyncPropertyImpl<any, any, any>;
+        const reversals = reverseReactiveHint(meta.cstr, asyncProperty.loadHint);
+        reversals.forEach(({ entity, path, fields }) => {
+          getMetadata(entity).config.__data.reactiveDerivedValues.push({ name: field.fieldName, path, fields });
+        });
       });
-    });
   });
 }
 

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -58,7 +58,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     public otherColumnName: string,
   ) {
     super();
-    this.isCascadeDelete = otherMeta.config.__data.cascadeDeleteFields.includes(fieldName as any);
+    this.isCascadeDelete = otherMeta?.config.__data.cascadeDeleteFields.includes(fieldName as any);
   }
 
   private filterDeleted(entities: U[], opts?: { withDeleted?: boolean }): U[] {

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -75,7 +75,7 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     public otherFieldName: keyof U & string,
   ) {
     super();
-    this.isCascadeDelete = otherMeta.config.__data.cascadeDeleteFields.includes(fieldName as any);
+    this.isCascadeDelete = otherMeta?.config.__data.cascadeDeleteFields.includes(fieldName as any);
   }
 
   async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<U | N> {

--- a/packages/orm/src/relations/hasDerivedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasDerivedAsyncProperty.ts
@@ -1,0 +1,104 @@
+import { Entity } from "../Entity";
+import { Const, currentlyInstantiatingEntity } from "../EntityManager";
+import { getMetadata } from "../EntityMetadata";
+import { setField } from "../index";
+import { convertToLoadHint, Reacted, ReactiveHint } from "../reactiveHints";
+
+const I = Symbol();
+
+/**
+ * A `DerivedAsyncProperty` is a value that is derived from other entities/values,
+ * similar to an `AsyncProperty`, but it is also persisted in the database.
+ *
+ * This allows callers (or SQL queries) to access the value without first calling
+ * `await load()` on the property.
+ *
+ * So, unlike `AsyncProperty`, `.get` is always available; if the property is unloaded,
+ * then `.get` will return the last-calculated value, but if the property is loaded,
+ * then it will go ahead and invoke function to calculate the latest value (i.e. so
+ * that you can observe the latest & greatest value w/o waiting for `em.flush` to
+ * re-calc the value while persisting to the database.
+ */
+export interface DerivedAsyncProperty<T extends Entity, V> {
+  isLoaded: boolean;
+
+  /** Calculates the latest derived value. */
+  load(): Promise<V>;
+
+  /** If loaded, returns the latest derived value, or if unload returns the previously-calculated value. */
+  get: V;
+
+  [I]?: T;
+}
+
+/**
+ * Creates a calculated derived value from a load hint + lambda.
+ *
+ * The property can be accessed by default as a promise, with `someProperty.load()`.
+ *
+ * But if `someProperty` is used as a populate hint, then it can be accessed synchronously,
+ * with `someProperty.get`.
+ */
+export function hasDerivedAsyncProperty<T extends Entity, H extends ReactiveHint<T>, V>(
+  fieldName: keyof T & string,
+  hint: Const<H>,
+  fn: (entity: Reacted<T, H>) => V,
+): DerivedAsyncProperty<T, V> {
+  const entity = currentlyInstantiatingEntity as T;
+  return new DerivedAsyncPropertyImpl(entity, fieldName, hint, fn);
+}
+
+export class DerivedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T>, V>
+  implements DerivedAsyncProperty<T, V>
+{
+  private loaded = false;
+  private loadPromise: any;
+  constructor(
+    private entity: T,
+    public fieldName: keyof T & string,
+    public loadHint: Const<H>,
+    private fn: (entity: Reacted<T, H>) => V,
+  ) {}
+
+  load(): Promise<V> {
+    const { entity, loadHint, fn } = this;
+    if (!this.loaded) {
+      return (this.loadPromise ??= entity.em
+        .populate(entity, convertToLoadHint(getMetadata(entity), loadHint as ReactiveHint<T>))
+        .then((loaded) => {
+          this.loaded = true;
+          return this.get;
+        }));
+    }
+    return Promise.resolve(this.get);
+  }
+
+  get get(): V {
+    const { entity, fn } = this;
+    if (this.loaded) {
+      const newValue = fn(entity as Reacted<T, H>);
+      setField(entity, this.fieldName, newValue);
+      return newValue;
+    } else {
+      if (this.fieldName in entity.__orm.data) {
+        return entity.__orm.data[this.fieldName];
+      } else {
+        throw new Error(`${this.fieldName} has not been derived yet`);
+      }
+    }
+  }
+
+  get isLoaded() {
+    return this.loaded;
+  }
+}
+
+/** Type guard utility for determining if an entity field is an AsyncProperty. */
+export function isDerivedAsyncProperty(maybeAsyncProperty: any): maybeAsyncProperty is DerivedAsyncProperty<any, any> {
+  return maybeAsyncProperty instanceof DerivedAsyncPropertyImpl;
+}
+
+/** Type guard utility for determining if an entity field is a loaded AsyncProperty. */
+export function isLoadedAsyncProperty(maybeAsyncProperty: any): maybeAsyncProperty is DerivedAsyncProperty<any, any> {
+  return isDerivedAsyncProperty(maybeAsyncProperty) && maybeAsyncProperty.isLoaded;
+}

--- a/packages/orm/src/relations/hasDerivedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasDerivedAsyncProperty.ts
@@ -21,6 +21,7 @@ const I = Symbol();
  */
 export interface DerivedAsyncProperty<T extends Entity, V> {
   isLoaded: boolean;
+  isSet: boolean;
 
   /** Calculates the latest derived value. */
   load(): Promise<V>;
@@ -82,13 +83,15 @@ export class DerivedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T
       // official "being called during em.flush" update.
       setField(entity, this.fieldName, newValue);
       return newValue;
+    } else if (this.isSet) {
+      return entity.__orm.data[this.fieldName];
     } else {
-      if (this.fieldName in entity.__orm.data) {
-        return entity.__orm.data[this.fieldName];
-      } else {
-        throw new Error(`${this.fieldName} has not been derived yet`);
-      }
+      throw new Error(`${this.fieldName} has not been derived yet`);
     }
+  }
+
+  get isSet() {
+    return this.fieldName in this.entity.__orm.data;
   }
 
   get isLoaded() {

--- a/packages/orm/src/relations/hasDerivedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasDerivedAsyncProperty.ts
@@ -29,6 +29,15 @@ export interface DerivedAsyncProperty<T extends Entity, V> {
   /** If loaded, returns the latest derived value, or if unload returns the previously-calculated value. */
   get: V;
 
+  /**
+   * Returns the as-of-last-flush previously-calculated value.
+   *
+   * This is useful if you have to purposefully avoid using the lambda to calc the latest value,
+   * i.e. if you're in a test and want to watch a calculated value change from some dummy value
+   * to the new derived value.
+   * */
+  getFieldValue: V;
+
   [I]?: T;
 }
 
@@ -88,6 +97,10 @@ export class DerivedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T
     } else {
       throw new Error(`${this.fieldName} has not been derived yet`);
     }
+  }
+
+  get getFieldValue(): V {
+    return this.entity.__orm.data[this.fieldName];
   }
 
   get isSet() {

--- a/packages/orm/src/relations/hasDerivedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasDerivedAsyncProperty.ts
@@ -67,6 +67,7 @@ export class DerivedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T
         .populate(entity, convertToLoadHint(getMetadata(entity), loadHint as ReactiveHint<T>))
         .then((loaded) => {
           this.loaded = true;
+          // Go through `this.get` so that `setField` is called to set our latest value
           return this.get;
         }));
     }
@@ -77,6 +78,8 @@ export class DerivedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T
     const { entity, fn } = this;
     if (this.loaded) {
       const newValue = fn(entity as Reacted<T, H>);
+      // It's cheap to set this every time we're called, i.e. even if it's not the
+      // official "being called during em.flush" update.
       setField(entity, this.fieldName, newValue);
       return newValue;
     } else {

--- a/packages/orm/src/relations/hasDerivedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasDerivedAsyncProperty.ts
@@ -36,7 +36,7 @@ export interface DerivedAsyncProperty<T extends Entity, V> {
    * i.e. if you're in a test and want to watch a calculated value change from some dummy value
    * to the new derived value.
    * */
-  getFieldValue: V;
+  fieldValue: V;
 
   [I]?: T;
 }
@@ -99,7 +99,7 @@ export class DerivedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T
     }
   }
 
-  get getFieldValue(): V {
+  get fieldValue(): V {
     return this.entity.__orm.data[this.fieldName];
   }
 

--- a/packages/orm/src/relations/hasPersistedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasPersistedAsyncProperty.ts
@@ -7,7 +7,7 @@ import { convertToLoadHint, Reacted, ReactiveHint } from "../reactiveHints";
 const I = Symbol();
 
 /**
- * A `DerivedAsyncProperty` is a value that is derived from other entities/values,
+ * A `PersistedAsyncProperty` is a value that is derived from other entities/values,
  * similar to an `AsyncProperty`, but it is also persisted in the database.
  *
  * This allows callers (or SQL queries) to access the value without first calling
@@ -19,7 +19,7 @@ const I = Symbol();
  * that you can observe the latest & greatest value w/o waiting for `em.flush` to
  * re-calc the value while persisting to the database.
  */
-export interface DerivedAsyncProperty<T extends Entity, V> {
+export interface PersistedAsyncProperty<T extends Entity, V> {
   isLoaded: boolean;
   isSet: boolean;
 
@@ -49,17 +49,17 @@ export interface DerivedAsyncProperty<T extends Entity, V> {
  * But if `someProperty` is used as a populate hint, then it can be accessed synchronously,
  * with `someProperty.get`.
  */
-export function hasDerivedAsyncProperty<T extends Entity, H extends ReactiveHint<T>, V>(
+export function hasPersistedAsyncProperty<T extends Entity, H extends ReactiveHint<T>, V>(
   fieldName: keyof T & string,
   hint: Const<H>,
   fn: (entity: Reacted<T, H>) => V,
-): DerivedAsyncProperty<T, V> {
+): PersistedAsyncProperty<T, V> {
   const entity = currentlyInstantiatingEntity as T;
-  return new DerivedAsyncPropertyImpl(entity, fieldName, hint, fn);
+  return new PersistedAsyncPropertyImpl(entity, fieldName, hint, fn);
 }
 
-export class DerivedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T>, V>
-  implements DerivedAsyncProperty<T, V>
+export class PersistedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T>, V>
+  implements PersistedAsyncProperty<T, V>
 {
   private loaded = false;
   private loadPromise: any;
@@ -113,11 +113,13 @@ export class DerivedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint<T
 }
 
 /** Type guard utility for determining if an entity field is an AsyncProperty. */
-export function isDerivedAsyncProperty(maybeAsyncProperty: any): maybeAsyncProperty is DerivedAsyncProperty<any, any> {
-  return maybeAsyncProperty instanceof DerivedAsyncPropertyImpl;
+export function isPersistedAsyncProperty(
+  maybeAsyncProperty: any,
+): maybeAsyncProperty is PersistedAsyncProperty<any, any> {
+  return maybeAsyncProperty instanceof PersistedAsyncPropertyImpl;
 }
 
 /** Type guard utility for determining if an entity field is a loaded AsyncProperty. */
-export function isLoadedAsyncProperty(maybeAsyncProperty: any): maybeAsyncProperty is DerivedAsyncProperty<any, any> {
-  return isDerivedAsyncProperty(maybeAsyncProperty) && maybeAsyncProperty.isLoaded;
+export function isLoadedAsyncProperty(maybeAsyncProperty: any): maybeAsyncProperty is PersistedAsyncProperty<any, any> {
+  return isPersistedAsyncProperty(maybeAsyncProperty) && maybeAsyncProperty.isLoaded;
 }

--- a/packages/orm/src/relations/index.ts
+++ b/packages/orm/src/relations/index.ts
@@ -8,7 +8,7 @@ export {
   isLoadedAsyncProperty,
   LoadedProperty,
 } from "./hasAsyncProperty";
-export { DerivedAsyncProperty, hasDerivedAsyncProperty, isDerivedAsyncProperty } from "./hasDerivedAsyncProperty";
+export { PersistedAsyncProperty, hasPersistedAsyncProperty, isPersistedAsyncProperty } from "./hasPersistedAsyncProperty";
 export { hasManyDerived } from "./hasManyDerived";
 export { hasManyThrough } from "./hasManyThrough";
 export { hasOneDerived } from "./hasOneDerived";

--- a/packages/orm/src/relations/index.ts
+++ b/packages/orm/src/relations/index.ts
@@ -8,6 +8,7 @@ export {
   isLoadedAsyncProperty,
   LoadedProperty,
 } from "./hasAsyncProperty";
+export { DerivedAsyncProperty, hasDerivedAsyncProperty, isDerivedAsyncProperty } from "./hasDerivedAsyncProperty";
 export { hasManyDerived } from "./hasManyDerived";
 export { hasManyThrough } from "./hasManyThrough";
 export { hasOneDerived } from "./hasOneDerived";


### PR DESCRIPTION
This replaces the previous config based API, with the benefits that:

* Users can explicitly call the properties to get the latest value,
  i.e. from other derived properties.

* If the load hint is satisified, users can call the property
  immediately after creating the entity, w/o waiting for em.flush to
  calc the value.

* If the property is loaded, it will always calc the latest value
  instead of potentially using an outdated value from the last
  em.flush.