### PR TITLE
fix: Fix populate performance

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -192,7 +192,9 @@ export class EntityDbMetadata {
 
   constructor(config: Config, table: Table, enums: EnumMetadata = {}) {
     this.entity = makeEntity(tableToEntityName(config, table));
-    this.idDbType = table.columns.filter((c) => c.isPrimaryKey).map((c) => c.type.shortName)[0] ?? fail();
+    this.idDbType =
+      table.columns.filter((c) => c.isPrimaryKey).map((c) => c.type.shortName)[0] ??
+      fail(`No primary key found for ${table.name}`);
 
     this.primitives = table.columns
       .filter((c) => !c.isPrimaryKey && !c.isForeignKey)

--- a/packages/integration-tests/src/EntityManager.populate.test.ts
+++ b/packages/integration-tests/src/EntityManager.populate.test.ts
@@ -171,11 +171,10 @@ describe("EntityManager.populate", () => {
     expect(result).toEqual(["a1", 0]);
   });
 
-  // jest.setTimeout(1_000_000);
-
   it.skip("can be huge", async () => {
-    const em1 = newEntityManager();
+    jest.setTimeout(1_000_000);
     setEntityLimit(100_000);
+    const em1 = newEntityManager();
     // Create 10,000 entities
     for (let i = 0; i < 10; i++) {
       const p = newPublisher(em1);
@@ -187,9 +186,11 @@ describe("EntityManager.populate", () => {
       }
     }
     await em1.flush();
+    // console.log({ em1: em1.populates });
     // Now call a single populate
     const em2 = newEntityManager();
     const publishers = await em2.find(Publisher, {});
     await em2.populate(publishers, { authors: { books: { author: "publisher" } } });
+    // console.log({ em2: em2.populates });
   });
 });

--- a/packages/integration-tests/src/EntityManager.populate.test.ts
+++ b/packages/integration-tests/src/EntityManager.populate.test.ts
@@ -188,9 +188,11 @@ describe("EntityManager.populate", () => {
       }
     }
     await em1.flush();
+    em1.printPopulates();
 
     const em2 = newEntityManager();
     const publishers = await em2.find(Publisher, {});
     await em2.populate(publishers, { authors: { books: { author: "publisher" } } });
+    em2.printPopulates();
   });
 });

--- a/packages/integration-tests/src/EntityManager.populate.test.ts
+++ b/packages/integration-tests/src/EntityManager.populate.test.ts
@@ -171,12 +171,11 @@ describe("EntityManager.populate", () => {
     expect(result).toEqual(["a1", 0]);
   });
 
-  jest.setTimeout(1_000_000);
+  // jest.setTimeout(1_000_000);
 
-  it.only("can be huge", async () => {
+  it.skip("can be huge", async () => {
     const em1 = newEntityManager();
     setEntityLimit(100_000);
-
     // Create 10,000 entities
     for (let i = 0; i < 10; i++) {
       const p = newPublisher(em1);
@@ -188,11 +187,9 @@ describe("EntityManager.populate", () => {
       }
     }
     await em1.flush();
-    em1.printPopulates();
-
+    // Now call a single populate
     const em2 = newEntityManager();
     const publishers = await em2.find(Publisher, {});
     await em2.populate(publishers, { authors: { books: { author: "publisher" } } });
-    em2.printPopulates();
   });
 });

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -625,7 +625,7 @@ export class EntityManager<C = {}> {
     }
 
     // If a bunch of `.load`s get called in parallel for the same entity type + load hint, dedup them down
-    // to a single promise to avoid making more and more promises with each level of load hint.
+    // to a single promise to avoid making more and more promises with each level/fan-out of a nested load hint.
     const key = `${list[0]?.__orm.metadata.tagName}-${JSON.stringify(hint)}`;
     const loader = getOrSet(
       this.populateLoaders,
@@ -660,7 +660,6 @@ export class EntityManager<C = {}> {
               throw new Error(`Unexpected hint ${hint}`);
             }
           });
-
         return Promise.all(promises);
       }),
     );

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -40,11 +40,13 @@ export class ConfigApi<T extends Entity, C> {
     } else {
       const hint = ruleOrHint;
       // Create a wrapper around the user's function to populate
-      const fn = async (entity: T) => {
+      const fn = (entity: T) => {
         // Ideally we'd convert this once outside `fn`, but we don't have `metadata` yet
         const loadHint = convertToLoadHint(getMetadata(entity), hint);
-        const loaded = await entity.em.populate(entity, loadHint);
-        return maybeRule!(loaded);
+        if (Object.keys(loadHint).length > 0) {
+          return entity.em.populate(entity, loadHint).then((loaded) => maybeRule!(loaded));
+        }
+        return maybeRule!(entity);
       };
       this.__data.rules.push({ name, fn, hint });
     }

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -26,5 +26,5 @@ export function findDataLoader<T extends Entity>(
 const replacer = (v: any) => (isEntity(v) ? v.id : v);
 
 export function whereFilterHash(where: FilterAndSettings<any>): string {
-  return hash(where, { replacer });
+  return hash(where, { replacer, algorithm: "md5" });
 }

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -65,13 +65,13 @@ export function setField<T extends Entity>(entity: T, fieldName: keyof T & strin
   if (em.isFlushing) {
     const { flushSecret } = currentFlushSecret.getStore() || {};
     if (flushSecret === undefined) {
-      // throw new Error(
-      //   `Cannot set '${fieldName}' on ${entity} during a flush outside of a entity hook or from afterCommit`,
-      // );
+      throw new Error(
+        `Cannot set '${fieldName}' on ${entity} during a flush outside of a entity hook or from afterCommit`,
+      );
     }
-    // if (flushSecret !== em["flushSecret"]) {
-    //   throw new Error(`Attempting to reuse a hook context outside its flush loop`);
-    // }
+    if (flushSecret !== em["flushSecret"]) {
+      throw new Error(`Attempting to reuse a hook context outside its flush loop`);
+    }
   }
 
   const { data, originalData } = entity.__orm;

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -65,13 +65,13 @@ export function setField<T extends Entity>(entity: T, fieldName: keyof T & strin
   if (em.isFlushing) {
     const { flushSecret } = currentFlushSecret.getStore() || {};
     if (flushSecret === undefined) {
-      throw new Error(
-        `Cannot set '${fieldName}' on ${entity} during a flush outside of a entity hook or from afterCommit`,
-      );
+      // throw new Error(
+      //   `Cannot set '${fieldName}' on ${entity} during a flush outside of a entity hook or from afterCommit`,
+      // );
     }
-    if (flushSecret !== em["flushSecret"]) {
-      throw new Error(`Attempting to reuse a hook context outside its flush loop`);
-    }
+    // if (flushSecret !== em["flushSecret"]) {
+    //   throw new Error(`Attempting to reuse a hook context outside its flush loop`);
+    // }
   }
 
   const { data, originalData } = entity.__orm;


### PR DESCRIPTION
This fixes `em.populate` doing too much fan-out, i.e. if we do something like:

```
em.populate([publishers], { authors: { books: { author: "publisher" } })
```

Or other sufficiently-deep load hint, because of the flexibility+opaqueness of load hints (where the contract is basically "just call `.load` and see what happens"--which is great b/c it allows a very flexible contract w/o needing to like pre-plan out an entire N layer 'query plan'), it meant that if we had 10,000 books all with the same author, we'd call:

* book1.author.load --> new promise for a:1
* book2.author.load --> new promise for a:2
* book3.author.load --> new promise for a:3
* ...repeat for 10k promises...

And then if we wanted to load `author.publisher`, all of those 10k promises would do their _own_:

* Load a:1.publisher --> new promise for p:1
* Load a:1.publisher --> new promise for p:1
* Load a:1.publisher --> new promise for p:1
* ...repeat...

I was initially pretty concerned that fixing this would require fundamentally inverting the "just call `.load`" approach that Joist uses to somehow recognize "X of these loads are the same thing, I'm going to turn them into a batch call", ala https://github.com/facebook/Haxl or https://github.com/47degrees/fetch.

...but, wait a sec, we already have a JS library that magically dedups N-separate-calls-into-1-batch-call, so we just had `DataLoader` into `populate`, and that seems to magically fix things.

Here is a `console.log` added to `EntityManager.populate` from the "make ~10k entities" test case, that shows "number of times `populate` is called for a given tag + hint combination":

```
-- before
  console.log
    {
      'a-{"books":{}}': 300,
      'a-{"books":{"comments":{}}}': 100,
      'b-{}': 300,
      'b-{"comments":{}}': 100,
      'undefined-{}': 19692,
      'p-{"authors":{}}': 10,
      'a-{"mentor":{}}': 100,
      'a-{}': 19398,
      'b-{"author":{}}': 20000,
      'b-{"reviews":{}}': 10000
    }
```

You can see that that we're spamming "load `author` for a given `b`" ~20k times.

As a light tangent, the 1st cleanup was noticing of the `undefined-{}: 19k` entries, which basically shows code calling `populate` when it didn't have to (b/c the load hint was empty, or it had an empty list), so the initial clean up is to find those places teach them to just early return instead, which gives us:

```
--after
  console.log
    {
      'a-{"books":{}}': 300,
      'a-{"books":{"comments":{}}}': 100,
      'b-{"comments":{}}': 100,
      'p-{"authors":{}}': 10,
      'a-{"mentor":{}}': 100,
      'b-{"author":{}}': 19594,
      'b-{"reviews":{}}': 9796
    }
```

Which is much cleaner, but still has things like "call `populate` 19k times for book/author".

With the dataloader change this drops to:

```
-- after
  console.log
    {
      'a-{"books":{}}': 1,
      'a-{"books":{"comments":{}}}': 1,
      'b-{"comments":{}}': 1,
      'p-{"authors":{}}': 1,
      'a-{"mentor":{}}': 1,
      'b-{"author":{}}': 1,
      'b-{"reviews":{}}': 1
    }
```

Which looks better.

I've verified on the problematic "Lot Config Review" step in the Blueprint that the load time went from ~30s earlier today to ~7s with our hacked-down-load-hint temporary fix to ~500ms.

And the same "add a `console.log` to see how many times `populate` is called" (this is for the real production code and not the test cases like above) is now dramatically smaller:

```
$ ls -lh | grep log
-rw-rw-r--    1 stephen stephen 128M Sep 13 13:53 log1.out
-rw-rw-r--    1 stephen stephen  38M Sep 13 14:08 log2.out
-rw-rw-r--    1 stephen stephen  19K Sep 13 18:37 log3.out
```

I.e. we started the day with 128mb of `console.log`-in-`em.populate` output, got it down to 38mb with our load hint work around, and now 19kb with this fix.

Granted, 19kb still sounds like a lot, and it is ~350 `populate` calls, so not _great_, but scanning the file they seem "reasonable I guess" vs. the original 128mb `log1.out` which was like "...wtf is all of this duplicated cruft".

