### PR TITLE
feat: Support async properties in reactive hints.

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -606,4 +606,22 @@ describe("Author", () => {
       expect(m.fields["age"].immutable).toBe(true);
     });
   });
+
+  it("can access deleted children", async () => {
+    // Given an author and two books
+    await insertAuthor({ first_name: "a1", number_of_books: 2 });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertBook({ title: "b2", author_id: 1 });
+    const em = newEntityManager();
+    const a = await em.load(Author, "a:1", { books: "author" });
+    // When we delete the 2nd book
+    const b2 = a.books.get[1];
+    em.delete(b2);
+    // Then we can still access both books via getWithDeleted
+    expect(a.books.getWithDeleted.length).toBe(2);
+    // And b2 still knows that author is/was its parent
+    expect(b2.author.get).toBe(a);
+    // Even though its deleted
+    expect(b2.isPendingDelete).toBe(true);
+  });
 });

--- a/packages/integration-tests/src/entities/Book.ts
+++ b/packages/integration-tests/src/entities/Book.ts
@@ -5,6 +5,7 @@ export class Book extends BookCodegen {
   firstNameRuleInvoked = 0;
   favoriteColorsRuleInvoked = 0;
   reviewsRuleInvoked = 0;
+  numberOfBooks2RuleInvoked = 0;
 }
 
 config.addRule((book) => {
@@ -27,6 +28,11 @@ config.addRule({ author: ["favoriteColors", "firstName:ro"] }, (b) => {
 // Example of a rule on reviews, where the BookReview.book is cannotBeUpdated
 config.addRule("reviews", (b) => {
   b.entity.reviewsRuleInvoked++;
+});
+
+// Another noop rule to make Book reactive on author.numberOfBooks2, an async property
+config.addRule({ author: "numberOfBooks2" }, (b) => {
+  b.entity.numberOfBooks2RuleInvoked++;
 });
 
 config.cascadeDelete("reviews");

--- a/packages/integration-tests/src/entities/Publisher.ts
+++ b/packages/integration-tests/src/entities/Publisher.ts
@@ -52,3 +52,11 @@ config.addRule({ authors: "numberOfBooks2" }, (p) => {
     return "A publisher cannot have 13 books";
   }
 });
+
+// Example of reactive rule being fired by a persisted async property
+config.addRule({ authors: "numberOfBooks" }, (p) => {
+  const sum = p.authors.get.map((a) => a.numberOfBooks.get).reduce((a, b) => a + b, 0);
+  if (sum === 15) {
+    return "A publisher cannot have 15 books";
+  }
+});

--- a/packages/integration-tests/src/entities/Publisher.ts
+++ b/packages/integration-tests/src/entities/Publisher.ts
@@ -44,3 +44,11 @@ config.addRule("authors", (p) => {
     return "Cannot have 13 authors";
   }
 });
+
+// Example of reactive rule being fired by an async property
+config.addRule({ authors: "numberOfBooks2" }, (p) => {
+  const sum = p.authors.get.map((a) => (a.numberOfBooks2 as any).get).reduce((a, b) => a + b, 0);
+  if (sum === 13) {
+    return "A publisher cannot have 13 books";
+  }
+});

--- a/packages/integration-tests/src/entities/Publisher.ts
+++ b/packages/integration-tests/src/entities/Publisher.ts
@@ -47,7 +47,7 @@ config.addRule("authors", (p) => {
 
 // Example of reactive rule being fired by an async property
 config.addRule({ authors: "numberOfBooks2" }, (p) => {
-  const sum = p.authors.get.map((a) => (a.numberOfBooks2 as any).get).reduce((a, b) => a + b, 0);
+  const sum = p.authors.get.map((a) => a.numberOfBooks2.get).reduce((a, b) => a + b, 0);
   if (sum === 13) {
     return "A publisher cannot have 13 books";
   }

--- a/packages/integration-tests/src/getProperties.test.ts
+++ b/packages/integration-tests/src/getProperties.test.ts
@@ -1,6 +1,5 @@
 import { authorMeta, bookMeta, bookReviewMeta, imageMeta, publisherMeta } from "@src/entities";
 import {
-  BaseEntity,
   CustomCollection,
   CustomReference,
   getProperties,
@@ -24,6 +23,7 @@ describe("getProperties", () => {
       firstNameRuleInvoked: 0,
       reviewsRuleInvoked: 0,
       rulesInvoked: 0,
+      numberOfBooks2RuleInvoked: 0,
     });
   });
 

--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -1,6 +1,7 @@
 import { Entity } from "./Entity";
 import { EntityConstructor, FieldsOf } from "./EntityManager";
 import { EntityMetadata, getMetadata } from "./EntityMetadata";
+import { getProperties } from "./getProperties";
 import { Loadable, Loaded, LoadHint } from "./loadHints";
 import { NormalizeHint, normalizeHint, suffixRe, SuffixSeperator } from "./normalizeHints";
 import { Collection, LoadedCollection, LoadedReference, OneToOneReference, Reference } from "./relations";
@@ -59,49 +60,59 @@ export function reverseReactiveHint<T extends Entity>(
   const primitives: string[] = typeof reactForOtherSide === "string" ? [reactForOtherSide] : [];
   const subHints = Object.entries(normalizeHint(hint)).flatMap(([keyMaybeSuffix, subHint]) => {
     const key = keyMaybeSuffix.replace(suffixRe, "");
-    const field = meta.fields[key] || fail(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
-    const isReadOnly = !!keyMaybeSuffix.match(suffixRe) || field.immutable;
-    switch (field.kind) {
-      case "m2o": {
-        if (!isReadOnly) {
-          primitives.push(field.fieldName);
+    // const field = meta.fields[key] || fail(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
+    const field = meta.fields[key];
+    const isReadOnly = !!keyMaybeSuffix.match(suffixRe) || (field && field.immutable);
+    if (field) {
+      switch (field.kind) {
+        case "m2o": {
+          if (!isReadOnly) {
+            primitives.push(field.fieldName);
+          }
+          return reverseReactiveHint(field.otherMetadata().cstr, subHint, undefined, false).map(
+            ({ entity, fields, path }) => {
+              return { entity, fields, path: [...path, field.otherFieldName] };
+            },
+          );
         }
-        return reverseReactiveHint(field.otherMetadata().cstr, subHint, undefined, false).map(
-          ({ entity, fields, path }) => {
-            return { entity, fields, path: [...path, field.otherFieldName] };
-          },
-        );
-      }
-      case "m2m":
-      case "o2m":
-      case "o2o": {
-        const isOtherReadOnly = field.otherMetadata().fields[field.otherFieldName].immutable;
-        const otherFieldName =
-          field.otherMetadata().fields[field.otherFieldName].kind === "poly"
-            ? `${field.otherFieldName}@${meta.type}`
-            : field.otherFieldName;
-        // This is not a field, but we want our reverse side to be reactive, so pass reactForOtherSide
-        return reverseReactiveHint(
-          field.otherMetadata().cstr,
-          subHint,
-          // For o2m/o2o/m2m, isReadOnly will only be true if the hint is using a `:ro` / `_ro` suffix,
-          // in which case we really do want to be read-only. But if isOtherReadOnly is true, then we
-          // don't need to "react to the field changing" (which can't happen for immutable fields), but
-          // we do need to react to children being created/deleted.
-          isReadOnly ? undefined : isOtherReadOnly ? true : field.otherFieldName,
-          false,
-        ).map(({ entity, fields, path }) => {
-          return { entity, fields, path: [...path, otherFieldName] };
-        });
-      }
-      case "primitive":
-      case "enum":
-        if (!isReadOnly) {
-          primitives.push(key);
+        case "m2m":
+        case "o2m":
+        case "o2o": {
+          const isOtherReadOnly = field.otherMetadata().fields[field.otherFieldName].immutable;
+          const otherFieldName =
+            field.otherMetadata().fields[field.otherFieldName].kind === "poly"
+              ? `${field.otherFieldName}@${meta.type}`
+              : field.otherFieldName;
+          // This is not a field, but we want our reverse side to be reactive, so pass reactForOtherSide
+          return reverseReactiveHint(
+            field.otherMetadata().cstr,
+            subHint,
+            // For o2m/o2o/m2m, isReadOnly will only be true if the hint is using a `:ro` / `_ro` suffix,
+            // in which case we really do want to be read-only. But if isOtherReadOnly is true, then we
+            // don't need to "react to the field changing" (which can't happen for immutable fields), but
+            // we do need to react to children being created/deleted.
+            isReadOnly ? undefined : isOtherReadOnly ? true : field.otherFieldName,
+            false,
+          ).map(({ entity, fields, path }) => {
+            return { entity, fields, path: [...path, otherFieldName] };
+          });
         }
-        return [];
-      default:
-        throw new Error("Invalid hint");
+        case "primitive":
+        case "enum":
+          if (!isReadOnly) {
+            primitives.push(key);
+          }
+          return [];
+        default:
+          throw new Error("Invalid hint");
+      }
+    } else {
+      const p = getProperties(meta)[key];
+      if (p && p.hint) {
+        return reverseReactiveHint(meta.cstr, p.hint, undefined, false);
+      } else {
+        fail(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
+      }
     }
   });
   return [
@@ -119,19 +130,28 @@ export function convertToLoadHint<T extends Entity>(meta: EntityMetadata<T>, hin
   return Object.fromEntries(
     Object.entries(normalizeHint(hint)).flatMap(([keyMaybeSuffix, subHint]) => {
       const key = keyMaybeSuffix.replace(suffixRe, "");
-      const field = meta.fields[key] || fail(`Invalid hint ${meta.tableName} ${JSON.stringify(hint)}`);
-      switch (field.kind) {
-        case "m2m":
-        case "m2o":
-        case "o2m":
-        case "o2o": {
-          return [[key, convertToLoadHint(field.otherMetadata(), subHint)]];
+      const field = meta.fields[key];
+      if (field) {
+        switch (field.kind) {
+          case "m2m":
+          case "m2o":
+          case "o2m":
+          case "o2o": {
+            return [[key, convertToLoadHint(field.otherMetadata(), subHint)]];
+          }
+          case "primitive":
+          case "enum":
+            return [];
+          default:
+            throw new Error(`Invalid hint ${meta.tableName} ${JSON.stringify(hint)}`);
         }
-        case "primitive":
-        case "enum":
-          return [];
-        default:
-          throw new Error(`Invalid hint ${meta.tableName} ${JSON.stringify(hint)}`);
+      } else {
+        const p = getProperties(meta)[key];
+        if (p && p.hint) {
+          return Object.entries(convertToLoadHint(meta, p.hint));
+        } else {
+          fail(`Invalid hint ${meta.tableName} ${JSON.stringify(hint)}`);
+        }
       }
     }),
   ) as any;

--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -4,7 +4,15 @@ import { EntityMetadata, getMetadata } from "./EntityMetadata";
 import { getProperties } from "./getProperties";
 import { Loadable, Loaded, LoadHint } from "./loadHints";
 import { NormalizeHint, normalizeHint, suffixRe, SuffixSeperator } from "./normalizeHints";
-import { Collection, LoadedCollection, LoadedReference, OneToOneReference, Reference } from "./relations";
+import {
+  AsyncProperty,
+  Collection,
+  LoadedCollection,
+  LoadedProperty,
+  LoadedReference,
+  OneToOneReference,
+  Reference,
+} from "./relations";
 import { LoadedOneToOneReference } from "./relations/OneToOneReference";
 import { fail } from "./utils";
 
@@ -44,6 +52,8 @@ export type Reacted<T extends Entity, H> = Entity & {
     ? LoadedReference<T, Entity & Reacted<U, NormalizeHint<T, H>[K]>, N>
     : T[K] extends Collection<any, infer U>
     ? LoadedCollection<T, Entity & Reacted<U, NormalizeHint<T, H>[K]>>
+    : T[K] extends AsyncProperty<any, infer V>
+    ? LoadedProperty<any, V>
     : T[K];
 } & {
   // Give validation rules a way to get back to the full entity if they really need it

--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -13,6 +13,7 @@ import {
   OneToOneReference,
   Reference,
 } from "./relations";
+import { AsyncPropertyImpl } from "./relations/hasAsyncProperty";
 import { LoadedOneToOneReference } from "./relations/OneToOneReference";
 import { fail } from "./utils";
 
@@ -118,7 +119,7 @@ export function reverseReactiveHint<T extends Entity>(
       }
     } else {
       const p = getProperties(meta)[key];
-      if (p && p.hint) {
+      if (p instanceof AsyncPropertyImpl) {
         return reverseReactiveHint(meta.cstr, p.hint, undefined, false);
       } else {
         fail(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);

--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -71,7 +71,6 @@ export function reverseReactiveHint<T extends Entity>(
   const primitives: string[] = typeof reactForOtherSide === "string" ? [reactForOtherSide] : [];
   const subHints = Object.entries(normalizeHint(hint)).flatMap(([keyMaybeSuffix, subHint]) => {
     const key = keyMaybeSuffix.replace(suffixRe, "");
-    // const field = meta.fields[key] || fail(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
     const field = meta.fields[key];
     const isReadOnly = !!keyMaybeSuffix.match(suffixRe) || (field && field.immutable);
     if (field) {
@@ -115,14 +114,14 @@ export function reverseReactiveHint<T extends Entity>(
           }
           return [];
         default:
-          throw new Error("Invalid hint");
+          throw new Error(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
       }
     } else {
       const p = getProperties(meta)[key];
       if (p instanceof AsyncPropertyImpl) {
         return reverseReactiveHint(meta.cstr, p.hint, undefined, false);
       } else {
-        fail(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
+        throw new Error(`Invalid hint ${entityType.name} ${JSON.stringify(hint)}`);
       }
     }
   });

--- a/packages/orm/src/relations/hasAsyncProperty.ts
+++ b/packages/orm/src/relations/hasAsyncProperty.ts
@@ -33,12 +33,12 @@ export function hasAsyncProperty<T extends Entity, H extends LoadHint<T>, V>(
 export class AsyncPropertyImpl<T extends Entity, H extends LoadHint<T>, V> implements AsyncProperty<T, V> {
   private loaded = false;
   private loadPromise: any;
-  constructor(private entity: T, private loadHint: Const<H>, private fn: (entity: Loaded<T, H>) => V) {}
+  constructor(private entity: T, private hint: Const<H>, private fn: (entity: Loaded<T, H>) => V) {}
 
   load(): Promise<V> {
-    const { entity, loadHint, fn } = this;
+    const { entity, hint, fn } = this;
     if (!this.loaded) {
-      return (this.loadPromise ??= entity.em.populate(entity, loadHint).then((loaded) => {
+      return (this.loadPromise ??= entity.em.populate(entity, hint).then((loaded) => {
         this.loaded = true;
         return fn(loaded);
       }));

--- a/packages/orm/src/relations/hasAsyncProperty.ts
+++ b/packages/orm/src/relations/hasAsyncProperty.ts
@@ -33,7 +33,7 @@ export function hasAsyncProperty<T extends Entity, H extends LoadHint<T>, V>(
 export class AsyncPropertyImpl<T extends Entity, H extends LoadHint<T>, V> implements AsyncProperty<T, V> {
   private loaded = false;
   private loadPromise: any;
-  constructor(private entity: T, private hint: Const<H>, private fn: (entity: Loaded<T, H>) => V) {}
+  constructor(private entity: T, public hint: Const<H>, private fn: (entity: Loaded<T, H>) => V) {}
 
   load(): Promise<V> {
     const { entity, hint, fn } = this;


### PR DESCRIPTION
This includes both non-persisted `AsyncProperty` and `PersistedAsyncProperty`s.

`PersistedAsyncProperty` basically worked for free, b/c a rule depending on persisted field would already get the transitiveness basically for free:

1) new `Book` recalcs the `Author.numberOfBooks` persisted property,
2) `Author`'s reactive validations see `numberOfBooks` changing and queue the `Publisher` rule to rerun.

(Note that `em.flush`s design of "loop over all pending entities first, then do a single validate pass" worked out really well to avoid ordering issues, i.e. we don't have to worry about the Author's reactive validations (step 2) having already been evaluated before the step 1 recalc ran, which if it did happen would mean missing that `numberOfBook`s _will_ change but just hasn't yet.)

For `AsyncProperty`, we don't have the persisted property (`numberOfBooks`) to implicitly stitch together the step 1 "this reactive hint triggers when the property has changed" (from `Book` -> `Author.numberOfBooks2`) with step 2 "this reactive hint triggers the validation rule" (from `Author.numberOfBooks2` -> `Publisher`), so we just explicitly merge them together into a single reactive hint.

I.e. in `reverseReactiveHint` (e.g. while creating the `Author.numberOfBooks2` -> `Publisher` hint for the `Publisher` rule) if we notice an async property (`numberOfBooks2`), we just copy/paste that property's reactive hint (`Book` -> `Author.numberOfBooks2`) into the current reactive hint, and so end up with a singular `Book` -> `Author` -> `Publisher` hint.

So, `Book` ends up with a reaction that, when Book changes, re-evals the `Publisher` validation rule, even though `Publisher`'s validation rule hint (`{ authors: numberOfBooks2 }`) doesn't explicitly show/know that `Author.numberOfBooks2` accessed `Book`.
