### PR TITLE
feat: Calling o2m.set(values) deletes owned children

### DIFF
--- a/packages/integration-tests/src/EntityManager.createOrUpdatePartial.test.ts
+++ b/packages/integration-tests/src/EntityManager.createOrUpdatePartial.test.ts
@@ -5,6 +5,7 @@ import {
   countOfTags,
   insertAuthor,
   insertBook,
+  insertBookReview,
   insertBookToTag,
   insertTag,
   select,
@@ -198,19 +199,20 @@ describe("EntityManager.createOrUpdatePartial", () => {
   it("collections can delete children w/o delete flag if they are owned", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    await insertBook({ title: "b2", author_id: 1 });
+    await insertBookReview({ book_id: 1, rating: 5 });
+    await insertBookReview({ book_id: 1, rating: 5 });
     const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, {
-      id: "a:1",
-      books: [{ id: "b:2" }],
+    const b1 = await em.createOrUpdatePartial(Book, {
+      id: "b:1",
+      reviews: [{ id: "br:2" }],
     });
-    const loaded = await em.populate(a1, "books");
-    // get shows only b1
-    expect(loaded.books.get.length).toBe(1);
+    const loaded = await em.populate(b1, "reviews");
+    // get shows only br1
+    expect(loaded.reviews.get.length).toBe(1);
     // getWithDeleted still shows both b1 and b2
-    expect(loaded.books.getWithDeleted.length).toBe(2);
+    expect(loaded.reviews.getWithDeleted.length).toBe(2);
     await em.flush();
-    const rows = await select("books");
+    const rows = await select("book_reviews");
     expect(rows.length).toEqual(1);
   });
 

--- a/packages/integration-tests/src/EntityManager.createOrUpdatePartial.test.ts
+++ b/packages/integration-tests/src/EntityManager.createOrUpdatePartial.test.ts
@@ -176,14 +176,33 @@ describe("EntityManager.createOrUpdatePartial", () => {
     expect(b2.title).toEqual("b2");
   });
 
-  it("collections can delete children", async () => {
+  it("collections can delete children with delete flag", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     await insertBook({ title: "b2", author_id: 1 });
     const em = newEntityManager();
-    const a1 = await await em.createOrUpdatePartial(Author, {
+    const a1 = await em.createOrUpdatePartial(Author, {
       id: "a:1",
       books: [{ id: "b:1", delete: true }, { id: "b:2" }],
+    });
+    const loaded = await em.populate(a1, "books");
+    // get shows only b1
+    expect(loaded.books.get.length).toBe(1);
+    // getWithDeleted still shows both b1 and b2
+    expect(loaded.books.getWithDeleted.length).toBe(2);
+    await em.flush();
+    const rows = await select("books");
+    expect(rows.length).toEqual(1);
+  });
+
+  it("collections can delete children w/o delete flag if they are owned", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertBook({ title: "b2", author_id: 1 });
+    const em = newEntityManager();
+    const a1 = await em.createOrUpdatePartial(Author, {
+      id: "a:1",
+      books: [{ id: "b:2" }],
     });
     const loaded = await em.populate(a1, "books");
     // get shows only b1
@@ -225,7 +244,7 @@ describe("EntityManager.createOrUpdatePartial", () => {
   });
 
   it("collections can incrementally remove children", async () => {
-    // Given an book with two tags
+    // Given a book with two tags
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     await insertTag({ name: "t1" });
@@ -243,7 +262,7 @@ describe("EntityManager.createOrUpdatePartial", () => {
   });
 
   it("collections can incrementally delete children", async () => {
-    // Given an book with two tag
+    // Given a book with two tag
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     await insertTag({ name: "t1" });
@@ -261,7 +280,7 @@ describe("EntityManager.createOrUpdatePartial", () => {
   });
 
   it("collections can incrementally add children", async () => {
-    // Given an book with one tag
+    // Given a book with one tag
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     await insertTag({ name: "t1" });
@@ -276,7 +295,7 @@ describe("EntityManager.createOrUpdatePartial", () => {
   });
 
   it("collections can incrementally not clear collections by seeing a marker", async () => {
-    // Given an book with one tag
+    // Given a book with one tag
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     await insertTag({ name: "t1" });

--- a/packages/integration-tests/src/relations/OneToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/OneToManyCollection.test.ts
@@ -1,4 +1,4 @@
-import { insertAuthor, insertBook, insertPublisher, select } from "@src/entities/inserts";
+import { insertAuthor, insertBook, insertBookReview, insertPublisher, select } from "@src/entities/inserts";
 import { Author, Book, newAuthor, newBook, newPublisher, Publisher } from "../entities";
 import { newEntityManager, numberOfQueries, resetQueryCount } from "../setupDbTests";
 
@@ -236,23 +236,24 @@ describe("OneToManyCollection", () => {
   });
 
   it("can set and deleted owned children", async () => {
-    // Given an author has two books
+    // Given a book with two reviews
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
-    await insertBook({ title: "b2", author_id: 1 });
+    await insertBookReview({ book_id: 1, rating: 5 });
+    await insertBookReview({ book_id: 1, rating: 5 });
     const em = newEntityManager();
-    const a1 = await em.load(Author, "a:1", "books");
-    const [b1, b2] = a1.books.get;
-    // When we set a1.books to be only b2
-    a1.books.set([b2]);
-    // Then get shows only b1
-    await expect(a1).toMatchEntity({ books: [b2] });
+    const b1 = await em.load(Book, "b:1", "reviews");
+    const [r1, r2] = b1.reviews.get;
+    // When we set b1.reviews to be only r2
+    b1.reviews.set([r2]);
+    // Then get shows only r1
+    expect(b1.reviews.get.length).toBe(1);
     // And getWithDeleted still shows both b1 and b2
-    expect(a1.books.getWithDeleted.length).toBe(2);
-    // And b1 is marked for deletion
-    expect(b1.isPendingDelete).toBe(true);
+    expect(b1.reviews.getWithDeleted.length).toBe(2);
+    // And r1 is marked for deletion
+    expect(r1.isPendingDelete).toBe(true);
     await em.flush();
-    const rows = await select("books");
+    const rows = await select("book_reviews");
     expect(rows.length).toEqual(1);
   });
 

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -187,14 +187,6 @@ export function setOpts<T extends Entity>(
           }
         });
 
-        // If we're changes `a1.books = [b1, b2]` to `a1.books = [b2]`, then implicitly delete the old book
-        // if ((current as any).isCascadeDelete) {
-        //   const existing = (current as any).get as Entity[];
-        //   const implicitlyDeleted = existing.filter((e) => !toSet.includes(e));
-        //   implicitlyDeleted.forEach((e) => entity.em.delete(e));
-        //   toSet.push(...implicitlyDeleted);
-        // }
-
         current.set(toSet);
       } else {
         current.set(value);

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -186,6 +186,15 @@ export function setOpts<T extends Entity>(
             toSet.push(e);
           }
         });
+
+        // If we're changes `a1.books = [b1, b2]` to `a1.books = [b2]`, then implicitly delete the old book
+        // if ((current as any).isCascadeDelete) {
+        //   const existing = (current as any).get as Entity[];
+        //   const implicitlyDeleted = existing.filter((e) => !toSet.includes(e));
+        //   implicitlyDeleted.forEach((e) => entity.em.delete(e));
+        //   toSet.push(...implicitlyDeleted);
+        // }
+
         current.set(toSet);
       } else {
         current.set(value);

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -66,7 +66,8 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
   private loaded!: U | N | undefined;
   // We need a separate boolean to b/c loaded == undefined can still mean "_isLoaded" for nullable fks.
   private _isLoaded = false;
-  private readonly isCascadeDelete: boolean;
+  // Used by setOpts to handle implicit deletion
+  readonly isCascadeDelete: boolean;
 
   constructor(
     private entity: T,

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -66,8 +66,7 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
   private loaded!: U | N | undefined;
   // We need a separate boolean to b/c loaded == undefined can still mean "_isLoaded" for nullable fks.
   private _isLoaded = false;
-  // Used by setOpts to handle implicit deletion
-  readonly isCascadeDelete: boolean;
+  private readonly isCascadeDelete: boolean;
 
   constructor(
     private entity: T,

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -119,6 +119,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     if (this.isCascadeDelete) {
       const implicitlyDeleted = this.loaded.filter((e) => !values.includes(e));
       implicitlyDeleted.forEach((e) => this.entity.em.delete(e));
+      // Keep the implicitlyDeleted values for `getWithDeleted` to return
       values.push(...implicitlyDeleted);
     }
 

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -116,7 +116,8 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     }
 
     // If we're changing `a1.books = [b1, b2]` to `a1.books = [b2]`, then implicitly delete the old book
-    if (this.isCascadeDelete) {
+    const otherCannotChange = this.otherMeta.fields[this.otherFieldName].immutable;
+    if (this.isCascadeDelete && otherCannotChange) {
       const implicitlyDeleted = this.loaded.filter((e) => !values.includes(e));
       implicitlyDeleted.forEach((e) => this.entity.em.delete(e));
       // Keep the implicitlyDeleted values for `getWithDeleted` to return

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -114,6 +114,14 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     if (this.loaded === undefined) {
       throw new Error("set was called when not loaded");
     }
+
+    // If we're changing `a1.books = [b1, b2]` to `a1.books = [b2]`, then implicitly delete the old book
+    if (this.isCascadeDelete) {
+      const implicitlyDeleted = this.loaded.filter((e) => !values.includes(e));
+      implicitlyDeleted.forEach((e) => this.entity.em.delete(e));
+      values.push(...implicitlyDeleted);
+    }
+
     // Make a copy for safe iteration
     const loaded = [...this.loaded];
     // Remove old values


### PR DESCRIPTION
Where ownership is determined by cascade deletion from the parent to the child.