### PR TITLE
fix: Allow toMatchEntity to work on object literals.

### DIFF
--- a/packages/integration-tests/src/toMatchEntity.test.ts
+++ b/packages/integration-tests/src/toMatchEntity.test.ts
@@ -194,12 +194,16 @@ expect(received).toMatchObject(expected)
     const p1 = newPublisher(em, { name: "p1" });
     await expect({
       publisher: p1,
+      publisher2: p1 as Publisher | null,
       publishers: [p1],
       publishers2: [p1] as readonly Publisher[],
+      publishers3: [p1] as readonly Publisher[] | null,
     }).toMatchEntity({
       publisher: { name: "p1" },
+      publisher2: { name: "p1" },
       publishers: [{ name: "p1" }],
       publishers2: [{ name: "p1" }],
+      publishers3: [{ name: "p1" }],
     });
   });
 });

--- a/packages/integration-tests/src/toMatchEntity.test.ts
+++ b/packages/integration-tests/src/toMatchEntity.test.ts
@@ -1,5 +1,5 @@
 import { alignedAnsiStyleSerializer } from "@src/alignedAnsiStyleSerializer";
-import { newAuthor, newBook, newPublisher } from "@src/entities";
+import { newAuthor, newBook, newPublisher, Publisher } from "@src/entities";
 import { newEntityManager } from "./setupDbTests";
 
 expect.addSnapshotSerializer(alignedAnsiStyleSerializer as any);
@@ -187,5 +187,19 @@ expect(received).toMatchObject(expected)
     const b1 = newBook(em);
     // @ts-expect-error
     await expect(expect(b1).toMatchEntity({ author: { firstName2: "name" } })).rejects.toThrow();
+  });
+
+  it("can match object literals", async () => {
+    const em = newEntityManager();
+    const p1 = newPublisher(em, { name: "p1" });
+    await expect({
+      publisher: p1,
+      publishers: [p1],
+      publishers2: [p1] as readonly Publisher[],
+    }).toMatchEntity({
+      publisher: { name: "p1" },
+      publishers: [{ name: "p1" }],
+      publishers2: [{ name: "p1" }],
+    });
   });
 });

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -113,5 +113,9 @@ export type MatchedEntity<T> = {
     ? Array<MatchedEntity<U> | U>
     : T[K] extends AsyncProperty<any, infer V>
     ? V
+    : T[K] extends Entity
+    ? MatchedEntity<T[K]>
+    : T[K] extends ReadonlyArray<infer U>
+    ? MatchedEntity<readonly U[]>
     : T[K] | null;
 };

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -115,7 +115,11 @@ export type MatchedEntity<T> = {
     ? V
     : T[K] extends Entity
     ? MatchedEntity<T[K]>
+    : T[K] extends Entity | null
+    ? MatchedEntity<T[K] | null>
     : T[K] extends ReadonlyArray<infer U>
     ? MatchedEntity<readonly U[]>
+    : T[K] extends ReadonlyArray<infer U> | null
+    ? MatchedEntity<readonly U[] | null>
     : T[K] | null;
 };


### PR DESCRIPTION
I.e. results of GraphQL resolvers.