### PR TITLE
fix: Fix calling isLoaded with the wrong hint.

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -225,6 +225,12 @@ describe("Author", () => {
     expect(rows[0].number_of_books).toEqual(1);
   });
 
+  it("can access async derived values if loaded", async () => {
+    const em = newEntityManager();
+    const a1 = new Author(em, { firstName: "a1" });
+    expect(a1.numberOfBooks.get).toEqual(0);
+  });
+
   it("has async derived values automatically recalced", async () => {
     const em = newEntityManager();
     // Given an author with initially no books

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -91,7 +91,9 @@ export class Author extends AuthorCodegen {
   /** Example of a derived async property that can be calculated via a populate hint. */
   readonly numberOfBooks: PersistedAsyncProperty<Author, number> = hasPersistedAsyncProperty(
     "numberOfBooks",
-    "books",
+    // Include firstName to ensure `.get` uses the load hint (and not the full reactive hint)
+    // when evaluating whether to eval our lambda during pre-flush calls.
+    ["books", "firstName"],
     (a) => {
       a.entity.numberOfBooksCalcInvoked++;
       return a.books.get.length;

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -256,12 +256,14 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
     Object.values(meta.fields)
       .filter((f) => f.kind === "primitive" && f.derived === "async")
       .forEach((field) => {
-        const asyncProperty = getFakeInstance(meta)[field.fieldName] as PersistedAsyncPropertyImpl<any, any, any>;
+        const asyncProperty = getFakeInstance(meta)[field.fieldName] as
+          | PersistedAsyncPropertyImpl<any, any, any>
+          | undefined;
         // We might have an async property configured in joist-codegen.json that has not yet
         // been made a `hasPersistedAsyncProperty` in the entity file, so avoid continuing
         // if we don't actually have a property/loadHint available.
-        if (asyncProperty.loadHint) {
-          const reversals = reverseReactiveHint(meta.cstr, asyncProperty.loadHint);
+        if (asyncProperty?.reactiveHint) {
+          const reversals = reverseReactiveHint(meta.cstr, asyncProperty.reactiveHint);
           reversals.forEach(({ entity, path, fields }) => {
             getMetadata(entity).config.__data.reactiveDerivedValues.push({ name: field.fieldName, path, fields });
           });


### PR DESCRIPTION
We were using the reactiveHint which has primitives in it like `firstName` that will never be loaded / pass isLoaded check.

If we use the load hint, then we'll only have relations, which is what `isLoaded` expects to see.