### PR TITLE
fix: Fix getCallerName when running via tsx.

### DIFF
--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -165,7 +165,9 @@ export class ConfigData<T extends Entity, C> {
 function getCallerName(): string {
   const err = getErrorObject();
   // E.g. at Object.<anonymous> (/home/stephen/homebound/graphql-service/src/entities/Activity.ts:86:8)
-  const line = err.stack!.split("\n")[4];
+  // (Make sure to drop lines that don't start with 'at' b/c the stack format can differ
+  // slightly i.e. if running via tsx/using a node loader (probably?)
+  const line = err.stack!.split("\n").filter((line) => line.includes(" at "))[3];
   const parts = line.split("/");
   // Get the last part, which will be the file name, i.e. Activity.ts:86:8
   return parts[parts.length - 1].replace(/:\d+\)?$/, "");


### PR DESCRIPTION
For some reason using tsx means `error.stack` is more verbose and has a few lines at the beginning that we did not have before...maybe b/c of going through the loader API?

Not entirely sure, but this fixes it by ignoring any lines in the stack that are not `at` lines in the souce.