### PR TITLE
feat: Add EntityManager.assignNewIds capability

### DIFF
--- a/packages/integration-tests/src/EntityManager.assignNewIds.test.ts
+++ b/packages/integration-tests/src/EntityManager.assignNewIds.test.ts
@@ -1,0 +1,24 @@
+import { newPublisher } from "./entities";
+import { newEntityManager } from "./setupDbTests";
+
+describe("EntityManager.assignNewIds", () => {
+  it("can assign entity IDs on request", async () => {
+    const em = newEntityManager();
+
+    // Given an entity
+    const p1 = newPublisher(em, { name: "p1" });
+    expect(p1.id).toBeUndefined();
+
+    // When I ask to assign the ids
+    await em.assignNewIds();
+    // Then the ID was set appropriately and the entity is still considered new
+    expect(p1.id).toEqual("p:1");
+    expect(p1.isNewEntity).toEqual(true);
+
+    // And when I flush
+    await em.flush();
+    // Then the id remains the same and the entity is no longer new
+    expect(p1.id).toEqual("p:1");
+    expect(p1.isNewEntity).toEqual(false);
+  });
+});

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -773,6 +773,12 @@ export class EntityManager<C = {}> {
     getRelations(deletedEntity).forEach((relation) => relation.maybeCascadeDelete());
   }
 
+  async assignNewIds() {
+    let pendingEntities = this.entities.filter((e) => e.isNewEntity && !e.id);
+    let todos = createTodos(pendingEntities);
+    return this.driver.assignNewIds(this, todos);
+  }
+
   /**
    * Flushes the SQL for any changed entities to the database.
    *

--- a/packages/orm/src/drivers/IdAssigner.ts
+++ b/packages/orm/src/drivers/IdAssigner.ts
@@ -20,7 +20,9 @@ export class SequenceIdAssigner implements IdAssigner {
       if (todo.inserts.length > 0) {
         const meta = todo.inserts[0].__orm.metadata;
         const sequenceName = `${meta.tableName}_id_seq`;
-        const sql = `select nextval('${sequenceName}') from generate_series(1, ${todo.inserts.length})`;
+        const sql = `select nextval('${sequenceName}') from generate_series(1, ${
+          todo.inserts.filter((e) => e.id === undefined).length
+        })`;
         seqStatements.push(sql);
       }
     });
@@ -30,7 +32,7 @@ export class SequenceIdAssigner implements IdAssigner {
       const result = await knex.raw(sql);
       let i = 0;
       Object.values(todos).forEach((todo) => {
-        for (const insert of todo.inserts) {
+        for (const insert of todo.inserts.filter((e) => e.id === undefined)) {
           insert.__orm.data["id"] = keyToString(todo.metadata, result.rows![i++]["nextval"]);
         }
       });

--- a/packages/orm/src/drivers/PostgresDriver.ts
+++ b/packages/orm/src/drivers/PostgresDriver.ts
@@ -276,6 +276,11 @@ export class PostgresDriver implements Driver {
     });
   }
 
+  async assignNewIds(em: EntityManager, todos: Record<string, Todo>): Promise<void> {
+    const knex = this.getMaybeInTxnKnex(em);
+    return this.idAssigner.assignNewIds(knex, todos);
+  }
+
   async flushEntities(em: EntityManager, todos: Record<string, Todo>): Promise<void> {
     const knex = this.getMaybeInTxnKnex(em);
     const now = getNow();

--- a/packages/orm/src/drivers/driver.ts
+++ b/packages/orm/src/drivers/driver.ts
@@ -68,6 +68,8 @@ export interface Driver {
     isolationLevel?: "serializable",
   ): Promise<T>;
 
+  assignNewIds(em: EntityManager, todos: Record<string, Todo>): Promise<void>;
+
   flushEntities(em: EntityManager, todos: Record<string, Todo>): Promise<void>;
 
   flushJoinTables(em: EntityManager, joinRows: Record<string, JoinRowTodo>): Promise<void>;


### PR DESCRIPTION
For cases where you need to know the ID of an entity prior to it being flushed, you can now call `EntityManager.assignNewIds`.