### PR TITLE
fix: Add constraints to Loaded and Reacted hints.

### DIFF
--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -95,6 +95,7 @@ export class Author extends AuthorCodegen {
     // when evaluating whether to eval our lambda during pre-flush calls.
     ["books", "firstName"],
     (a) => {
+      const b = a.entity;
       a.entity.numberOfBooksCalcInvoked++;
       return a.books.get.length;
     },


### PR DESCRIPTION
Currently Loaded's and Reacted's H hint types are not enforced to be valid hints for the given entity.

This fixes that, although with some admitted more boilerplate around destructuring nested load hints b/c we have to keep conditionally asking "is the next load/reactive hint valid?" before recursively calling Loaded<...U...> / Reacted<...U...>.

Going to leave this draft for now and see if it we need it.