### PR TITLE
fix: Ensure sameEntity works even if an ID has been assigned to a new entity

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1246,6 +1246,18 @@ describe("EntityManager", () => {
       expect(sameEntity(a2, a1)).toEqual(false);
     });
 
+    it("handles new entity which has id assigned", async () => {
+      const em = newEntityManager();
+      const a1 = newAuthor(em);
+
+      expect(sameEntity(a1, a1)).toEqual(true);
+      await em.assignNewIds();
+
+      expect(sameEntity(a1, a1)).toEqual(true);
+      expect(sameEntity(a1, a1.idOrFail)).toEqual(true);
+      expect(sameEntity(a1.idOrFail, a1)).toEqual(true);
+    });
+
     it("handles existing entities", async () => {
       const em = newEntityManager();
       const a1 = newAuthor(em);

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1053,10 +1053,11 @@ export function sameEntity(a: Entity | string | undefined, b: Entity | string | 
   if (a === undefined || b === undefined) {
     return a === undefined && b === undefined;
   }
-  // If either entity is new, then neither can be a persisted id
-  if ((isEntity(a) && a.isNewEntity) || (isEntity(b) && b.isNewEntity)) {
+  // If both are entities, return if they are the same reference
+  if (isEntity(a) && isEntity(b)) {
     return a === b;
   }
+  // Otherwise check by ID
   const aId = isEntity(a) ? a.idTagged : a;
   const bId = isEntity(b) ? b.idTagged : b;
   return aId === bId;


### PR DESCRIPTION
This fixes a max stack trace exceeded observed when using the original commit in graphql-service