### PR TITLE
fix: loadHints.isNew was checking for idTagged===undefined

### DIFF
--- a/packages/integration-tests/src/EntityManager.assignNewIds.test.ts
+++ b/packages/integration-tests/src/EntityManager.assignNewIds.test.ts
@@ -1,5 +1,6 @@
 import { newPublisher } from "./entities";
 import { newEntityManager } from "./setupDbTests";
+import { isNew } from "joist-orm";
 
 describe("EntityManager.assignNewIds", () => {
   it("can assign entity IDs on request", async () => {
@@ -14,11 +15,13 @@ describe("EntityManager.assignNewIds", () => {
     // Then the ID was set appropriately and the entity is still considered new
     expect(p1.id).toEqual("p:1");
     expect(p1.isNewEntity).toEqual(true);
+    expect(isNew(p1)).toEqual(true);
 
     // And when I flush
     await em.flush();
     // Then the id remains the same and the entity is no longer new
     expect(p1.id).toEqual("p:1");
     expect(p1.isNewEntity).toEqual(false);
+    expect(isNew(p1)).toEqual(false);
   });
 });

--- a/packages/orm/src/loadHints.ts
+++ b/packages/orm/src/loadHints.ts
@@ -95,7 +95,7 @@ export type DeepNew<T extends Entity> = Loaded<T, DeepLoadHint<T>>;
 
 /** Detects whether an entity is newly created, and so we can treat all the relations as loaded. */
 export function isNew<T extends Entity>(e: T): e is New<T> {
-  return e.idTagged === undefined;
+  return e.isNewEntity;
 }
 
 /**


### PR DESCRIPTION
Switched to using `entity.isNewEntity`