### PR TITLE
fix: Issue where isLoaded does not correctly handle nullable loaded references

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -630,4 +630,14 @@ describe("Author", () => {
     // Even though its deleted
     expect(b2.isPendingDelete).toBe(true);
   });
+
+  it("isLoaded returns correctly when a field is nullable", async () => {
+    // Given an author without a publisher that has two comments
+    const em = newEntityManager();
+    const a = newAuthor(em, { publisher: null, comments: [{}, {}] });
+    // When we ask for latestComment
+    const comment = a.latestComment.get;
+    // Then it should succeed
+    expect(comment).toEqual(a.comments.get[0]);
+  });
 });

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -6,11 +6,13 @@ import {
   hasAsyncProperty,
   hasManyDerived,
   hasManyThrough,
+  hasOneDerived,
   hasPersistedAsyncProperty,
   Loaded,
   PersistedAsyncProperty,
+  Reference,
 } from "joist-orm";
-import { AuthorCodegen, authorConfig as config, Book, BookReview } from "./entities";
+import { AuthorCodegen, authorConfig as config, Book, BookReview, Comment } from "./entities";
 
 export class Author extends AuthorCodegen {
   readonly reviews: Collection<Author, BookReview> = hasManyThrough((author) => author.books.reviews);
@@ -40,6 +42,10 @@ export class Author extends AuthorCodegen {
         loaded.reviews.get.forEach((r) => getEm(author).delete(r));
       },
     },
+  );
+  readonly latestComment: Reference<Author, Comment, undefined> = hasOneDerived(
+    { publisher: "comments", comments: {} },
+    (author) => author.publisher.get?.comments.get[0] ?? author.comments.get[0],
   );
 
   public beforeFlushRan = false;

--- a/packages/orm/src/loadHints.ts
+++ b/packages/orm/src/loadHints.ts
@@ -162,7 +162,9 @@ export function isLoaded<T extends Entity, H extends LoadHint<T>>(entity: T, hin
         const result = relation.get;
         return Array.isArray(result)
           ? result.every((entity) => isLoaded(entity, nestedHint))
-          : isLoaded(result, nestedHint);
+          : result
+          ? isLoaded(result, nestedHint)
+          : true;
       } else {
         return false;
       }


### PR DESCRIPTION
Discovered due to this failing test in GQL service
![image](https://user-images.githubusercontent.com/24765506/198850405-6a88b0fd-4356-4190-b7ff-1a1e8820f71e.png)

When the `changeOrder` was loaded but null, we would still attempt to recurse into `isLoaded` again giving the message above.