### PR TITLE
fix: Make metadata inaccessible via Object.keys enumeration.

### DIFF
--- a/packages/integration-tests/src/Entity.test.ts
+++ b/packages/integration-tests/src/Entity.test.ts
@@ -1,0 +1,215 @@
+import { Author } from "@src/entities";
+import { insertAuthor } from "@src/entities/inserts";
+import { newEntityManager } from "@src/setupDbTests";
+
+describe("Entity", () => {
+  it("does not expose the metadata via Object.keys/enumerable properties", async () => {
+    await insertAuthor({ first_name: "f" });
+    const em = newEntityManager();
+    const author = await em.load(Author, "1");
+    const copy = deepCopyAndNormalize(author);
+    expect(copy).toMatchInlineSnapshot(`
+      {
+        "afterCommitIdIsSet": false,
+        "afterCommitIsDeletedEntity": false,
+        "afterCommitIsNewEntity": false,
+        "afterCommitRan": false,
+        "afterValidationRan": false,
+        "ageRuleInvoked": 0,
+        "authors": {
+          "addedBeforeLoaded": [],
+          "entity": "[Circular reference found] Truncated by IDE",
+          "fieldName": "authors",
+          "isCascadeDelete": false,
+          "otherColumnName": "mentor_id",
+          "otherFieldName": "mentor",
+          "undefined": null,
+        },
+        "beforeCreateRan": false,
+        "beforeDeleteRan": false,
+        "beforeFlushRan": false,
+        "beforeUpdateRan": false,
+        "bookComments": {
+          "entity": "[Circular reference found] Truncated by IDE",
+          "fieldName": "bookComments",
+          "fn": {},
+          "loadHint": {
+            "books": {
+              "comments": {},
+            },
+          },
+          "loaded": false,
+          "reactiveHint": {
+            "books": {
+              "comments": "text",
+            },
+          },
+        },
+        "bookCommentsCalcInvoked": 0,
+        "books": {
+          "addedBeforeLoaded": [],
+          "entity": "[Circular reference found] Truncated by IDE",
+          "fieldName": "books",
+          "isCascadeDelete": true,
+          "otherColumnName": "author_id",
+          "otherFieldName": "author",
+          "undefined": null,
+        },
+        "comments": {
+          "addedBeforeLoaded": [],
+          "entity": "[Circular reference found] Truncated by IDE",
+          "fieldName": "comments",
+          "isCascadeDelete": false,
+          "otherColumnName": "parent_author_id",
+          "otherFieldName": "parent",
+          "undefined": null,
+        },
+        "currentDraftBook": {
+          "_isLoaded": false,
+          "fieldName": "currentDraftBook",
+          "isCascadeDelete": false,
+          "otherFieldName": "currentDraftAuthor",
+          "undefined": null,
+        },
+        "deleteDuringFlush": false,
+        "entity": "[Circular reference found] Truncated by IDE",
+        "graduatedRuleInvoked": 0,
+        "image": {
+          "_isLoaded": false,
+          "entity": "[Circular reference found] Truncated by IDE",
+          "fieldName": "image",
+          "isCascadeDelete": true,
+          "otherColumnName": "author_id",
+          "otherFieldName": "author",
+          "undefined": null,
+        },
+        "latestComment": {
+          "_isLoaded": false,
+          "entity": "[Circular reference found] Truncated by IDE",
+          "opts": {
+            "get": {},
+            "isLoaded": {},
+            "load": {},
+          },
+          "undefined": null,
+        },
+        "mentor": {
+          "_isLoaded": false,
+          "fieldName": "mentor",
+          "isCascadeDelete": false,
+          "otherFieldName": "authors",
+          "undefined": null,
+        },
+        "mentorRuleInvoked": 0,
+        "numberOfBooks": {
+          "entity": "[Circular reference found] Truncated by IDE",
+          "fieldName": "numberOfBooks",
+          "fn": {},
+          "loadHint": {
+            "books": {},
+          },
+          "loaded": false,
+          "reactiveHint": [
+            "books",
+            "firstName",
+          ],
+        },
+        "numberOfBooks2": {
+          "entity": "[Circular reference found] Truncated by IDE",
+          "fn": {},
+          "hint": "books",
+          "loaded": false,
+        },
+        "numberOfBooksCalcInvoked": 0,
+        "publisher": {
+          "_isLoaded": false,
+          "fieldName": "publisher",
+          "isCascadeDelete": false,
+          "otherFieldName": "authors",
+          "undefined": null,
+        },
+        "reviewedBooks": {
+          "_isLoaded": false,
+          "entity": "[Circular reference found] Truncated by IDE",
+          "opts": {
+            "add": {},
+            "get": {},
+            "isLoaded": {},
+            "load": {},
+            "remove": {},
+            "set": {},
+          },
+        },
+        "reviews": {
+          "_isLoaded": false,
+          "entity": "[Circular reference found] Truncated by IDE",
+          "opts": {
+            "get": {},
+            "isLoaded": {},
+            "load": {},
+          },
+        },
+        "tags": {
+          "addedBeforeLoaded": [],
+          "columnName": "author_id",
+          "entity": "[Circular reference found] Truncated by IDE",
+          "fieldName": "tags",
+          "isCascadeDelete": false,
+          "joinTableName": "authors_to_tags",
+          "otherColumnName": "tag_id",
+          "otherFieldName": "authors",
+          "removedBeforeLoaded": [],
+        },
+      }
+    `);
+  });
+});
+
+// Based on the deep copy that was tripping up Webstorm
+function deepCopyAndNormalize(value: any) {
+  const active: unknown[] = [];
+  return (function doCopy(value, path): any {
+    if (value == null) {
+      return value;
+    }
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "string") {
+      return value;
+    }
+    if (value instanceof RegExp) {
+      return value;
+    }
+
+    if (active.indexOf(value) !== -1) {
+      return "[Circular reference found] Truncated by IDE";
+    }
+    active.push(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map(function (element, i) {
+          return doCopy(element, `${path}.${i}`);
+        });
+      }
+
+      if (isObject(value)) {
+        var keys = Object.keys(value);
+        keys.sort();
+        var ret: any = {};
+        keys.forEach(function (key) {
+          // If we hint anything with `.hooks` assume it's metadata
+          if (key === "hooks") {
+            throw new Error(`Recursed into the metadata: ${path}`);
+          }
+          ret[key] = doCopy(value[key], `${path}.${key}`);
+        });
+        return ret;
+      }
+      return value;
+    } finally {
+      active.pop();
+    }
+  })(value, "value");
+}
+
+function isObject(val: any): boolean {
+  return val === Object(val);
+}

--- a/packages/integration-tests/src/Entity.test.ts
+++ b/packages/integration-tests/src/Entity.test.ts
@@ -17,10 +17,7 @@ describe("Entity", () => {
         "afterValidationRan": false,
         "ageRuleInvoked": 0,
         "authors": {
-          "addedBeforeLoaded": [],
-          "entity": "[Circular reference found] Truncated by IDE",
           "fieldName": "authors",
-          "isCascadeDelete": false,
           "otherColumnName": "mentor_id",
           "otherFieldName": "mentor",
           "undefined": null,
@@ -30,7 +27,6 @@ describe("Entity", () => {
         "beforeFlushRan": false,
         "beforeUpdateRan": false,
         "bookComments": {
-          "entity": "[Circular reference found] Truncated by IDE",
           "fieldName": "bookComments",
           "fn": {},
           "loadHint": {
@@ -47,19 +43,13 @@ describe("Entity", () => {
         },
         "bookCommentsCalcInvoked": 0,
         "books": {
-          "addedBeforeLoaded": [],
-          "entity": "[Circular reference found] Truncated by IDE",
           "fieldName": "books",
-          "isCascadeDelete": true,
           "otherColumnName": "author_id",
           "otherFieldName": "author",
           "undefined": null,
         },
         "comments": {
-          "addedBeforeLoaded": [],
-          "entity": "[Circular reference found] Truncated by IDE",
           "fieldName": "comments",
-          "isCascadeDelete": false,
           "otherColumnName": "parent_author_id",
           "otherFieldName": "parent",
           "undefined": null,
@@ -72,11 +62,9 @@ describe("Entity", () => {
           "undefined": null,
         },
         "deleteDuringFlush": false,
-        "entity": "[Circular reference found] Truncated by IDE",
         "graduatedRuleInvoked": 0,
         "image": {
           "_isLoaded": false,
-          "entity": "[Circular reference found] Truncated by IDE",
           "fieldName": "image",
           "isCascadeDelete": true,
           "otherColumnName": "author_id",
@@ -85,7 +73,6 @@ describe("Entity", () => {
         },
         "latestComment": {
           "_isLoaded": false,
-          "entity": "[Circular reference found] Truncated by IDE",
           "opts": {
             "get": {},
             "isLoaded": {},
@@ -102,7 +89,6 @@ describe("Entity", () => {
         },
         "mentorRuleInvoked": 0,
         "numberOfBooks": {
-          "entity": "[Circular reference found] Truncated by IDE",
           "fieldName": "numberOfBooks",
           "fn": {},
           "loadHint": {
@@ -115,7 +101,6 @@ describe("Entity", () => {
           ],
         },
         "numberOfBooks2": {
-          "entity": "[Circular reference found] Truncated by IDE",
           "fn": {},
           "hint": "books",
           "loaded": false,
@@ -130,7 +115,6 @@ describe("Entity", () => {
         },
         "reviewedBooks": {
           "_isLoaded": false,
-          "entity": "[Circular reference found] Truncated by IDE",
           "opts": {
             "add": {},
             "get": {},
@@ -142,7 +126,6 @@ describe("Entity", () => {
         },
         "reviews": {
           "_isLoaded": false,
-          "entity": "[Circular reference found] Truncated by IDE",
           "opts": {
             "get": {},
             "isLoaded": {},
@@ -152,7 +135,6 @@ describe("Entity", () => {
         "tags": {
           "addedBeforeLoaded": [],
           "columnName": "author_id",
-          "entity": "[Circular reference found] Truncated by IDE",
           "fieldName": "tags",
           "isCascadeDelete": false,
           "joinTableName": "authors_to_tags",

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -23,20 +23,24 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
   // This gives rules a way to access the fully typed object instead of their Reacted view.
   // And we make it public so that a function that takes Reacted<...> can accept a Loaded<...>
   // that sufficiently overlaps.
-  readonly entity: this;
+  readonly entity!: this;
 
   protected constructor(em: EntityManager, metadata: any, defaultValues: object, opts: any) {
     Object.defineProperty(this, "__orm", {
       value: { em, metadata, data: { ...defaultValues }, originalData: {}, isNew: true, isTouched: false },
       enumerable: false,
-    })
+    });
+    Object.defineProperty(this, "entity", {
+      value: this,
+      enumerable: false,
+      writable: false,
+    });
     // Ensure we have at least id set so the `EntityManager.register` works
     if (typeof opts === "string") {
       this.__orm.data["id"] = opts;
       this.__orm.isNew = false;
     }
     em.register(metadata, this);
-    this.entity = this;
   }
 
   get idUntagged(): string | undefined {

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -19,14 +19,17 @@ import {
 export abstract class BaseEntity<EM extends EntityManager = EntityManager> implements Entity {
   abstract id: string | undefined;
   abstract idTagged: string | undefined;
-  readonly __orm: EntityOrmField;
+  readonly __orm!: EntityOrmField;
   // This gives rules a way to access the fully typed object instead of their Reacted view.
   // And we make it public so that a function that takes Reacted<...> can accept a Loaded<...>
   // that sufficiently overlaps.
   readonly entity: this;
 
   protected constructor(em: EntityManager, metadata: any, defaultValues: object, opts: any) {
-    this.__orm = { em, metadata, data: { ...defaultValues }, originalData: {}, isNew: true, isTouched: false };
+    Object.defineProperty(this, "__orm", {
+      value: { em, metadata, data: { ...defaultValues }, originalData: {}, isNew: true, isTouched: false },
+      enumerable: false,
+    })
     // Ensure we have at least id set so the `EntityManager.register` works
     if (typeof opts === "string") {
       this.__orm.data["id"] = opts;

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -19,7 +19,7 @@ export interface Entity {
   idTaggedOrFail: string;
   idOrFail: string;
   /** Joist internal metadata, should be considered a private implementation detail. */
-  __orm: EntityOrmField;
+  readonly __orm: EntityOrmField;
   readonly em: EntityManager<any>;
   readonly isNewEntity: boolean;
   readonly isDeletedEntity: boolean;

--- a/packages/orm/src/dataloaders/oneToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyDataLoader.ts
@@ -18,7 +18,6 @@ export function oneToManyDataLoader<T extends Entity, U extends Entity>(
       assertIdsAreTagged(_keys);
       const keys = deTagIds(meta, _keys);
 
-      const { em } = collection.entity;
       const rows = await em.driver.loadOneToMany(em, collection, keys);
 
       const entities = rows.map((row) => em.hydrate(otherMeta.cstr, row, { overwriteExisting: false }));

--- a/packages/orm/src/getProperties.ts
+++ b/packages/orm/src/getProperties.ts
@@ -46,7 +46,8 @@ export function getFakeInstance<T extends Entity>(meta: EntityMetadata<T>): T {
     {
       register: (metadata: any, entity: any) => {
         em.currentlyInstantiatingEntity = entity;
-        entity.__orm = { metadata: meta, data: {} };
+        entity.__orm.metadata = meta;
+        entity.__orm.data = {};
       },
     } as any,
     {},

--- a/packages/orm/src/relations/CustomReference.ts
+++ b/packages/orm/src/relations/CustomReference.ts
@@ -30,13 +30,15 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
   extends AbstractRelationImpl<U>
   implements Reference<T, U, N>
 {
+  readonly #entity: T;
   // We keep both a promise+loaded flag and not an actual `this.loaded = await load` because
   // the value can become stale; we want to each `.get` call to repeatedly evaluate the latest value.
   private loadPromise: Promise<void> | undefined;
   private _isLoaded = false;
 
-  constructor(public entity: T, private opts: CustomReferenceOpts<T, U, N>) {
+  constructor(entity: T, private opts: CustomReferenceOpts<T, U, N>) {
     super();
+    this.#entity = entity;
   }
 
   get get(): U | N {
@@ -52,10 +54,10 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
   }
 
   async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<U | N> {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     if (!this.isLoaded || opts.forceReload) {
       if (this.loadPromise === undefined) {
-        this.loadPromise = this.opts.load(this.entity, opts);
+        this.loadPromise = this.opts.load(this.#entity, opts);
         await this.loadPromise;
         this.loadPromise = undefined;
         this._isLoaded = true;
@@ -94,19 +96,19 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
   get isSet(): boolean {
     this.ensureNewOrLoaded();
     const { get } = this.opts;
-    return get(this.entity) !== undefined;
+    return get(this.#entity) !== undefined;
   }
 
   set(value: U): void {
     // We allow setting CustomReferences on new entities w/o being loaded
-    if (!this.entity.isNewEntity) {
+    if (!this.#entity.isNewEntity) {
       this.ensureNewOrLoaded();
     }
     const { set } = this.opts;
     if (set === undefined) {
       throw new Error(`'set' not implemented on ${this}`);
     }
-    set(this.entity, value);
+    set(this.#entity, value);
   }
 
   setFromOpts(value: U): void {
@@ -119,17 +121,17 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
 
   /** Finds this CustomReferences field name by looking in the entity for the key that we're assigned to. */
   get fieldName(): string {
-    return Object.entries(this.entity).filter((e) => e[1] === this)[0][0];
+    return Object.entries(this.#entity).filter((e) => e[1] === this)[0][0];
   }
 
   toString(): string {
-    return `CustomReference(entity: ${this.entity}, fieldName: ${this.fieldName})`;
+    return `CustomReference(entity: ${this.#entity}, fieldName: ${this.fieldName})`;
   }
 
   private doGet(opts?: { withDeleted?: boolean }): U | N {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     this.ensureNewOrLoaded();
-    return this.filterDeleted(this.opts.get(this.entity), opts);
+    return this.filterDeleted(this.opts.get(this.#entity), opts);
   }
 
   private filterDeleted(entity: U | N, opts?: { withDeleted?: boolean }): U | N {
@@ -141,7 +143,7 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
     if (this.isLoaded || (this.opts.isLoaded && this.opts.isLoaded())) {
       return;
     }
-    fail(`${this.entity}.${this.fieldName} was not loaded`);
+    fail(`${this.#entity}.${this.fieldName} was not loaded`);
   }
 
   [RelationT]: T = null!;

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -38,6 +38,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   extends AbstractRelationImpl<U[]>
   implements Collection<T, U>
 {
+  readonly #entity: T;
   private loaded: U[] | undefined;
   private addedBeforeLoaded: U[] = [];
   private removedBeforeLoaded: U[] = [];
@@ -51,7 +52,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     // columnName = book_id, what we use as the `where book_id = us` to find our join table rows
     // otherFieldName = books, how tags points to us
     // otherColumnName = tag_id, how the other side finds its join table rows
-    public entity: T,
+    entity: T,
     public fieldName: keyof T & string,
     public columnName: string,
     otherMeta: EntityMetadata<U>,
@@ -59,6 +60,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     public otherColumnName: string,
   ) {
     super();
+    this.#entity = entity;
     this.#otherMeta = otherMeta;
     this.isCascadeDelete = otherMeta?.config.__data.cascadeDeleteFields.includes(fieldName as any);
   }
@@ -68,17 +70,17 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   }
 
   async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<ReadonlyArray<U>> {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     if (this.loaded === undefined || opts.forceReload) {
-      const key = `${this.columnName}=${this.entity.id}`;
-      this.loaded = await manyToManyDataLoader(this.entity.em, this).load(key);
+      const key = `${this.columnName}=${this.#entity.id}`;
+      this.loaded = await manyToManyDataLoader(this.#entity.em, this).load(key);
       this.maybeApplyAddedAndRemovedBeforeLoaded();
     }
     return this.filterDeleted(this.loaded!, opts) as ReadonlyArray<U>;
   }
 
   async find(id: IdOf<U>): Promise<U | undefined> {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     if (this.loaded !== undefined) {
       return this.loaded.find((u) => u.id === id);
     } else {
@@ -87,14 +89,14 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
         return added;
       }
       // Make a cacheable tuple to look up this specific m2m row
-      const key = `${this.columnName}=${this.entity.id},${this.otherColumnName}=${id}`;
-      const includes = await manyToManyFindDataLoader(this.entity.em, this).load(key);
-      return includes ? this.entity.em.load(id) : undefined;
+      const key = `${this.columnName}=${this.#entity.id},${this.otherColumnName}=${id}`;
+      const includes = await manyToManyFindDataLoader(this.#entity.em, this).load(key);
+      return includes ? this.#entity.em.load(id) : undefined;
     }
   }
 
   async includes(other: U): Promise<boolean> {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     if (this.loaded !== undefined) {
       return this.loaded.includes(other);
     } else {
@@ -104,13 +106,13 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
         return false;
       }
       // Make a cacheable tuple to look up this specific m2m row
-      const key = `${this.columnName}=${this.entity.idOrFail},${this.otherColumnName}=${other.idOrFail}`;
-      return manyToManyFindDataLoader(this.entity.em, this).load(key);
+      const key = `${this.columnName}=${this.#entity.idOrFail},${this.otherColumnName}=${other.idOrFail}`;
+      return manyToManyFindDataLoader(this.#entity.em, this).load(key);
     }
   }
 
   add(other: U, percolated = false): void {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.#entity);
 
     if (this.loaded !== undefined) {
       if (this.loaded.includes(other)) {
@@ -128,20 +130,20 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
       const joinRow: JoinRow = {
         id: undefined,
         m2m: this,
-        [this.columnName]: this.entity,
+        [this.columnName]: this.#entity,
         [this.otherColumnName]: other,
       };
-      getOrSet(this.entity.em.__data.joinRows, this.joinTableName, []).push(joinRow);
-      (other[this.otherFieldName] as any as ManyToManyCollection<U, T>).add(this.entity, true);
+      getOrSet(this.#entity.em.__data.joinRows, this.joinTableName, []).push(joinRow);
+      (other[this.otherFieldName] as any as ManyToManyCollection<U, T>).add(this.#entity, true);
     }
   }
 
   remove(other: U, percolated = false): void {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
 
     if (!percolated) {
-      const joinRows = getOrSet(this.entity.em.__data.joinRows, this.joinTableName, []);
-      const row = joinRows.find((r) => r[this.columnName] === this.entity && r[this.otherColumnName] === other);
+      const joinRows = getOrSet(this.#entity.em.__data.joinRows, this.joinTableName, []);
+      const row = joinRows.find((r) => r[this.columnName] === this.#entity && r[this.otherColumnName] === other);
       if (row) {
         row.deleted = true;
       } else {
@@ -149,13 +151,13 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
           // Use -1 to force the sortJoinRows to notice us as dirty ("delete: true but id is set")
           id: -1,
           m2m: this,
-          [this.columnName]: this.entity,
+          [this.columnName]: this.#entity,
           [this.otherColumnName]: other,
           deleted: true,
         };
-        getOrSet(this.entity.em.__data.joinRows, this.joinTableName, []).push(joinRow);
+        getOrSet(this.#entity.em.__data.joinRows, this.joinTableName, []).push(joinRow);
       }
-      (other[this.otherFieldName] as any as ManyToManyCollection<U, T>).remove(this.entity, true);
+      (other[this.otherFieldName] as any as ManyToManyCollection<U, T>).remove(this.#entity, true);
     }
 
     if (this.loaded !== undefined) {
@@ -173,7 +175,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   }
 
   private doGet(): U[] {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.#entity);
     if (this.loaded === undefined) {
       // This should only be callable in the type system if we've already resolved this to an instance
       throw new Error("get was called when not loaded");
@@ -190,7 +192,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   }
 
   set(values: U[]): void {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.#entity);
     if (this.loaded === undefined) {
       throw new Error("set was called when not loaded");
     }
@@ -210,7 +212,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   }
 
   removeAll(): void {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.#entity);
     if (this.loaded === undefined) {
       throw new Error("removeAll was called when not loaded");
     }
@@ -235,7 +237,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
 
   maybeCascadeDelete() {
     if (this.isCascadeDelete) {
-      this.current({ withDeleted: true }).forEach((e) => this.entity.em.delete(e));
+      this.current({ withDeleted: true }).forEach((e) => this.#entity.em.delete(e));
     }
   }
 
@@ -243,7 +245,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     const entities = await this.load({ withDeleted: true });
     entities.forEach((other) => {
       const m2m = other[this.otherFieldName] as any as ManyToManyCollection<U, T>;
-      m2m.remove(this.entity);
+      m2m.remove(this.#entity);
     });
     this.loaded = [];
   }
@@ -254,9 +256,9 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
       // this.addedBeforeLoaded = [];
       this.removedBeforeLoaded.forEach((e) => {
         remove(this.loaded!, e);
-        const { em } = this.entity;
+        const { em } = this.#entity;
         const row = em.__data.joinRows[this.joinTableName].find(
-          (r) => r[this.columnName] === this.entity && r[this.otherColumnName] === e,
+          (r) => r[this.columnName] === this.#entity && r[this.otherColumnName] === e,
         );
         if (row) {
           row.deleted = true;
@@ -270,8 +272,12 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     return this.filterDeleted(this.loaded || this.addedBeforeLoaded, opts);
   }
 
+  public get entity(): T {
+    return this.#entity;
+  }
+
   public get meta(): EntityMetadata<T> {
-    return getMetadata(this.entity);
+    return getMetadata(this.#entity);
   }
 
   public get otherMeta(): EntityMetadata<U> {
@@ -279,7 +285,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   }
 
   public toString(): string {
-    return `OneToManyCollection(entity: ${this.entity}, fieldName: ${this.fieldName}, otherType: ${
+    return `OneToManyCollection(entity: ${this.#entity}, fieldName: ${this.fieldName}, otherType: ${
       this.#otherMeta.type
     }, otherFieldName: ${this.otherFieldName})`;
   }

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -42,6 +42,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   private addedBeforeLoaded: U[] = [];
   private removedBeforeLoaded: U[] = [];
   private isCascadeDelete: boolean;
+  readonly #otherMeta: EntityMetadata<U>;
 
   constructor(
     public joinTableName: string,
@@ -53,11 +54,12 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     public entity: T,
     public fieldName: keyof T & string,
     public columnName: string,
-    public otherMeta: EntityMetadata<U>,
+    otherMeta: EntityMetadata<U>,
     public otherFieldName: keyof U & string,
     public otherColumnName: string,
   ) {
     super();
+    this.#otherMeta = otherMeta;
     this.isCascadeDelete = otherMeta?.config.__data.cascadeDeleteFields.includes(fieldName as any);
   }
 
@@ -272,8 +274,14 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     return getMetadata(this.entity);
   }
 
+  public get otherMeta(): EntityMetadata<U> {
+    return this.#otherMeta;
+  }
+
   public toString(): string {
-    return `OneToManyCollection(entity: ${this.entity}, fieldName: ${this.fieldName}, otherType: ${this.otherMeta.type}, otherFieldName: ${this.otherFieldName})`;
+    return `OneToManyCollection(entity: ${this.entity}, fieldName: ${this.fieldName}, otherType: ${
+      this.#otherMeta.type
+    }, otherFieldName: ${this.otherFieldName})`;
   }
 
   [RelationT]: T = null!;

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -31,36 +31,38 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   extends AbstractRelationImpl<U[]>
   implements Collection<T, U>
 {
+  #entity: T;
   private loaded: U[] | undefined;
   // We don't need to track removedBeforeLoaded, because if a child is removed in our unloaded state,
   // when we load and get back the `child X has parent_id = our id` rows from the db, `loaderForCollection`
   // groups the hydrated rows by their _current parent m2o field value_, which for a removed child will no
   // longer be us, so it will effectively not show up in our post-load `loaded` array.
-  private addedBeforeLoaded: U[] = [];
-  private isCascadeDelete: boolean;
+  #addedBeforeLoaded: U[] = [];
+  #isCascadeDelete: boolean;
   #otherMeta: EntityMetadata<U>;
 
   constructor(
     // These are public to our internal implementation but not exposed in the Collection API
-    public entity: T,
+    entity: T,
     otherMeta: EntityMetadata<U>,
     public fieldName: keyof T & string,
     public otherFieldName: keyof U & string,
     public otherColumnName: string,
   ) {
     super();
+    this.#entity = entity;
     this.#otherMeta = otherMeta;
-    this.isCascadeDelete = getMetadata(entity).config.__data.cascadeDeleteFields.includes(fieldName as any);
+    this.#isCascadeDelete = getMetadata(entity).config.__data.cascadeDeleteFields.includes(fieldName as any);
   }
 
   // opts is an internal parameter
   async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<readonly U[]> {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     if (this.loaded === undefined || opts.forceReload) {
-      if (this.entity.idTagged === undefined) {
+      if (this.#entity.idTagged === undefined) {
         this.loaded = [];
       } else {
-        this.loaded = await oneToManyDataLoader(this.entity.em, this).load(this.entity.idTagged);
+        this.loaded = await oneToManyDataLoader(this.#entity.em, this).load(this.#entity.idTagged);
       }
       this.maybeAppendAddedBeforeLoaded();
     }
@@ -68,22 +70,22 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   }
 
   async find(id: IdOf<U>): Promise<U | undefined> {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     if (this.loaded !== undefined) {
       return this.loaded.find((other) => other.id === id);
     } else {
-      const added = this.addedBeforeLoaded.find((u) => u.id === id);
+      const added = this.#addedBeforeLoaded.find((u) => u.id === id);
       if (added) {
         return added;
       }
       // Make a cacheable tuple to look up this specific o2m row
-      const key = `id=${id},${this.otherColumnName}=${this.entity.idOrFail}`;
-      return oneToManyFindDataLoader(this.entity.em, this).load(key);
+      const key = `id=${id},${this.otherColumnName}=${this.#entity.idOrFail}`;
+      return oneToManyFindDataLoader(this.#entity.em, this).load(key);
     }
   }
 
   async includes(other: U): Promise<boolean> {
-    return sameEntity(this.entity, this.getOtherRelation(other).current());
+    return sameEntity(this.#entity, this.getOtherRelation(other).current());
   }
 
   get isLoaded(): boolean {
@@ -99,7 +101,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   }
 
   private doGet(): U[] {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     if (this.loaded === undefined) {
       // This should only be callable in the type system if we've already resolved this to an instance
       throw new Error("get was called when not preloaded");
@@ -108,16 +110,16 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   }
 
   set(values: U[]): void {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.#entity);
     if (this.loaded === undefined) {
       throw new Error("set was called when not loaded");
     }
 
     // If we're changing `a1.books = [b1, b2]` to `a1.books = [b2]`, then implicitly delete the old book
     const otherCannotChange = this.#otherMeta.fields[this.otherFieldName].immutable;
-    if (this.isCascadeDelete && otherCannotChange) {
+    if (this.#isCascadeDelete && otherCannotChange) {
       const implicitlyDeleted = this.loaded.filter((e) => !values.includes(e));
-      implicitlyDeleted.forEach((e) => this.entity.em.delete(e));
+      implicitlyDeleted.forEach((e) => this.#entity.em.delete(e));
       // Keep the implicitlyDeleted values for `getWithDeleted` to return
       values.push(...implicitlyDeleted);
     }
@@ -138,10 +140,10 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   }
 
   add(other: U): void {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.#entity);
     if (this.loaded === undefined) {
-      if (!this.addedBeforeLoaded.includes(other)) {
-        this.addedBeforeLoaded.push(other);
+      if (!this.#addedBeforeLoaded.includes(other)) {
+        this.#addedBeforeLoaded.push(other);
       }
     } else {
       if (!this.loaded.includes(other)) {
@@ -149,23 +151,23 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
       }
     }
     // This will no-op and mark other dirty if necessary
-    this.getOtherRelation(other).set(this.entity);
+    this.getOtherRelation(other).set(this.#entity);
   }
 
   // We're not supported remove(other) because that might leave other.otherFieldName as undefined,
   // which we don't know if that's valid or not, i.e. depending on whether the field is nullable.
   remove(other: U, opts: { requireLoaded: boolean } = { requireLoaded: true }) {
-    ensureNotDeleted(this.entity, { ignore: "pending" });
+    ensureNotDeleted(this.#entity, { ignore: "pending" });
     if (this.loaded === undefined && opts.requireLoaded) {
       throw new Error("remove was called when not loaded");
     }
-    remove(this.loaded || this.addedBeforeLoaded, other);
+    remove(this.loaded || this.#addedBeforeLoaded, other);
     // This will no-op and mark other dirty if necessary
     this.getOtherRelation(other).set(undefined);
   }
 
   removeAll(): void {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.#entity);
     if (this.loaded === undefined) {
       throw new Error("removeAll was called when not loaded");
     }
@@ -192,13 +194,13 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     if (this.loaded !== undefined) {
       remove(this.loaded, other);
     } else {
-      remove(this.addedBeforeLoaded, other);
+      remove(this.#addedBeforeLoaded, other);
     }
   }
 
   maybeCascadeDelete(): void {
-    if (this.isCascadeDelete) {
-      this.current({ withDeleted: true }).forEach((e) => this.entity.em.delete(e));
+    if (this.#isCascadeDelete) {
+      this.current({ withDeleted: true }).forEach((e) => this.#entity.em.delete(e));
     }
   }
 
@@ -207,32 +209,36 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     const current = await this.load({ withDeleted: true });
     current.forEach((other) => {
       const m2o = this.getOtherRelation(other);
-      if (maybeResolveReferenceToId(m2o.current({ withDeleted: true })) === this.entity.id) {
+      if (maybeResolveReferenceToId(m2o.current({ withDeleted: true })) === this.#entity.id) {
         // TODO What if other.otherFieldName is required/not-null?
         m2o.set(undefined);
       }
     });
     this.loaded = [];
-    this.addedBeforeLoaded = [];
+    this.#addedBeforeLoaded = [];
   }
 
   private maybeAppendAddedBeforeLoaded(): void {
     if (this.loaded) {
-      const newEntities = this.addedBeforeLoaded.filter((e) => !this.loaded?.includes(e));
+      const newEntities = this.#addedBeforeLoaded.filter((e) => !this.loaded?.includes(e));
       // Push on the end to better match the db order of "newer things come last"
       for (const e of newEntities) {
         this.loaded.push(e);
       }
-      this.addedBeforeLoaded = [];
+      this.#addedBeforeLoaded = [];
     }
   }
 
   current(opts?: { withDeleted?: boolean }): U[] {
-    return this.filterDeleted(this.loaded || this.addedBeforeLoaded, opts);
+    return this.filterDeleted(this.loaded || this.#addedBeforeLoaded, opts);
   }
 
   public get meta(): EntityMetadata<T> {
-    return getMetadata(this.entity);
+    return getMetadata(this.#entity);
+  }
+
+  public get entity(): T {
+    return this.#entity;
   }
 
   public get otherMeta(): EntityMetadata<U> {
@@ -240,7 +246,9 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   }
 
   public toString(): string {
-    return `OneToManyCollection(entity: ${this.entity}, fieldName: ${this.fieldName}, otherType: ${this.#otherMeta.type}, otherFieldName: ${this.otherFieldName})`;
+    return `OneToManyCollection(entity: ${this.#entity}, fieldName: ${this.fieldName}, otherType: ${
+      this.#otherMeta.type
+    }, otherFieldName: ${this.otherFieldName})`;
   }
 
   private filterDeleted(entities: U[], opts?: { withDeleted?: boolean }): U[] {

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -82,16 +82,18 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
   private loaded: U | undefined;
   private _isLoaded: boolean = false;
   private isCascadeDelete: boolean;
+  readonly #otherMeta: EntityMetadata<U>;
 
   constructor(
     // These are public to our internal implementation but not exposed in the Collection API
     public entity: T,
-    public otherMeta: EntityMetadata<U>,
+    otherMeta: EntityMetadata<U>,
     public fieldName: keyof T & string,
     public otherFieldName: keyof U & string,
     public otherColumnName: string,
   ) {
     super();
+    this.#otherMeta = otherMeta;
     this.isCascadeDelete = getMetadata(entity).config.__data.cascadeDeleteFields.includes(fieldName as any);
   }
 
@@ -107,7 +109,7 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
   }
 
   get idUntagged(): string | undefined {
-    return this.id && deTagIds(this.otherMeta, [this.id])[0];
+    return this.id && deTagIds(this.#otherMeta, [this.id])[0];
   }
 
   get idUntaggedOrFail(): string {
@@ -161,6 +163,10 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
 
   get get(): U | undefined {
     return this.filterDeleted(this.doGet(), { withDeleted: false });
+  }
+
+  get otherMeta(): EntityMetadata<U> {
+    return this.#otherMeta;
   }
 
   private doGet(): U | undefined {

--- a/packages/orm/src/relations/hasAsyncProperty.ts
+++ b/packages/orm/src/relations/hasAsyncProperty.ts
@@ -33,12 +33,15 @@ export function hasAsyncProperty<T extends Entity, H extends LoadHint<T>, V>(
 export class AsyncPropertyImpl<T extends Entity, H extends LoadHint<T>, V> implements AsyncProperty<T, V> {
   private loaded = false;
   private loadPromise: any;
-  constructor(private entity: T, public hint: Const<H>, private fn: (entity: Loaded<T, H>) => V) {}
+  readonly #entity: T;
+  constructor(entity: T, public hint: Const<H>, private fn: (entity: Loaded<T, H>) => V) {
+    this.#entity = entity;
+  }
 
   load(): Promise<V> {
-    const { entity, hint, fn } = this;
+    const { hint, fn } = this;
     if (!this.loaded) {
-      return (this.loadPromise ??= entity.em.populate(entity, hint).then((loaded) => {
+      return (this.loadPromise ??= this.#entity.em.populate(this.#entity, hint).then((loaded) => {
         this.loaded = true;
         return fn(loaded);
       }));
@@ -47,8 +50,7 @@ export class AsyncPropertyImpl<T extends Entity, H extends LoadHint<T>, V> imple
   }
 
   get get(): V {
-    const { entity, fn } = this;
-    return fn(entity as Loaded<T, H>);
+    return this.fn(this.#entity as Loaded<T, H>);
   }
 
   get isLoaded() {


### PR DESCRIPTION
This keeps code that wants to recursively compare/diff entities (via `Object.keys`, e.g. Jest's `toMatchObject` and IntelliJ's Jest integration) from getting bogged down in the extremely large `metadata` data.