### PR TITLE
fix: Correctly handle partial unique indexes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,7 +24,6 @@ After checkout:
 
 - Run `yarn install`
 - Run `yarn build`
-- `cd packages/integration-tests`
 - Run `make db` to boot up a Docker postgres instance w/the integration test schema.
 - Run `yarn test` to run the tests.
 - Prior to committing your changes, run `yarn workspaces run format`

--- a/packages/integration-tests/migrations/1580658856631_author.ts
+++ b/packages/integration-tests/migrations/1580658856631_author.ts
@@ -82,6 +82,10 @@ export function up(b: MigrationBuilder): void {
     address: { type: "jsonb", notNull: false },
   });
 
+  // A publisher can only have one author named `Jim`, but still have other authors
+  // Verifies that partial unique indexes do not result in o2o collections
+  b.createIndex("authors", ["publisher_id"], { unique: true, where: "first_name = 'Jim'" });
+
   // for testing required enums
   createEnumTable(b, "advance_status", [
     ["PENDING", "Pending"],


### PR DESCRIPTION
Here is the fix discussed for partial unique indexes resulting in o2o collection instead of o2m.

The key point to observe in the diffs is that now there are no changes to the metadata. Publisher still has an `authors: Author[]` collection.