### PR TITLE
fix: Don't skip soft-deleted entity in m2o.get.

### DIFF
--- a/docs/docs/features/soft-deletes.md
+++ b/docs/docs/features/soft-deletes.md
@@ -28,7 +28,7 @@ Note that currently Joist assumes that `deleted_at` columns are timestamps, but 
 
 ### Behavior
 
-When rows are soft-deleted, Joist will still fetch them from the database, but any accessors will, by default, filter them out of the results.
+When rows are soft-deleted, Joist will still fetch them from the database, but collection accessors (i.e. `o2m.get` and `m2m.get`) will, by default, filter them out of the results.
 
 For example, if an `Author` has a soft-deleted `Book`:
 

--- a/packages/orm/src/loadLens.ts
+++ b/packages/orm/src/loadLens.ts
@@ -64,7 +64,7 @@ export async function loadLens<T, U, V>(
       current = [...new Set(current.filter((c: any) => c !== undefined && !c.isSoftDeletedEntity))];
     } else {
       current = await maybeLoad(current, path, opts);
-      seenSoftDeleted ||= (current as any).isSoftDeletedEntity;
+      seenSoftDeleted ||= (current as any)?.isSoftDeletedEntity;
       // If we had been traversing m2o -> m2o and just hit an o2m/m2m, and any of our
       // prior m2os had been soft deleted, just filter everything out.
       if (Array.isArray(current) && seenSoftDeleted) {

--- a/packages/orm/src/loadLens.ts
+++ b/packages/orm/src/loadLens.ts
@@ -56,13 +56,20 @@ export async function loadLens<T, U, V>(
 ): Promise<V> {
   const paths = collectPaths(fn);
   let current: any = start;
+  let seenSoftDeleted = false;
   // Now evaluate each step of the path
   for await (const path of paths) {
     if (Array.isArray(current)) {
       current = (await Promise.all(current.map((c) => maybeLoad(c, path, opts)))).flat();
-      current = [...new Set(current.filter((c: any) => c !== undefined))];
+      current = [...new Set(current.filter((c: any) => c !== undefined && !c.isSoftDeletedEntity))];
     } else {
       current = await maybeLoad(current, path, opts);
+      seenSoftDeleted ||= (current as any).isSoftDeletedEntity;
+      // If we had been traversing m2o -> m2o and just hit an o2m/m2m, and any of our
+      // prior m2os had been soft deleted, just filter everything out.
+      if (Array.isArray(current) && seenSoftDeleted) {
+        return [] as any;
+      }
     }
   }
   return current!;

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -276,9 +276,17 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     }, otherFieldName: ${this.otherFieldName}, id: ${this.id})`;
   }
 
-  /** Removes pending-hard-delete or soft-deleted entities, unless explicitly asked for. */
+  /**
+   * Removes pending-hard-delete (but not soft-deleted), unless explicitly asked for.
+   *
+   * Note that we leave soft-deleted entities b/c the call signature of a `book.author.get`
+   * very likely does not expect a soft-deleted entity to result in `undefined`.
+   *
+   * (Contrasted with `author.books.get` which is more intuitive to have soft-deleted
+   * entities filtered out, i.e. it doesn't fundamentally change the return type.)
+   */
   private filterDeleted(entity: U | N, opts?: { withDeleted?: boolean }): U | N {
-    if (entity && (!opts || !opts.withDeleted) && (entity.isDeletedEntity || (entity as any).isSoftDeletedEntity)) {
+    if (entity && (!opts || !opts.withDeleted) && entity.isDeletedEntity) {
       return undefined!;
     }
     return entity;


### PR DESCRIPTION
In retrospect, it changes the return type too much (from Entity to undefined) for what can be a pretty common case.

(Vs. the "skip hard-deleted entities" logic that we have now, which is rare enough that it's worth the return type disruption.)