### PR TITLE
fix: Update toMatchEntity to include soft-deleted entities.

### DIFF
--- a/packages/integration-tests/src/toMatchEntity.test.ts
+++ b/packages/integration-tests/src/toMatchEntity.test.ts
@@ -1,5 +1,6 @@
 import { alignedAnsiStyleSerializer } from "@src/alignedAnsiStyleSerializer";
 import { Author, newAuthor, newBook } from "@src/entities";
+import { jan1 } from "joist-orm";
 import { newEntityManager } from "./setupDbTests";
 
 expect.addSnapshotSerializer(alignedAnsiStyleSerializer as any);
@@ -17,6 +18,13 @@ describe("toMatchEntity", () => {
     const b1 = newBook(em);
     await em.flush();
     expect(b1).toMatchEntity({ author: { firstName: "a1" } });
+  });
+
+  it("can match collections with soft-deleted entities", async () => {
+    const em = newEntityManager();
+    const a1 = newAuthor(em, { books: [{ deletedAt: jan1 }] });
+    await em.flush();
+    expect(a1).toMatchEntity({ books: [{ deletedAt: jan1 }] });
   });
 
   it("can match async properties", async () => {

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -44,7 +44,11 @@ export function toMatchEntity<T>(actual: Entity, expected: MatchedEntity<T>): Cu
         isAsyncProperty(actualValue) ||
         isPersistedAsyncProperty(actualValue)
       ) {
-        actualValue = (actualValue as any).get;
+        if ("getWithDeleted" in actualValue) {
+          actualValue = (actualValue as any).getWithDeleted;
+        } else {
+          actualValue = (actualValue as any).get;
+        }
       }
 
       if (actualValue instanceof Array) {


### PR DESCRIPTION
Otherwise the test assertion is unclear if soft-deleted entities are soft-deleted-and-being-suppressed or actually hard-deleted and literally not there anymore.