### PR TITLE
chore: Add benchmarks with postgres.js.

### DIFF
--- a/packages/integration-tests/benchmark.ts
+++ b/packages/integration-tests/benchmark.ts
@@ -1,0 +1,136 @@
+import { newPgConnectionConfig } from "joist-utils";
+import { Benchmark } from "kelonio";
+import { knex as createKnex } from "knex";
+import postgres from "postgres";
+
+const knex = createKnex({
+  client: "pg",
+  connection: newPgConnectionConfig(),
+  debug: false,
+  asyncStackTraces: true,
+});
+
+const sql = postgres("postgres://joist:local@localhost:5435/joist", {});
+
+async function main() {
+  await knex.raw("select flush_database()");
+
+  const benchmark = new Benchmark();
+  const numberOfEntities = 10;
+  const iterations = 100;
+
+  await benchmark.record(
+    `Knex ${numberOfEntities} individually`,
+    async () => {
+      for await (const i of zeroTo(numberOfEntities)) {
+        await knex.raw(`INSERT INTO "authors" (first_name, initials, number_of_books) VALUES (?, ?, ?)`, [
+          `a${i}`,
+          "a",
+          0,
+        ]);
+      }
+    },
+    { iterations },
+  );
+
+  await benchmark.record(
+    `Knex ${numberOfEntities} with VALUES`,
+    async () => {
+      await knex.raw(
+        `INSERT INTO "authors" (first_name, initials, number_of_books) VALUES ${zeroTo(numberOfEntities)
+          .map(() => `(?, ?, ?)`)
+          .join(", ")}`,
+        zeroTo(numberOfEntities).flatMap((i) => [`a${i}`, "a", 0]),
+      );
+    },
+    { iterations },
+  );
+
+  await benchmark.record(
+    `Postgres.js ${numberOfEntities} individually`,
+    async () => {
+      for await (const i of zeroTo(numberOfEntities)) {
+        await sql`INSERT INTO "authors" (first_name, initials, number_of_books) VALUES (${`a${i}`}, ${"a"}, ${0})`;
+      }
+    },
+    { iterations },
+  );
+
+  await benchmark.record(
+    `Postgres.js ${numberOfEntities} individual but pipelined`,
+    async () => {
+      await sql.begin((sql) => {
+        return zeroTo(numberOfEntities).map((i) => {
+          return sql`INSERT INTO "authors" (first_name, initials, number_of_books) VALUES (${`a${i}`}, ${"a"}, ${0})`;
+        });
+      });
+    },
+    { iterations },
+  );
+
+  await benchmark.record(
+    `Postgres.js ${numberOfEntities} with VALUES`,
+    async () => {
+      await sql`INSERT INTO "authors" ${sql(
+        zeroTo(numberOfEntities).map((i) => ({ first_name: `a${i}`, initials: "a", number_of_books: 0 })),
+      )}`;
+    },
+    { iterations },
+  );
+
+  await benchmark.record(
+    `Knex ${numberOfEntities} Authors & Books with VALUES`,
+    async () => {
+      await knex.raw(
+        `INSERT INTO "authors" (first_name, initials, number_of_books) VALUES ${zeroTo(numberOfEntities)
+          .map(() => `(?, ?, ?)`)
+          .join(", ")}`,
+        zeroTo(numberOfEntities).flatMap((i) => [`a${i}`, "a", 0]),
+      );
+      await knex.raw(
+        `INSERT INTO "books" (title, author_id) VALUES ${zeroTo(numberOfEntities)
+          .map(() => `(?, ?)`)
+          .join(", ")}`,
+        zeroTo(numberOfEntities).flatMap((i) => [`b${i}`, 1]),
+      );
+    },
+    { iterations },
+  );
+
+  await benchmark.record(
+    `Postgres.js ${numberOfEntities} Authors & Books with VALUES`,
+    async () => {
+      await sql`INSERT INTO "authors" ${sql(
+        zeroTo(numberOfEntities).map((i) => ({ first_name: `a${i}`, initials: "a", number_of_books: 0 })),
+      )}`;
+      await sql`INSERT INTO "books" ${sql(zeroTo(numberOfEntities).map((i) => ({ title: `b${i}`, author_id: 1 })))}`;
+    },
+    { iterations },
+  );
+
+  await benchmark.record(
+    `Postgres.js ${numberOfEntities} Authors & Books individual but pipelined`,
+    async () => {
+      await sql.begin((sql) => {
+        return zeroTo(numberOfEntities).flatMap((i) => {
+          return [
+            sql`INSERT INTO "authors" (first_name, initials, number_of_books) VALUES (${`a${i}`}, ${"a"}, ${0})`,
+            sql`INSERT INTO "books" (title, author_id) VALUES (${`b${i}`}, ${1})`,
+          ];
+        });
+      });
+    },
+    { iterations },
+  );
+
+  console.log(benchmark.report());
+
+  await knex.destroy();
+  await sql.end();
+}
+
+main();
+
+function zeroTo(n: number): number[] {
+  return [...Array(n).keys()];
+}

--- a/packages/integration-tests/benchmark.ts
+++ b/packages/integration-tests/benchmark.ts
@@ -182,6 +182,23 @@ async function main() {
     { iterations, serial },
   );
 
+  await benchmark.record(
+    `Postgres.js ${numberOfEntities} Authors & Books ${numberOfEntities} individual but pipelined in order in txn`,
+    async () => {
+      await sql.begin((sql) => {
+        return [
+          ...zeroTo(numberOfEntities).map((i) => {
+            return sql`INSERT INTO "authors" (first_name, initials, number_of_books) VALUES (${`a${i}`}, ${"a"}, ${0})`;
+          }),
+          ...zeroTo(numberOfEntities).map((i) => {
+            return sql`INSERT INTO "books" (title, author_id) VALUES (${`b${i}`}, ${1})`;
+          }),
+        ];
+      });
+    },
+    { iterations, serial },
+  );
+
   console.log(benchmark.report());
 
   await knex.destroy();

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -31,6 +31,8 @@
     "joist-graphql-codegen": "workspace:*",
     "joist-migration-utils": "workspace:*",
     "joist-test-utils": "workspace:*",
+    "kelonio": "^0.8.0",
+    "postgres": "^3.3.2",
     "prettier": "^2.8.1",
     "prettier-plugin-organize-imports": "^3.2.1",
     "superstruct": "^0.15.5",

--- a/packages/integration-tests/run.sh
+++ b/packages/integration-tests/run.sh
@@ -2,4 +2,6 @@
 
 export $(grep -v '^#' local.env | sed 's/\"/\\\"/g' | xargs)
 
+export NODE_OPTIONS=--max-old-space-size=8096
+
 ../.././node_modules/.bin/ts-node "$@"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7662,6 +7662,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browser-process-hrtime@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "browser-process-hrtime@npm:1.0.0"
+  checksum: e30f868cdb770b1201afb714ad1575dd86366b6e861900884665fb627109b3cc757c40067d3bfee1ff2a29c835257ea30725a8018a9afd02ac1c24b408b1e45f
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.0.0, browserslist@npm:^4.14.5, browserslist@npm:^4.17.5, browserslist@npm:^4.17.6":
   version: 4.18.1
   resolution: "browserslist@npm:4.18.1"
@@ -8502,6 +8509,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"complex.js@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "complex.js@npm:2.1.1"
+  checksum: a0802cc3f0eb7703088edfc3fe209ae7be5ce93c0e710a0f288be2e29ee31b3530a8c0d3330d7c2a668410dfe4293a4038554d66c7f1f1165997941bdc1092aa
+  languageName: node
+  linkType: hard
+
 "compressible@npm:~2.0.16":
   version: 2.0.18
   resolution: "compressible@npm:2.0.18"
@@ -9109,6 +9123,13 @@ __metadata:
   version: 5.0.1
   resolution: "decamelize@npm:5.0.1"
   checksum: 7c3b1ed4b3e60e7fbc00a35fb248298527c1cdfe603e41dfcf05e6c4a8cb9efbee60630deb677ed428908fb4e74e322966c687a094d1478ddc9c3a74e9dc7140
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.3.1":
+  version: 10.4.3
+  resolution: "decimal.js@npm:10.4.3"
+  checksum: 796404dcfa9d1dbfdc48870229d57f788b48c21c603c3f6554a1c17c10195fc1024de338b0cf9e1efe0c7c167eeb18f04548979bcc5fdfabebb7cc0ae3287bae
   languageName: node
   linkType: hard
 
@@ -9749,6 +9770,13 @@ __metadata:
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
+  languageName: node
+  linkType: hard
+
+"escape-latex@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "escape-latex@npm:1.2.0"
+  checksum: 73a787319f0965ecb8244bb38bf3a3cba872f0b9a5d3da8821140e9f39fe977045dc953a62b1a2bed4d12bfccbe75a7d8ec786412bf00739eaa2f627d0a8e0d6
   languageName: node
   linkType: hard
 
@@ -11978,6 +12006,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"javascript-natural-sort@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "javascript-natural-sort@npm:0.7.1"
+  checksum: 161e2c512cc7884bc055a582c6645d9032cab88497a76123d73cb23bfb03d97a04cf7772ecdb8bd3366fc07192c2f996366f479f725c23ef073fffe03d6a586a
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^29.2.0":
   version: 29.2.0
   resolution: "jest-changed-files@npm:29.2.0"
@@ -12610,6 +12645,8 @@ __metadata:
     joist-migration-utils: "workspace:*"
     joist-orm: "workspace:*"
     joist-test-utils: "workspace:*"
+    kelonio: ^0.8.0
+    postgres: ^3.3.2
     prettier: ^2.8.1
     prettier-plugin-organize-imports: ^3.2.1
     superstruct: ^0.15.5
@@ -12963,6 +13000,16 @@ __metadata:
   version: 5.0.1
   resolution: "just-diff@npm:5.0.1"
   checksum: efbdb652987ca109839dba385904ea152cc73ef4c165eebb4be0af261734cf91387e529fcd52aea5ba9567b4ef76c584ee6254ccf0030dc5d0ccdab3b890a085
+  languageName: node
+  linkType: hard
+
+"kelonio@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "kelonio@npm:0.8.0"
+  dependencies:
+    browser-process-hrtime: ^1.0.0
+    mathjs: ^10.5.2
+  checksum: 23898e646e3a61bb68140bd0322cb12200ee576e07606af813adfe48a392800e05d549dee847ef81c22bd6acdab9c50c7fcfcd3b631081edcad54c8fd5f55298
   languageName: node
   linkType: hard
 
@@ -13578,6 +13625,25 @@ __metadata:
   bin:
     marked: bin/marked.js
   checksum: 7575117f85a8986652f3ac8b8a7b95056c4c5fce01a1fc76dc4c7960412cb4c9bd9da8133487159b6b3ff84f52b543dfe9a36f826a5f358892b5ec4b6824f192
+  languageName: node
+  linkType: hard
+
+"mathjs@npm:^10.5.2":
+  version: 10.6.4
+  resolution: "mathjs@npm:10.6.4"
+  dependencies:
+    "@babel/runtime": ^7.18.6
+    complex.js: ^2.1.1
+    decimal.js: ^10.3.1
+    escape-latex: ^1.2.0
+    fraction.js: ^4.2.0
+    javascript-natural-sort: ^0.7.1
+    seedrandom: ^3.0.5
+    tiny-emitter: ^2.1.0
+    typed-function: ^2.1.0
+  bin:
+    mathjs: bin/cli.js
+  checksum: 64c785d6f3cd0500888be31793d677d50f7da51b04fe009ba2d5be5f29948b3ef70fd26f8fa80064f4c18716a9ab59dd600236ffcca7e9ea6265a91c5b1540a9
   languageName: node
   linkType: hard
 
@@ -15957,6 +16023,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postgres@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "postgres@npm:3.3.2"
+  checksum: 6de16e5c8854ebe95f344a7fae2d4f667f319fce76bf8c9657269fe5c60ba315aade59e91808ca6729a50de09d494d24f403d96697f731b457aad04f43ab65d5
+  languageName: node
+  linkType: hard
+
 "prepend-http@npm:^2.0.0":
   version: 2.0.0
   resolution: "prepend-http@npm:2.0.0"
@@ -17218,6 +17291,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"seedrandom@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "seedrandom@npm:3.0.5"
+  checksum: 728b56bc3bc1b9ddeabd381e449b51cb31bdc0aa86e27fcd0190cea8c44613d5bcb2f6bb63ed79f78180cbe791c20b8ec31a9627f7b7fc7f476fd2bdb7e2da9f
+  languageName: node
+  linkType: hard
+
 "select-hose@npm:^2.0.0":
   version: 2.0.0
   resolution: "select-hose@npm:2.0.0"
@@ -18440,6 +18520,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-emitter@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "tiny-emitter@npm:2.1.0"
+  checksum: fbcfb5145751a0e3b109507a828eb6d6d4501352ab7bb33eccef46e22e9d9ad3953158870a6966a59e57ab7c3f9cfac7cab8521db4de6a5e757012f4677df2dd
+  languageName: node
+  linkType: hard
+
 "tiny-invariant@npm:^1.0.2":
   version: 1.2.0
   resolution: "tiny-invariant@npm:1.2.0"
@@ -18744,6 +18831,13 @@ __metadata:
     media-typer: 0.3.0
     mime-types: ~2.1.24
   checksum: 2c8e47675d55f8b4e404bcf529abdf5036c537a04c2b20177bcf78c9e3c1da69da3942b1346e6edb09e823228c0ee656ef0e033765ec39a70d496ef601a0c657
+  languageName: node
+  linkType: hard
+
+"typed-function@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "typed-function@npm:2.1.0"
+  checksum: 168c2c8f765fbecc842521a5fb62a5800958f9fcb0ce78d69c38a5e96c81fe133f853256ec8ee245ee2fc42b4c9342b5ba754c732189550c64c12e758892dc43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Clone `joist-ts`
* `yarn`
* `make db`
* `yarn codegen` to create `flush_database` function
* `cd packages/integration-tests`
* `./run.sh benchmark.ts`


```
$ ./run.sh benchmark.ts
{ numberOfEntities: 20, iterations: 100, serial: false }
- - - - - - - - - - - - - - - - - Performance - - - - - - - - - - - - - - - - -
Knex 20 Authors individually:
  238.35666 ms (+/- 14.21493 ms) from 100 iterations
Knex 20 Authors with VALUES:
  21.89214 ms (+/- 2.2392 ms) from 100 iterations
Postgres.js 20 Authors individually:
  92.01067 ms (+/- 6.92755 ms) from 100 iterations
Postgres.js 20 Authors individual but pipelined:
  26.8869 ms (+/- 2.63665 ms) from 100 iterations
Postgres.js 20 Authors with VALUES:
  19.96301 ms (+/- 1.41438 ms) from 100 iterations
Knex 20 Authors & 20 Books with VALUES in txn:
  28.94912 ms (+/- 2.91046 ms) from 100 iterations
Knex 20 Authors & 20 Books with VALUES no txn:
  20.22975 ms (+/- 1.79286 ms) from 100 iterations
Postgres.js 20 Authors & 20 Books with VALUES in txn:
  21.10671 ms (+/- 1.96911 ms) from 100 iterations
Postgres.js 20 Authors & 20 Books with VALUES no txn:
  17.12486 ms (+/- 1.24313 ms) from 100 iterations
Postgres.js 20 Authors & Books 20 individual but pipelined in txn:
  44.77275 ms (+/- 4.3227 ms) from 100 iterations
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```