### PR TITLE
feat: Let newTestInstance deep merge opts.

### DIFF
--- a/packages/codegen/src/generateFactoriesFiles.ts
+++ b/packages/codegen/src/generateFactoriesFiles.ts
@@ -14,7 +14,7 @@ export function generateFactoriesFiles(entities: EntityDbMetadata[]): CodegenFil
         em: ${EntityManager},
         opts: ${FactoryOpts}<${entity.type}> = {},
       ): ${DeepNew}<${entity.type}> {
-        return ${newTestInstance}(em, ${entity.type}, opts);
+        return ${newTestInstance}(em, ${entity.type}, opts, {});
       }`;
     return { name: `./${entity.name}.factories.ts`, contents, overwrite: false };
   });

--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -246,6 +246,7 @@ describe("EntityManager.factories", () => {
     const em = newEntityManager();
     newBookReview(em, { book: {} });
     expect(lastBookFactoryOpts).toStrictEqual({
+      author: maybeNew<Author>({ age: 40 }),
       reviews: [],
       use: expect.any(Map),
     });

--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -60,6 +60,8 @@ describe("EntityManager.factories", () => {
     await em.flush();
     // Then we create the author b/c it's required
     expect(b1.author.get.firstName).toEqual("long name");
+    // And we kept the Book.factories.ts `{ age: 40 }` default
+    expect(b1.author.get.age).toEqual(40);
   });
 
   it("can create a child and use an existing parent from opt", async () => {
@@ -115,7 +117,10 @@ describe("EntityManager.factories", () => {
     newBook(em);
     // Then the newAuthor factory was told to override any `books: [{}]` defaults
     expect(lastAuthorFactoryOpts).toStrictEqual({
+      age: 40,
       books: [],
+      opts: { age: 40 },
+      polyRefPreferredOrder: [],
       use: expect.any(Map),
     });
   });
@@ -133,8 +138,11 @@ describe("EntityManager.factories", () => {
     expect(a1.publisher.get).toEqual(p1);
     // And we explicitly passed the publisher b/c it's an explicit `use` entry
     expect(lastAuthorFactoryOpts).toStrictEqual({
+      age: 40,
       books: [],
       publisher: p1,
+      opts: { age: 40 },
+      polyRefPreferredOrder: [],
       use: expect.any(Map),
     });
   });

--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -119,8 +119,6 @@ describe("EntityManager.factories", () => {
     expect(lastAuthorFactoryOpts).toStrictEqual({
       age: 40,
       books: [],
-      opts: { age: 40 },
-      polyRefPreferredOrder: [],
       use: expect.any(Map),
     });
   });
@@ -141,8 +139,6 @@ describe("EntityManager.factories", () => {
       age: 40,
       books: [],
       publisher: p1,
-      opts: { age: 40 },
-      polyRefPreferredOrder: [],
       use: expect.any(Map),
     });
   });

--- a/packages/integration-tests/src/entities/Book.factories.ts
+++ b/packages/integration-tests/src/entities/Book.factories.ts
@@ -1,10 +1,13 @@
-import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
-import { Book } from "./entities";
+import { DeepNew, EntityManager, FactoryOpts, maybeNew, newTestInstance } from "joist-orm";
+import { Author, Book } from "./entities";
 
 // for testing factories
 export let lastBookFactoryOpts: any = null;
 
-export function newBook(em: EntityManager, opts?: FactoryOpts<Book>): DeepNew<Book> {
+export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): DeepNew<Book> {
   lastBookFactoryOpts = opts;
-  return newTestInstance(em, Book, opts);
+  return newTestInstance(em, Book, opts, {
+    // Pass a default age so that we can test deep-merging author.age and opts.firstName
+    author: maybeNew<Author>({ age: 40 }),
+  });
 }

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -309,7 +309,8 @@ function getObviousDefault<T extends Entity>(
 // opts of only-one-existing or factory-created instances.
 
 /** Given we're going to call a factory, make sure any `use`s are put into `opts`. */
-function applyUse(opts: object, use: UseMap, metadata: EntityMetadata<any>): object {
+function applyUse(optsMaybeNew: object, use: UseMap, metadata: EntityMetadata<any>): object {
+  const opts = optsMaybeNew instanceof MaybeNew ? optsMaybeNew.opts : optsMaybeNew;
   // Find any unset fields
   Object.values(metadata.fields)
     .filter((f) => !(f.fieldName in opts))
@@ -324,7 +325,7 @@ function applyUse(opts: object, use: UseMap, metadata: EntityMetadata<any>): obj
         }
       }
     });
-  // Make a copy so we don't leak `use` onto opts that tests might later use in assertions.
+  // Make a copy so that we don't leak `use` onto opts that tests might later use in assertions.
   return { ...opts, use };
 }
 


### PR DESCRIPTION
It's ~somewhat common for a factory to have a default it wants to apply, like:

```ts
export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): DeepNew<Book> {
  return newTestInstance(em, Book, {
    author: { age: 40 },
    ...opts,
  });
}
```

And then a test want to customize some _other_ author field, like `firstName`:

```ts
const b1 = newBook(em, {
  author: { firstName: "long name" }
});
```

Which, as written so far, will drop the `{ age: 40 }` default from the `newBook` factory.

To prevent this, historically factories had to manually merge their `{ age: 40 }` defaults with the test's `{ firstName: "long name" }` overrides, which initially seems trivial:

```ts
export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): DeepNew<Book> {
  const { author, ...rest } = opts;
  return newTestInstance(em, Book, {
    author: { age: 40, ...author },
    ...rest,
  });
}
```

However, because the type of `opts.author` can be an actual `Author` instance, the `...author` spread does not work without some tedious `typeof author` / `isPlainObject` detection.

So this PR teaches `newTestInstance` to do the merge, with a non-breaking API change of the factory passing in both its default opts + the test's opts.

```ts
export function newBook(em: EntityManager, opts: FactoryOpts<Book> = {}): DeepNew<Book> {
  // Note how newTestInstance now takes two hashes
  return newTestInstance(em, Book, opts, {
    author: { age: 40 }
  });
}
```

