### PR TITLE
feat: Bump TypeScript output to ES2022.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - build:
           matrix:
             parameters:
-              node-version: ["14.20.0", "16.16.0", "18.10.0"]
+              node-version: ["18.0.0", "18.10.0"]
 
 jobs:
   build:

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -21,6 +21,12 @@ If you want a faster intro than this page, you should be able to check out the s
 
 :::
 
+::: info
+
+Joist requires Node 18.
+
+:::
+
 ## Setting up your database
 
 The sample app uses `docker compose` and a `db.dockerfile` file to manage the local Postgres database.

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -456,7 +456,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
         ${defaultValues}
       };
 
-      readonly __orm!: ${EntityOrmField} & {
+      declare readonly __orm: ${EntityOrmField} & {
         filterType: ${entityName}Filter;
         gqlFilterType: ${entityName}GraphQLFilter;
         orderType: ${entityName}Order;

--- a/packages/codegen/tsconfig.json
+++ b/packages/codegen/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/graphql-codegen/tsconfig.json
+++ b/packages/graphql-codegen/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/graphql-resolver-utils/tsconfig.json
+++ b/packages/graphql-resolver-utils/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/integration-tests/src/Entity.test.ts
+++ b/packages/integration-tests/src/Entity.test.ts
@@ -18,6 +18,7 @@ describe("Entity", () => {
         "ageRuleInvoked": 0,
         "authors": {
           "fieldName": "authors",
+          "loaded": undefined,
           "otherColumnName": "mentor_id",
           "otherFieldName": "mentor",
           "undefined": null,
@@ -34,6 +35,7 @@ describe("Entity", () => {
               "comments": {},
             },
           },
+          "loadPromise": undefined,
           "loaded": false,
           "reactiveHint": {
             "books": {
@@ -44,12 +46,14 @@ describe("Entity", () => {
         "bookCommentsCalcInvoked": 0,
         "books": {
           "fieldName": "books",
+          "loaded": undefined,
           "otherColumnName": "author_id",
           "otherFieldName": "author",
           "undefined": null,
         },
         "comments": {
           "fieldName": "comments",
+          "loaded": undefined,
           "otherColumnName": "parent_author_id",
           "otherFieldName": "parent",
           "undefined": null,
@@ -58,6 +62,7 @@ describe("Entity", () => {
           "_isLoaded": false,
           "fieldName": "currentDraftBook",
           "isCascadeDelete": false,
+          "loaded": undefined,
           "otherFieldName": "currentDraftAuthor",
           "undefined": null,
         },
@@ -67,12 +72,14 @@ describe("Entity", () => {
           "_isLoaded": false,
           "fieldName": "image",
           "isCascadeDelete": true,
+          "loaded": undefined,
           "otherColumnName": "author_id",
           "otherFieldName": "author",
           "undefined": null,
         },
         "latestComment": {
           "_isLoaded": false,
+          "loadPromise": undefined,
           "opts": {
             "get": {},
             "isLoaded": {},
@@ -84,6 +91,7 @@ describe("Entity", () => {
           "_isLoaded": false,
           "fieldName": "mentor",
           "isCascadeDelete": false,
+          "loaded": undefined,
           "otherFieldName": "authors",
           "undefined": null,
         },
@@ -94,6 +102,7 @@ describe("Entity", () => {
           "loadHint": {
             "books": {},
           },
+          "loadPromise": undefined,
           "loaded": false,
           "reactiveHint": [
             "books",
@@ -103,6 +112,7 @@ describe("Entity", () => {
         "numberOfBooks2": {
           "fn": {},
           "hint": "books",
+          "loadPromise": undefined,
           "loaded": false,
         },
         "numberOfBooksCalcInvoked": 0,
@@ -110,11 +120,13 @@ describe("Entity", () => {
           "_isLoaded": false,
           "fieldName": "publisher",
           "isCascadeDelete": false,
+          "loaded": undefined,
           "otherFieldName": "authors",
           "undefined": null,
         },
         "reviewedBooks": {
           "_isLoaded": false,
+          "loadPromise": undefined,
           "opts": {
             "add": {},
             "get": {},
@@ -126,6 +138,7 @@ describe("Entity", () => {
         },
         "reviews": {
           "_isLoaded": false,
+          "loadPromise": undefined,
           "opts": {
             "get": {},
             "isLoaded": {},
@@ -138,6 +151,7 @@ describe("Entity", () => {
           "fieldName": "tags",
           "isCascadeDelete": false,
           "joinTableName": "authors_to_tags",
+          "loaded": undefined,
           "otherColumnName": "tag_id",
           "otherFieldName": "authors",
           "removedBeforeLoaded": [],

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -195,7 +195,7 @@ authorConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/integration-tests/src/entities/AuthorStatCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorStatCodegen.ts
@@ -125,7 +125,7 @@ authorStatConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class AuthorStatCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: AuthorStatFilter;
     gqlFilterType: AuthorStatGraphQLFilter;
     orderType: AuthorStatOrder;

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -103,7 +103,7 @@ bookAdvanceConfig.addRule(newRequiredRule("publisher"));
 export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: BookAdvanceFilter;
     gqlFilterType: BookAdvanceGraphQLFilter;
     orderType: BookAdvanceOrder;

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -135,7 +135,7 @@ bookConfig.addRule(newRequiredRule("author"));
 export abstract class BookCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = { order: 1 };
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -104,7 +104,7 @@ bookReviewConfig.addRule(newRequiredRule("book"));
 export abstract class BookReviewCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: BookReviewFilter;
     gqlFilterType: BookReviewGraphQLFilter;
     orderType: BookReviewOrder;

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -88,7 +88,7 @@ commentConfig.addRule(newRequiredRule("parent"));
 export abstract class CommentCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: CommentFilter;
     gqlFilterType: CommentGraphQLFilter;
     orderType: CommentOrder;

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -96,7 +96,7 @@ criticConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class CriticCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: CriticFilter;
     gqlFilterType: CriticGraphQLFilter;
     orderType: CriticOrder;

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -80,7 +80,7 @@ criticColumnConfig.addRule(newRequiredRule("critic"));
 export abstract class CriticColumnCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: CriticColumnFilter;
     gqlFilterType: CriticColumnGraphQLFilter;
     orderType: CriticColumnOrder;

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -117,7 +117,7 @@ imageConfig.addRule(newRequiredRule("type"));
 export abstract class ImageCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: ImageFilter;
     gqlFilterType: ImageGraphQLFilter;
     orderType: ImageOrder;

--- a/packages/integration-tests/src/entities/LargePublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/LargePublisherCodegen.ts
@@ -63,7 +63,7 @@ export const largePublisherConfig = new ConfigApi<LargePublisher, Context>();
 export abstract class LargePublisherCodegen extends Publisher {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: LargePublisherFilter;
     gqlFilterType: LargePublisherGraphQLFilter;
     orderType: LargePublisherOrder;

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -32,7 +32,6 @@ import {
   ValueGraphQLFilter,
 } from "joist-orm";
 import { Context } from "src/context";
-import type { EntityManager } from "./entities";
 import {
   Author,
   AuthorId,
@@ -65,6 +64,7 @@ import {
   TagId,
   tagMeta,
 } from "./entities";
+import type { EntityManager } from "./entities";
 
 export type PublisherId = Flavor<string, "Publisher">;
 
@@ -151,7 +151,7 @@ publisherConfig.addRule(newRequiredRule("type"));
 export abstract class PublisherCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = { type: PublisherType.Big };
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: PublisherFilter;
     gqlFilterType: PublisherGraphQLFilter;
     orderType: PublisherOrder;

--- a/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
@@ -81,7 +81,7 @@ publisherGroupConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: PublisherGroupFilter;
     gqlFilterType: PublisherGroupGraphQLFilter;
     orderType: PublisherGroupOrder;

--- a/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
@@ -66,7 +66,7 @@ smallPublisherConfig.addRule(newRequiredRule("city"));
 export abstract class SmallPublisherCodegen extends Publisher {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: SmallPublisherFilter;
     gqlFilterType: SmallPublisherGraphQLFilter;
     orderType: SmallPublisherOrder;

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -87,7 +87,7 @@ tagConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class TagCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: TagFilter;
     gqlFilterType: TagGraphQLFilter;
     orderType: TagOrder;

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
     "moduleResolution": "Node16",
-    "lib": ["es2020"],
     "strict": true,
     "types": ["jest", "node"],
     "esModuleInterop": true,

--- a/packages/migration-utils/tsconfig.json
+++ b/packages/migration-utils/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/orm/tsconfig.json
+++ b/packages/orm/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -77,7 +77,7 @@ artistConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class ArtistCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: ArtistFilter;
     gqlFilterType: ArtistGraphQLFilter;
     orderType: ArtistOrder;

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -76,7 +76,7 @@ authorConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -72,7 +72,7 @@ bookConfig.addRule(newRequiredRule("author"));
 export abstract class BookCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -80,7 +80,7 @@ paintingConfig.addRule(newRequiredRule("artist"));
 export abstract class PaintingCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: PaintingFilter;
     gqlFilterType: PaintingGraphQLFilter;
     orderType: PaintingOrder;

--- a/packages/tests/schema-misc/tsconfig.json
+++ b/packages/tests/schema-misc/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "types": ["jest", "node"],
     "esModuleInterop": true,

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -77,7 +77,7 @@ authorConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -81,7 +81,7 @@ bookConfig.addRule(newRequiredRule("author"));
 export abstract class BookCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/untagged-ids/tsconfig.json
+++ b/packages/tests/untagged-ids/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "types": ["jest", "node"],
     "esModuleInterop": true,

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -76,7 +76,7 @@ authorConfig.addRule(newRequiredRule("updatedAt"));
 export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: AuthorFilter;
     gqlFilterType: AuthorGraphQLFilter;
     orderType: AuthorOrder;

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -80,7 +80,7 @@ bookConfig.addRule(newRequiredRule("author"));
 export abstract class BookCodegen extends BaseEntity<EntityManager> {
   static defaultValues: object = {};
 
-  readonly __orm!: EntityOrmField & {
+  declare readonly __orm: EntityOrmField & {
     filterType: BookFilter;
     gqlFilterType: BookGraphQLFilter;
     orderType: BookOrder;

--- a/packages/tests/uuid-ids/tsconfig.json
+++ b/packages/tests/uuid-ids/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "types": ["jest", "node"],
     "esModuleInterop": true,

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2020"],
     "strict": true,
     "noImplicitReturns": true,
     "types": ["jest", "node"],


### PR DESCRIPTION
This uses native JS fields/private fields so just has much cleaner output.