### PR TITLE
fix: Fix derived fields on subtypes.

### DIFF
--- a/packages/integration-tests/joist-config.json
+++ b/packages/integration-tests/joist-config.json
@@ -34,7 +34,7 @@
     "LargePublisher": { "tag": "p" },
     "Publisher": { "abstract": true, "tag": "p" },
     "PublisherGroup": { "relations": { "critics": { "large": true } }, "tag": "pg" },
-    "SmallPublisher": { "tag": "p" },
+    "SmallPublisher": { "fields": { "allAuthorNames": { "derived": "async" } }, "tag": "p" },
     "Tag": { "relations": { "authors": { "large": true } }, "tag": "t" }
   },
   "entitiesDirectory": "./src/entities"

--- a/packages/integration-tests/migrations/1580658856631_author.ts
+++ b/packages/integration-tests/migrations/1580658856631_author.ts
@@ -51,6 +51,8 @@ export function up(b: MigrationBuilder): void {
   // Create two subclass tables
   createSubTable(b, "publishers", "small_publishers", {
     city: { type: "text", notNull: true },
+    // Used to test reactive fields that only exist on a subtype
+    all_author_names: { type: "text" },
   });
   createSubTable(b, "publishers", "large_publishers", {
     country: "text",

--- a/packages/integration-tests/schema/.history.json
+++ b/packages/integration-tests/schema/.history.json
@@ -174,10 +174,10 @@
     "updatedAt"
   ],
   "SavePublisherResult": ["publisher"],
-  "SaveSmallPublisherInput": ["city", "id", "idId"],
+  "SaveSmallPublisherInput": ["allAuthorNames", "city", "id", "idId"],
   "SaveSmallPublisherResult": ["smallPublisher"],
   "SaveTagInput": ["createdAt", "id", "name", "updatedAt"],
   "SaveTagResult": ["tag"],
-  "SmallPublisher": ["city", "id"],
+  "SmallPublisher": ["allAuthorNames", "city", "id"],
   "Tag": ["books", "createdAt", "id", "name", "publishers", "updatedAt"]
 }

--- a/packages/integration-tests/schema/smallPublisher.graphql
+++ b/packages/integration-tests/schema/smallPublisher.graphql
@@ -11,7 +11,6 @@ type SmallPublisher {
 input SaveSmallPublisherInput {
   id: ID
   city: String
-  allAuthorNames: String
 }
 
 type SaveSmallPublisherResult {

--- a/packages/integration-tests/schema/smallPublisher.graphql
+++ b/packages/integration-tests/schema/smallPublisher.graphql
@@ -5,11 +5,13 @@ extend type Mutation {
 type SmallPublisher {
   id: ID!
   city: String
+  allAuthorNames: String
 }
 
 input SaveSmallPublisherInput {
   id: ID
   city: String
+  allAuthorNames: String
 }
 
 type SaveSmallPublisherResult {

--- a/packages/integration-tests/src/Inheritance.test.ts
+++ b/packages/integration-tests/src/Inheritance.test.ts
@@ -283,12 +283,12 @@ describe("Inheritance", () => {
   });
 
   it("can ignore persisted fields from a different subtype", async () => {
-    // Given a small publisher
+    // Given a large publisher
     await insertLargePublisher({ name: "lp1" });
     const em = newEntityManager();
     // When we make an author
     newAuthor(em, { publisher: "p:1" });
-    // Then we can flush w/o erroring out
+    // Then we can flush w/o blowing up on `allAuthorNames` is an invalid field
     await expect(em.flush()).resolves.toBeDefined();
   });
 });

--- a/packages/integration-tests/src/entities/SmallPublisher.ts
+++ b/packages/integration-tests/src/entities/SmallPublisher.ts
@@ -1,8 +1,18 @@
 import { SmallPublisherCodegen } from "./entities";
 
+import { hasPersistedAsyncProperty, PersistedAsyncProperty } from "joist-orm";
 import { smallPublisherConfig as config } from "./entities";
 
 export class SmallPublisher extends SmallPublisherCodegen {
+  // Used for testing a derived property that only exists on a subtype
+  readonly allAuthorNames: PersistedAsyncProperty<SmallPublisher, string> = hasPersistedAsyncProperty(
+    "allAuthorNames",
+    { authors: ["firstName"] },
+    (sp) => {
+      console.log("CALC", sp.authors.get.length, sp.authors.get.map((a) => a.firstName).join(", "));
+      return sp.authors.get.map((a) => a.firstName).join(", ");
+    },
+  );
   public beforeFlushRan = false;
   public beforeCreateRan = false;
   public beforeUpdateRan = false;

--- a/packages/integration-tests/src/entities/SmallPublisher.ts
+++ b/packages/integration-tests/src/entities/SmallPublisher.ts
@@ -8,10 +8,7 @@ export class SmallPublisher extends SmallPublisherCodegen {
   readonly allAuthorNames: PersistedAsyncProperty<SmallPublisher, string> = hasPersistedAsyncProperty(
     "allAuthorNames",
     { authors: ["firstName"] },
-    (sp) => {
-      console.log("CALC", sp.authors.get.length, sp.authors.get.map((a) => a.firstName).join(", "));
-      return sp.authors.get.map((a) => a.firstName).join(", ");
-    },
+    (sp) => sp.authors.get.map((a) => a.firstName).join(", "),
   );
   public beforeFlushRan = false;
   public beforeCreateRan = false;

--- a/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
@@ -14,6 +14,7 @@ import {
   OptsOf,
   OrderBy,
   PartialOrNull,
+  PersistedAsyncProperty,
   setField,
   setOpts,
   ValueFilter,
@@ -49,14 +50,17 @@ export interface SmallPublisherIdsOpts extends PublisherIdsOpts {
 
 export interface SmallPublisherFilter extends PublisherFilter {
   city?: ValueFilter<string, never>;
+  allAuthorNames?: ValueFilter<string, null | undefined>;
 }
 
 export interface SmallPublisherGraphQLFilter extends PublisherGraphQLFilter {
   city?: ValueGraphQLFilter<string>;
+  allAuthorNames?: ValueGraphQLFilter<string>;
 }
 
 export interface SmallPublisherOrder extends PublisherOrder {
   city?: OrderBy;
+  allAuthorNames?: OrderBy;
 }
 
 export const smallPublisherConfig = new ConfigApi<SmallPublisher, Context>();
@@ -105,6 +109,8 @@ export abstract class SmallPublisherCodegen extends Publisher {
   set city(city: string) {
     setField(this, "city", city);
   }
+
+  abstract readonly allAuthorNames: PersistedAsyncProperty<SmallPublisher, string | undefined>;
 
   set(opts: Partial<SmallPublisherOpts>): void {
     setOpts(this as any as SmallPublisher, opts);

--- a/packages/integration-tests/src/entities/metadata.ts
+++ b/packages/integration-tests/src/entities/metadata.ts
@@ -412,7 +412,11 @@ export const smallPublisherMeta: EntityMetadata<SmallPublisher> = {
   idType: "int",
   tagName: "p",
   tableName: "small_publishers",
-  fields: { "id": { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("p", "id", "id", "int"), immutable: true }, "city": { kind: "primitive", fieldName: "city", fieldIdName: undefined, derived: false, required: true, protected: false, type: "string", serde: new PrimitiveSerde("city", "city", "text"), immutable: false } },
+  fields: {
+    "id": { kind: "primaryKey", fieldName: "id", fieldIdName: undefined, required: true, serde: new KeySerde("p", "id", "id", "int"), immutable: true },
+    "city": { kind: "primitive", fieldName: "city", fieldIdName: undefined, derived: false, required: true, protected: false, type: "string", serde: new PrimitiveSerde("city", "city", "text"), immutable: false },
+    "allAuthorNames": { kind: "primitive", fieldName: "allAuthorNames", fieldIdName: undefined, derived: "async", required: false, protected: false, type: "string", serde: new PrimitiveSerde("allAuthorNames", "all_author_names", "text"), immutable: false },
+  },
   allFields: {},
   timestampFields: { createdAt: undefined, updatedAt: undefined, deletedAt: undefined },
   config: smallPublisherConfig,

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1174,11 +1174,9 @@ async function addReactiveAsyncDerivedValues(todos: Record<string, Todo>): Promi
           e.isDeletedEntity ||
           ((e as any).changes as Changes<any>).fields.some((f) => field.fields.includes(f)),
       );
-      console.log("Handling", field.name, "triggered", triggered);
       (await followReverseHint(triggered, field.path))
         .filter((entity) => !entity.isDeletedEntity)
         .forEach((entity) => {
-          console.log("Queueing", field.name, "on", entity);
           const { asyncFields } = getTodo(todos, entity);
           if (!asyncFields.has(entity)) {
             asyncFields.set(entity, new Set());

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1338,7 +1338,7 @@ async function recalcAsyncDerivedFields(em: EntityManager, todos: Record<string,
       .flatMap(([entity, fields]) => {
         return (
           [...fields.values()]
-            // Look for fields that don't exist b/c they might be on a different subtype
+            // Ignores fields that don't exist b/c they are likely just on a different subtype
             .filter((fieldName) => (entity as any)[fieldName])
             .map((fieldName) => (entity as any)[fieldName].load())
         );

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -304,6 +304,9 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
           const reversals = reverseReactiveHint(meta.cstr, asyncProperty.reactiveHint);
           reversals.forEach(({ entity, path, fields }) => {
             getMetadata(entity).config.__data.reactiveDerivedValues.push({ name: field.fieldName, path, fields });
+            if (field.fieldName === "allAuthorNames") {
+              console.log(`Adding ${fields} -> ${path} to ${entity.name}`);
+            }
           });
         }
       });

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -304,9 +304,6 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
           const reversals = reverseReactiveHint(meta.cstr, asyncProperty.reactiveHint);
           reversals.forEach(({ entity, path, fields }) => {
             getMetadata(entity).config.__data.reactiveDerivedValues.push({ name: field.fieldName, path, fields });
-            if (field.fieldName === "allAuthorNames") {
-              console.log(`Adding ${fields} -> ${path} to ${entity.name}`);
-            }
           });
         }
       });

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -230,11 +230,9 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
       if (!this.#entity.isNewEntity) {
         this.#entity.em.entities
           .filter((e) => e instanceof this.#otherMeta.cstr)
+          .filter((e) => !this.#addedBeforeLoaded.includes(e as U))
           .forEach((e) => {
-            if (
-              sameEntity((e as any).__orm.data[this.otherFieldName], this.#entity) &&
-              !this.#addedBeforeLoaded.includes(e as U)
-            ) {
+            if (sameEntity((e as any).__orm.data[this.otherFieldName], this.#entity)) {
               this.#addedBeforeLoaded.push(e as U);
             }
           });

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -220,11 +220,28 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
 
   private maybeAppendAddedBeforeLoaded(): void {
     if (this.loaded) {
+      // If our entity is not new, then entities in the EM might have been mutated to point
+      // to our foreign key (instead of our loaded instance), which means they should be in
+      // `addedBeforeLoaded` but are not.
+      //
+      // (Note that we don't have to handle the case for "removed before loaded" here because
+      // the oneToManyDataLoader already handles that; although maybe arguably that logic should
+      // be handled here?)
+      if (!this.#entity.isNewEntity) {
+        this.#entity.em.entities
+          .filter((e) => e instanceof this.#otherMeta.cstr)
+          .forEach((e) => {
+            if (
+              sameEntity((e as any).__orm.data[this.otherFieldName], this.#entity) &&
+              !this.#addedBeforeLoaded.includes(e as U)
+            ) {
+              this.#addedBeforeLoaded.push(e as U);
+            }
+          });
+      }
       const newEntities = this.#addedBeforeLoaded.filter((e) => !this.loaded?.includes(e));
       // Push on the end to better match the db order of "newer things come last"
-      for (const e of newEntities) {
-        this.loaded.push(e);
-      }
+      this.loaded.push(...newEntities);
       this.#addedBeforeLoaded = [];
     }
   }


### PR DESCRIPTION
The derived field on the subtype itself worked, but entities of the _other_ subtype would blow up.

For example, `SmallPublisher.allAuthorNames` is a derived field.

If an Author points to a SmallPublisher, we can follow a1 -> publishers -> recalc sp1[allAuthorNames].

But if an Author points to a LargePublisher, if we try to follow a1 -> publishers -> recalc lp1[allAuthorNames], it will NPE because the LargePublisher doesn't have an `allAuthorNames` field.

Which is fine, the Author, when it said "hey tell my publisher to recalc things" can't know "is this publisher large or small?", so we just have to detect/infer that at runtime, by handling the "field does not exist" as a heuristic for "ah, because its not on this subtype".

---

This PR also happens to fix an unrelated bug with o2m collection loading, which was introduced when we started allowing setting m2os to just an id; i.e.:

em.create(Author, { publisher: "p:1" });