### PR TITLE
fix: Fix reactive rules on subtypes.

### DIFF
--- a/packages/integration-tests/src/EntityManager.reactiveRules.test.tsx
+++ b/packages/integration-tests/src/EntityManager.reactiveRules.test.tsx
@@ -96,55 +96,54 @@ describe("EntityManager.reactiveRules", () => {
   });
 
   it.withCtx("creates the right reactive rules", async () => {
+    const cstr = expect.any(Function);
+    const fn = expect.any(Function);
     expect(getMetadata(Author).config.__data.reactiveRules).toEqual([
       // Author's firstName/book.title validation rule
-      { name: sm(/Author.ts:\d+/), fields: ["firstName"], path: [], fn: expect.any(Function) },
+      { cstr, name: sm(/Author.ts:\d+/), fields: ["firstName"], path: [], fn },
       // Author's "cannot have 13 books" rules
-      { name: sm(/Author.ts:\d+/), fields: [], path: [], fn: expect.any(Function) },
+      { cstr, name: sm(/Author.ts:\d+/), fields: [], path: [], fn },
       // Author's noop mentor rule
-      { name: sm(/Author.ts:\d+/), fields: ["mentor"], path: [], fn: expect.any(Function) },
+      { cstr, name: sm(/Author.ts:\d+/), fields: ["mentor"], path: [], fn },
       // Author's graduated rule that runs on hook changes
-      { name: sm(/Author.ts:\d+/), fields: ["graduated"], path: [], fn: expect.any(Function) },
+      { cstr, name: sm(/Author.ts:\d+/), fields: ["graduated"], path: [], fn },
       // Author's immutable age rule (w/o age listed b/c it is immutable, but still needs to fire on create)
-      { name: sm(/Author.ts:\d+/), fields: [], path: [], fn: expect.any(Function) },
+      { cstr, name: sm(/Author.ts:\d+/), fields: [], path: [], fn },
       // Book's noop author.firstName rule, only depends on firstName
-      { name: sm(/Book.ts:\d+/), fields: ["firstName"], path: ["books"], fn: expect.any(Function) },
+      { cstr, name: sm(/Book.ts:\d+/), fields: ["firstName"], path: ["books"], fn },
       // Book's "too many colors" rule, only depends on favoriteColors, not firstName:ro
-      { name: sm(/Book.ts:\d+/), fields: ["favoriteColors"], path: ["books"], fn: expect.any(Function) },
+      { cstr, name: sm(/Book.ts:\d+/), fields: ["favoriteColors"], path: ["books"], fn },
       // Publisher's "cannot have 13 authors" rule
-      { name: sm(/Publisher.ts:\d+/), fields: ["publisher"], path: ["publisher"], fn: expect.any(Function) },
+      { cstr, name: sm(/Publisher.ts:\d+/), fields: ["publisher"], path: ["publisher"], fn },
       // Publisher's numberOfBooks2 "cannot have 13 books" rule
-      { name: sm(/Publisher.ts:\d+/), fields: ["publisher"], path: ["publisher"], fn: expect.any(Function) },
+      { cstr, name: sm(/Publisher.ts:\d+/), fields: ["publisher"], path: ["publisher"], fn },
       // Publisher's numberOfBooks "cannot have 15 books" rule
-      {
-        name: sm(/Publisher.ts:\d+/),
-        fields: ["publisher", "numberOfBooks"],
-        path: ["publisher"],
-        fn: expect.any(Function),
-      },
+      { cstr, name: sm(/Publisher.ts:\d+/), fields: ["publisher", "numberOfBooks"], path: ["publisher"], fn },
+      // SmallPublisher's "cannot have >5 authors" rule
+      { cstr, name: sm(/Publisher.ts:\d+/), fields: ["publisher"], path: ["publisher"], fn },
     ]);
 
     expect(getMetadata(Book).config.__data.reactiveRules).toEqual([
       // Author's firstName/book.title validation rule
-      { name: sm(/Author.ts:\d+/), fields: ["author", "title"], path: ["author"], fn: expect.any(Function) },
+      { cstr, name: sm(/Author.ts:\d+/), fields: ["author", "title"], path: ["author"], fn },
       // Author's "cannot have 13 books" rule
-      { name: sm(/Author.ts:\d+/), fields: ["author"], path: ["author"], fn: expect.any(Function) },
+      { cstr, name: sm(/Author.ts:\d+/), fields: ["author"], path: ["author"], fn },
       // Book's noop rule on author.firstName, if author changes
-      { name: sm(/Book.ts:\d+/), fields: ["author"], path: [], fn: expect.any(Function) },
+      { cstr, name: sm(/Book.ts:\d+/), fields: ["author"], path: [], fn },
       // Book's "too many colors" rule, if author changes
-      { name: sm(/Book.ts:\d+/), fields: ["author"], path: [], fn: expect.any(Function) },
+      { cstr, name: sm(/Book.ts:\d+/), fields: ["author"], path: [], fn },
       // Book's "reviewsRuleInvoked", when BookReview.book is immutable field
-      { name: sm(/Book.ts:\d+/), fields: [], path: [], fn: expect.any(Function) },
+      { cstr, name: sm(/Book.ts:\d+/), fields: [], path: [], fn },
       // Book's "numberOfBooks2" rule (this book + other books)
-      { name: sm(/Book.ts:\d+/), fields: ["author"], path: [], fn: expect.any(Function) },
-      { name: sm(/Book.ts:\d+/), fields: ["author"], path: ["author", "books"], fn: expect.any(Function) },
+      { cstr, name: sm(/Book.ts:\d+/), fields: ["author"], path: [], fn },
+      { cstr, name: sm(/Book.ts:\d+/), fields: ["author"], path: ["author", "books"], fn },
       // Publisher's numberOfBooks2 "cannot have 13 books" rule
-      { name: sm(/Publisher.ts:\d+/), fields: ["author"], path: ["author", "publisher"], fn: expect.any(Function) },
+      { cstr, name: sm(/Publisher.ts:\d+/), fields: ["author"], path: ["author", "publisher"], fn },
     ]);
 
     expect(getMetadata(BookReview).config.__data.reactiveRules).toEqual([
       // Book's "reviewsRuleInvoked", when BookReview.book is immutable field
-      { name: sm(/Book.ts:\d+/), fields: [], path: ["book"], fn: expect.any(Function) },
+      { cstr, name: sm(/Book.ts:\d+/), fields: [], path: ["book"], fn },
     ]);
   });
 
@@ -163,10 +162,11 @@ describe("EntityManager.reactiveRules", () => {
   });
 
   it.withCtx("creates the right reactive derived values", async () => {
+    const cstr = expect.any(Function);
     expect(getMetadata(Book).config.__data.reactiveDerivedValues).toEqual([
-      { name: "numberOfBooks", fields: ["author"], path: ["author"] },
-      { name: "bookComments", fields: ["author"], path: ["author"] },
-      { name: "isPublic", fields: ["author"], path: ["reviews"] },
+      { cstr, name: "numberOfBooks", fields: ["author"], path: ["author"] },
+      { cstr, name: "bookComments", fields: ["author"], path: ["author"] },
+      { cstr, name: "isPublic", fields: ["author"], path: ["reviews"] },
     ]);
   });
 
@@ -219,7 +219,7 @@ describe("EntityManager.reactiveRules", () => {
 
     it.withCtx("runs rule on added children", async ({ em }) => {
       // Given a publisher that has two authors
-      const p = newPublisher(em, {
+      newPublisher(em, {
         authors: [
           // And each author has 6 books
           { books: [{}, {}, {}, {}, {}, {}] },
@@ -271,7 +271,7 @@ describe("EntityManager.reactiveRules", () => {
 
     it.withCtx("runs rule on added children", async ({ em }) => {
       // Given a publisher that has two authors
-      const p = newPublisher(em, {
+      newPublisher(em, {
         authors: [
           // And each author has 7 books
           { books: [{}, {}, {}, {}, {}, {}, {}] },

--- a/packages/integration-tests/src/Inheritance.test.ts
+++ b/packages/integration-tests/src/Inheritance.test.ts
@@ -304,7 +304,7 @@ describe("Inheritance", () => {
     await expect(em.flush()).rejects.toThrow("SmallPublishers cannot have more than 5 authors");
   });
 
-  it("ignores have reactive rules from the other subtype", async () => {
+  it("ignores reactive rules from the other subtype", async () => {
     const em = newEntityManager();
     // Given a large publisher
     const lg = newLargePublisher(em, { name: "lp1" });

--- a/packages/integration-tests/src/Inheritance.test.ts
+++ b/packages/integration-tests/src/Inheritance.test.ts
@@ -8,10 +8,12 @@ import {
   insertTag,
   select,
 } from "@src/entities/inserts";
+import { zeroTo } from "@src/utils";
 import {
   Author,
   LargePublisher,
   newAuthor,
+  newLargePublisher,
   newPublisher,
   newSmallPublisher,
   Publisher,
@@ -289,6 +291,26 @@ describe("Inheritance", () => {
     // When we make an author
     newAuthor(em, { publisher: "p:1" });
     // Then we can flush w/o blowing up on `allAuthorNames` is an invalid field
+    await expect(em.flush()).resolves.toBeDefined();
+  });
+
+  it("can have reactive rules on a subtype", async () => {
+    const em = newEntityManager();
+    // Given a small publisher
+    const sp = newSmallPublisher(em, { name: "sp1" });
+    // When we make six authors
+    zeroTo(6).forEach(() => newAuthor(em, { publisher: sp }));
+    // Then the rule fails
+    await expect(em.flush()).rejects.toThrow("SmallPublishers cannot have more than 5 authors");
+  });
+
+  it("ignores have reactive rules from the other subtype", async () => {
+    const em = newEntityManager();
+    // Given a large publisher
+    const lg = newLargePublisher(em, { name: "lp1" });
+    // When we make six authors
+    zeroTo(6).forEach(() => newAuthor(em, { publisher: lg }));
+    // Then the rule isn't ran
     await expect(em.flush()).resolves.toBeDefined();
   });
 });

--- a/packages/integration-tests/src/entities/SmallPublisher.ts
+++ b/packages/integration-tests/src/entities/SmallPublisher.ts
@@ -24,6 +24,13 @@ config.addRule((p) => {
   }
 });
 
+// Example of a reactive rule on a subtype
+config.addRule("authors", (sp) => {
+  if (sp.authors.get.length > 5) {
+    return "SmallPublishers cannot have more than 5 authors";
+  }
+});
+
 // Noop rule to verify we can check both subtype & based type fields
 config.beforeFlush((sp) => {
   if (sp.changes.city.hasChanged || sp.changes.name.hasChanged) {

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -1,5 +1,13 @@
 import { Entity } from "./Entity";
-import { getMetadata, Loaded, LoadHint, Reacted, ReactiveHint, RelationsIn } from "./index";
+import {
+  getMetadata,
+  Loaded,
+  LoadHint,
+  MaybeAbstractEntityConstructor,
+  Reacted,
+  ReactiveHint,
+  RelationsIn,
+} from "./index";
 import { convertToLoadHint } from "./reactiveHints";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
 import { ValidationRule, ValidationRuleInternal } from "./rules";
@@ -137,6 +145,7 @@ export class ConfigApi<T extends Entity, C> {
  * a `ReactiveRule` with fields `["title"]`, path `books`, and rule `ruleFn`.
  */
 interface ReactiveRule {
+  cstr: MaybeAbstractEntityConstructor<any>;
   name: string;
   fields: string[];
   path: string[];
@@ -150,6 +159,7 @@ interface ReactiveRule {
  * a `ReactiveFields` with fields `["title"]`, path `books`, and name `title`.
  */
 interface ReactiveField {
+  cstr: MaybeAbstractEntityConstructor<any>;
   name: string;
   fields: string[];
   path: string[];

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -285,7 +285,7 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
         // For each reversal, tell its config about the reverse hint to force-re-validate
         // the original rule's instance any time it changes.
         reversals.forEach(({ entity, path, fields }) => {
-          getMetadata(entity).config.__data.reactiveRules.push({ name, fields, path, fn });
+          getMetadata(entity).config.__data.reactiveRules.push({ cstr: meta.cstr, name, fields, path, fn });
         });
       }
     });
@@ -303,7 +303,12 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
         if (asyncProperty?.reactiveHint) {
           const reversals = reverseReactiveHint(meta.cstr, asyncProperty.reactiveHint);
           reversals.forEach(({ entity, path, fields }) => {
-            getMetadata(entity).config.__data.reactiveDerivedValues.push({ name: field.fieldName, path, fields });
+            getMetadata(entity).config.__data.reactiveDerivedValues.push({
+              cstr: meta.cstr,
+              name: field.fieldName,
+              path,
+              fields,
+            });
           });
         }
       });


### PR DESCRIPTION
Reactive rules correctly worked on the subtype itself, but also would incorrectly fire on all types and not just the subtype they were added to.