### PR TITLE
feat: Add useFactoryDefaults escape hatch.

### DIFF
--- a/docs/docs/testing/test-factories.md
+++ b/docs/docs/testing/test-factories.md
@@ -258,6 +258,14 @@ expect(b.title).toBeUndefined();
 expect(b.author.get).toBeUndefined();
 ```
 
+:::tip
+
+If you find yourself regularly using `useFactoryDefaults`, it might be an indication that your factory's defaults are too opinionated, and the factory should do less by default.
+
+For example, instead of the factory having "not actually universally required/useful" defaults that frequently need to be turned off, only the tests that actually rely on the sometimes-wanted/sometimes-not-wanted defaults should opt in to them via a dedicated custom opt.
+
+:::
+
 ## `async` Free Assertions
 
 In production code, Joist relations must be accessed asynchronously, i.e. either with `load()` calls or `populate` preloads:

--- a/packages/integration-tests/src/entities/Author.factories.ts
+++ b/packages/integration-tests/src/entities/Author.factories.ts
@@ -9,7 +9,7 @@ export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): De
   return newTestInstance(em, Author, opts, {
     firstName: `a${testIndex}`,
     // example of using opts, and also used as an example of ignoring opts
-    age: opts?.isPopular ? 50 : undefined,
+    age: opts.isPopular ? 50 : undefined,
     // Adding to ensure newTestInstance doesn't infinitely recurse between m2os & o2os
     image: undefined,
   });

--- a/packages/integration-tests/src/entities/Author.factories.ts
+++ b/packages/integration-tests/src/entities/Author.factories.ts
@@ -8,7 +8,7 @@ export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): De
   lastAuthorFactoryOpts = opts;
   return newTestInstance(em, Author, opts, {
     firstName: `a${testIndex}`,
-    // example of using opts
+    // example of using opts, and also used as an example of ignoring opts
     age: opts?.isPopular ? 50 : undefined,
     // Adding to ensure newTestInstance doesn't infinitely recurse between m2os & o2os
     image: undefined,

--- a/packages/integration-tests/src/entities/BookReview.factories.ts
+++ b/packages/integration-tests/src/entities/BookReview.factories.ts
@@ -1,6 +1,9 @@
-import { DeepNew, EntityManager, FactoryOpts, newTestInstance } from "joist-orm";
+import { DeepNew, EntityManager, FactoryOpts, newTestInstance, testIndex } from "joist-orm";
 import { BookReview } from "./entities";
 
-export function newBookReview(em: EntityManager, opts?: FactoryOpts<BookReview>): DeepNew<BookReview> {
-  return newTestInstance(em, BookReview, opts);
+export function newBookReview(em: EntityManager, opts: FactoryOpts<BookReview> = {}): DeepNew<BookReview> {
+  return newTestInstance(em, BookReview, opts, {
+    // Used to test useFactoryDefaults (without the maybeNew that is used in Book.factories.ts)
+    book: { title: `Book for Review ${testIndex}` },
+  });
 }

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -104,7 +104,12 @@ export function newTestInstance<T extends Entity>(
       const ignoreAllDefaults = "useFactoryDefaults" in opts && opts.useFactoryDefaults === "none";
       const required = field.required && !ignoreAllDefaults;
 
-      if (field.kind === "primitive" && required && !field.derived && !field.protected) {
+      if (
+        field.kind === "primitive" &&
+        (required || (opts as any)[fieldName] === defaultValueMarker) &&
+        !field.derived &&
+        !field.protected
+      ) {
         const codegenDefault = (cstr as any).defaultValues[field.fieldName];
         return [fieldName, codegenDefault ?? defaultValueForField(em, cstr, field)];
       } else if (field.kind === "m2o") {

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -37,7 +37,10 @@ import { assertNever } from "./utils";
  *
  * 2. Works specifically against the constructor/entity opts fields.
  */
-export type FactoryOpts<T extends Entity> = DeepPartialOpts<T> & { use?: Entity | Entity[] };
+export type FactoryOpts<T extends Entity> = DeepPartialOpts<T> & {
+  use?: Entity | Entity[];
+  useFactoryDefaults?: boolean | "none";
+};
 
 // Chosen b/c it's a monday https://www.timeanddate.com/calendar/monthly.html?year=2018&month=1&country=1
 export const jan1 = new Date(2018, 0, 1);
@@ -97,12 +100,11 @@ export function newTestInstance<T extends Entity>(
         }
       }
 
-      if (
-        field.kind === "primitive" &&
-        (field.required || (opts as any)[fieldName] === defaultValueMarker) &&
-        !field.derived &&
-        !field.protected
-      ) {
+      // Don't fill in required fields if told not to
+      const ignoreAllDefaults = "useFactoryDefaults" in opts && opts.useFactoryDefaults === "none";
+      const required = field.required && !ignoreAllDefaults;
+
+      if (field.kind === "primitive" && required && !field.derived && !field.protected) {
         const codegenDefault = (cstr as any).defaultValues[field.fieldName];
         return [fieldName, codegenDefault ?? defaultValueForField(em, cstr, field)];
       } else if (field.kind === "m2o") {
@@ -116,17 +118,17 @@ export function newTestInstance<T extends Entity>(
           isOneToOneField(field.otherMetadata().fields[field.otherFieldName]) &&
           existing[field.otherFieldName].isLoaded &&
           existing[field.otherFieldName].isSet;
-        if (existing && !isUniqueAndAlreadyUsed) {
+        if (existing && !isUniqueAndAlreadyUsed && !ignoreAllDefaults) {
           return [fieldName, existing];
         }
         // Otherwise, only make a new entity only if the field is required
-        if (field.required) {
+        if (required) {
           return [fieldName, resolveFactoryOpt(em, opts, field, undefined, undefined)];
         }
-      } else if (field.kind === "enum" && field.required) {
+      } else if (field.kind === "enum" && required) {
         const codegenDefault = (cstr as any).defaultValues[field.fieldName];
         return [fieldName, codegenDefault ?? field.enumDetailType.getValues()[0]];
-      } else if (field.kind === "poly" && field.required) {
+      } else if (field.kind === "poly" && required) {
         return [fieldName, resolveFactoryOpt(em, opts, field, undefined, undefined)];
       }
       return [];
@@ -156,7 +158,10 @@ export function newTestInstance<T extends Entity>(
       // If this is a list of children, i.e. book.authors, handle partials to newTestInstance'd
       return [fieldName, (optValue as Array<any>).map((opt) => resolveFactoryOpt(em, opts, field, opt, entity))];
     } else if (field.kind == "m2m") {
-      return [fieldName, (optValue as Array<any>).map((opt) => resolveFactoryOpt(em, opts, field, opt, [entity]))];
+      return [
+        fieldName,
+        (optValue as Array<any>).map((opt) => resolveFactoryOpt(em, opts, field, opt, [entity] as any)),
+      ];
     } else if (field.kind === "o2o") {
       // If this is an o2o, i.e. author.image, just pass the optValue (i.e. it won't be a list)
       return [fieldName, resolveFactoryOpt(em, opts, field, optValue as any, entity)];
@@ -187,14 +192,14 @@ function resolveFactoryOpt<T extends Entity>(
   em: EntityManager,
   opts: FactoryOpts<any>,
   field: OneToManyField | ManyToOneField | OneToOneField | ManyToManyField | PolymorphicField,
-  opt: FactoryEntityOpt<T> | undefined,
+  opt: FactoryEntityOpt<any> | undefined,
   maybeEntity: T | undefined,
 ): T | IdOf<T> {
   const { meta, otherFieldName } = metaFromFieldAndOpt(field, opt);
   // const meta = field.kind === "poly" ? field.components[0].otherMetadata() : field.otherMetadata();
   // const otherFieldName = field.kind === "poly" ? field.components[0].otherFieldName : field.otherFieldName;
   if (isEntity(opt)) {
-    return opt;
+    return opt as T;
   } else if (isId(opt)) {
     // Try finding the entity in the UoW, otherwise fallback on just setting it as the id (which we support that now)
     return (em.entities.find((e) => e.idTagged === opt || getTestId(em, e) === opt) as T) || opt;
@@ -440,7 +445,10 @@ type DefinedOr<T> = T | undefined | null;
 type DeepPartialOpts<T extends Entity> = AllowRelationsOrPartials<OptsOf<T>>;
 
 /** What a factory can accept for a given entity. */
-export type FactoryEntityOpt<T extends Entity> = T | IdOf<T> | ActualFactoryOpts<T>;
+export type FactoryEntityOpt<T extends Entity> =
+  | T
+  | IdOf<T>
+  | (ActualFactoryOpts<T> & { useFactoryDefaults?: boolean | "none" });
 
 type AllowRelationsOrPartials<T> = {
   [P in keyof T]?: T[P] extends DefinedOr<infer U>
@@ -506,6 +514,9 @@ function getOrCreateUseMap(opts: FactoryOpts<any>): UseMap {
 /** Merge the factory's opts and the test's opts so that `{ age: 40 }` and `{ firstName: "b1" }` get merged. */
 function mergeOpts(testOpts: Record<string, any>, factoryOpts: Record<string, any>): object {
   // Merge the factory's opts and the test's opts so that `{ age: 40 }` and `{ firstName: "b1" }` get merged
+  if (testOpts.useFactoryDefaults === false || testOpts.useFactoryDefaults === "none") {
+    return testOpts;
+  }
   const opts: any = testOpts;
   Object.entries(factoryOpts).forEach(([key, factoryValue]) => {
     const testValue = testOpts[key];
@@ -517,12 +528,12 @@ function mergeOpts(testOpts: Record<string, any>, factoryOpts: Record<string, an
       }
     } else if (isPlainObject(factoryValue) && isPlainObject(testValue)) {
       // Should this deep merge? Probably?
-      opts[key] = { ...factoryValue, ...testValue };
+      opts[key] = mergeOpts(testValue, factoryValue);
     } else if (factoryValue instanceof MaybeNew && isPlainObject(testValue)) {
-      opts[key] = { ...factoryValue.opts, ...testValue };
+      opts[key] = mergeOpts(testValue, factoryValue.opts);
     } else if (factoryValue instanceof MaybeNew && testValue instanceof MaybeNew) {
       opts[key] = new MaybeNew<any>(
-        { ...factoryValue.opts, ...testValue.opts },
+        mergeOpts(testValue.opts, factoryValue.opts),
         testValue.polyRefPreferredOrder ?? factoryValue.polyRefPreferredOrder,
       );
     }


### PR DESCRIPTION
I've seen a few hand-written ways of "oh wait, ignore those factory defaults that _usually_ we want", so this provides a pattern to opt-out of defaults:

```ts
newBook(em, { useFactoryDefaults: false });
```

This will ignore any `Book.factories.ts` defaults but will still use the "title is a required field" defaults.

To ignore literally all defaults, you can use "none":

```ts
newBook(em, { useFactoryDefaults: "none" });
```

---

## API Musings

...currently in this PR, you get "all or none" of the factory defaults, maybe it would be cute to support only ignoring specific fields? Like:

```ts
newBook(em, { ignoreDefaults: "title" });
```

Although at that point, shouldn't the test just pass their own title:

```ts
newBook(em, { title: undefined });
```

Probably. Sticking with the "all or nothing" seems better; it's simpler and I like the `use` prefix to match `use` and it stands out as a "definitely a factory control knob" and not an actual domain field.