### PR TITLE
fix: Fix initial calc of subtype-only derived values.

### DIFF
--- a/packages/integration-tests/src/EntityManager.reactiveRules.test.tsx
+++ b/packages/integration-tests/src/EntityManager.reactiveRules.test.tsx
@@ -1,4 +1,14 @@
-import { Author, Book, BookReview, Color, newAuthor, newBook, newBookReview, newPublisher } from "@src/entities";
+import {
+  Author,
+  Book,
+  BookReview,
+  Color,
+  newAuthor,
+  newBook,
+  newBookReview,
+  newPublisher,
+  SmallPublisher,
+} from "@src/entities";
 import { getMetadata } from "joist-orm";
 
 const sm = expect.stringMatching;
@@ -144,6 +154,10 @@ describe("EntityManager.reactiveRules", () => {
     expect(getMetadata(BookReview).config.__data.reactiveRules).toEqual([
       // Book's "reviewsRuleInvoked", when BookReview.book is immutable field
       { cstr, name: sm(/Book.ts:\d+/), fields: [], path: ["book"], fn },
+    ]);
+
+    expect(getMetadata(SmallPublisher).config.__data.reactiveRules).toEqual([
+      { cstr: SmallPublisher, name: sm(/SmallPublisher.ts:\d+/), fields: [], path: [], fn },
     ]);
   });
 

--- a/packages/integration-tests/src/Inheritance.test.ts
+++ b/packages/integration-tests/src/Inheritance.test.ts
@@ -273,7 +273,7 @@ describe("Inheritance", () => {
     expect(sp.authors.get[0]?.books.get).toBeUndefined();
   });
 
-  it("can have persisted fields on a subtype", async () => {
+  it("can recalc persisted fields on a subtype", async () => {
     // Given a small publisher
     await insertPublisher({ name: "sp1" });
     const em = newEntityManager();
@@ -282,6 +282,15 @@ describe("Inheritance", () => {
     await em.flush();
     // Then the field is recacled
     expect(await select("small_publishers")).toMatchObject([{ all_author_names: "a1" }]);
+  });
+
+  it("can initialize persisted fields on a subtype", async () => {
+    const em = newEntityManager();
+    // Given a small publisher
+    const sp = newSmallPublisher(em, { name: "sp1" });
+    await em.flush();
+    // Then the field was initialized
+    expect(await select("small_publishers")).toMatchObject([{ all_author_names: "" }]);
   });
 
   it("can ignore persisted fields from a different subtype", async () => {

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1135,7 +1135,8 @@ async function addReactiveValidations(todos: Record<string, Todo>): Promise<void
   const p: Promise<void>[] = Object.values(todos).flatMap((todo) => {
     const entities = [...todo.inserts, ...todo.updates, ...todo.deletes];
     // Find each statically-declared reactive rule for the given entity type
-    return todo.metadata.config.__data.reactiveRules.map(async (rule) => {
+    const rules = getAllMetas(todo.metadata).flatMap((m) => m.config.__data.reactiveRules);
+    return rules.map(async (rule) => {
       // Of all changed entities of this type, how many specifically trigger this rule?
       const triggered = entities.filter(
         (e) =>
@@ -1167,7 +1168,9 @@ async function addReactiveValidations(todos: Record<string, Todo>): Promise<void
 async function addReactiveAsyncDerivedValues(todos: Record<string, Todo>): Promise<void> {
   const p: Promise<void>[] = Object.values(todos).flatMap((todo) => {
     const entities = [...todo.inserts, ...todo.updates, ...todo.deletes];
-    return todo.metadata.config.__data.reactiveDerivedValues.map(async (field) => {
+    // Use getAllMetas to ensure we pick up subtype-only fields
+    const fields = getAllMetas(todo.metadata).flatMap((m) => m.config.__data.reactiveDerivedValues);
+    return fields.map(async (field) => {
       // Of all changed entities of this type, how many specifically trigger this rule?
       const triggered = entities.filter(
         (e) =>


### PR DESCRIPTION
Reactively calculating subtype-only derived values was working correctly, but the initial "calc (non-reactively) on new entity" was only running for base type derived values, and not subtype-only derived values.