### PR TITLE
fix: Fix performance issue into o2m.addedBeforeLoaded handling.

### DIFF
--- a/packages/integration-tests/src/Inheritance.test.ts
+++ b/packages/integration-tests/src/Inheritance.test.ts
@@ -275,10 +275,10 @@ describe("Inheritance", () => {
 
   it("can recalc persisted fields on a subtype", async () => {
     // Given a small publisher
-    await insertPublisher({ name: "sp1" });
     const em = newEntityManager();
     // When we make an author
-    newAuthor(em, { publisher: "p:1" });
+    const sp1 = newSmallPublisher(em);
+    newAuthor(em, { publisher: sp1 });
     await em.flush();
     // Then the field is recacled
     expect(await select("small_publishers")).toMatchObject([{ all_author_names: "a1" }]);

--- a/packages/integration-tests/src/relations/OneToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/OneToManyCollection.test.ts
@@ -148,7 +148,8 @@ describe("OneToManyCollection", () => {
     expect(books[1].id).toEqual(undefined);
   });
 
-  it("combines both pre-added and persisted entities when not in memory yet", async () => {
+  // Skipped due to the first/naive implementation causing performance issues
+  it.skip("combines both pre-added and persisted entities when not in memory yet", async () => {
     // Given an author with one book
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -228,6 +228,11 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
       // the oneToManyDataLoader already handles that; although maybe arguably that logic should
       // be handled here?)
       if (!this.#entity.isNewEntity) {
+        /*
+        Scanning `em._entities.filter(...)` is just fundamentally too slow once there are 10k+
+        entities in the EM, and we might have 5k new entities all call this method, which means
+        scanning the list 5k times. So comment this out for now until we can find a better way.
+
         this.#entity.em.entities
           .filter((e) => e instanceof this.#otherMeta.cstr)
           .filter((e) => !this.#addedBeforeLoaded.includes(e as U))
@@ -236,6 +241,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
               this.#addedBeforeLoaded.push(e as U);
             }
           });
+        */
       }
       const newEntities = this.#addedBeforeLoaded.filter((e) => !this.loaded?.includes(e));
       // Push on the end to better match the db order of "newer things come last"


### PR DESCRIPTION
We recently fixed an issue with `author.books.get` missing books that had been set to the author, before the author itself was loaded from the db.

The fix was correct, but used a naive "scan all the things" implementation which really does not perform well in large UoWs, like over 10k entities.

Note that merely "scanning all loaded entities" (and commenting out the `.includes` n^2 issue) still results in too much of a performance regression, so we'll have to find a non-scanning way of fixing this bug.

The original "author missing a book" bug has existed for a long time and doesn't seem to have caused us any issues, so shouldn't be a lot of harm in going back to living with it.