### PR TITLE
fix: Fix repeatedly converting load hints

### DIFF
--- a/packages/integration-tests/src/Entity.test.ts
+++ b/packages/integration-tests/src/Entity.test.ts
@@ -30,11 +30,6 @@ describe("Entity", () => {
         "bookComments": {
           "fieldName": "bookComments",
           "fn": {},
-          "loadHint": {
-            "books": {
-              "comments": {},
-            },
-          },
           "loadPromise": undefined,
           "loaded": false,
           "reactiveHint": {
@@ -97,9 +92,6 @@ describe("Entity", () => {
         "numberOfBooks": {
           "fieldName": "numberOfBooks",
           "fn": {},
-          "loadHint": {
-            "books": {},
-          },
           "loadPromise": undefined,
           "loaded": false,
           "reactiveHint": [

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -183,6 +183,8 @@ export class ConfigData<T extends Entity, C> {
   // An array of the reactive fields that depend on this entity
   reactiveDerivedValues: ReactiveField[] = [];
   cascadeDeleteFields: Array<keyof RelationsIn<T>> = [];
+  // Constantly converting reactive hints to load hints is expense, so cache them here
+  cachedReactiveLoadHints: Record<string, any> = {};
 }
 
 function getCallerName(): string {

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -299,10 +299,10 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
         // been made a `hasPersistedAsyncProperty` in the entity file, so avoid continuing
         // if we don't actually have a property/loadHint available.
         if (ap?.reactiveHint) {
-          // Cache the load hint so that we don't constantly recalc it on instantiation.
-          getAllMetas(meta).forEach((m) => {
-            m.config.__data.cachedReactiveLoadHints[field.fieldName] = convertToLoadHint(meta, ap.reactiveHint);
-          });
+          // Cache the load hint so that we don't constantly re-calc it on instantiation.
+          const loadHint = convertToLoadHint(meta, ap.reactiveHint);
+          getAllMetas(meta).forEach((m) => (m.config.__data.cachedReactiveLoadHints[field.fieldName] = loadHint));
+
           const reversals = reverseReactiveHint(meta.cstr, ap.reactiveHint);
           reversals.forEach(({ entity, path, fields }) => {
             getMetadata(entity).config.__data.reactiveDerivedValues.push({

--- a/packages/orm/src/relations/hasPersistedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasPersistedAsyncProperty.ts
@@ -2,7 +2,7 @@ import { Entity } from "../Entity";
 import { Const, currentlyInstantiatingEntity } from "../EntityManager";
 import { getMetadata } from "../EntityMetadata";
 import { isLoaded, setField } from "../index";
-import { convertToLoadHint, Reacted, ReactiveHint } from "../reactiveHints";
+import { Reacted, ReactiveHint } from "../reactiveHints";
 
 const I = Symbol();
 
@@ -62,9 +62,9 @@ export class PersistedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint
   implements PersistedAsyncProperty<T, V>
 {
   readonly #entity: T;
+  readonly #reactiveHint: Const<H>;
   private loaded = false;
   private loadPromise: any;
-  private loadHint: any;
   constructor(
     entity: T,
     public fieldName: keyof T & string,
@@ -72,7 +72,7 @@ export class PersistedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint
     private fn: (entity: Reacted<T, H>) => V,
   ) {
     this.#entity = entity;
-    this.loadHint = convertToLoadHint(getMetadata(entity), reactiveHint as any);
+    this.#reactiveHint = reactiveHint;
   }
 
   load(): Promise<V> {
@@ -116,6 +116,10 @@ export class PersistedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint
 
   get isLoaded() {
     return this.loaded;
+  }
+
+  get loadHint(): any {
+    return getMetadata(this.#entity).config.__data.cachedReactiveLoadHints[this.fieldName];
   }
 }
 


### PR DESCRIPTION
The `hasAsyncPersistedField` cstr constantly converted reactive hints to load hints, which:

a) often were not needed, and
b) will always be the same so can be done once and cached

Before, loading ~5k project items each with ~8-ish derived fields, `convertToLoadHint` was a hot spot:

![image](https://user-images.githubusercontent.com/6401/214431582-37486b5e-fd50-493d-80c1-39129bdf862f.png)

After, it is not:

![image](https://user-images.githubusercontent.com/6401/214431646-1b94abfb-fd50-42a1-8480-70783a607de3.png)
