### PR TITLE
fix: Optimize em.register.

### DIFF
--- a/packages/orm/src/keys.ts
+++ b/packages/orm/src/keys.ts
@@ -59,6 +59,12 @@ export function assertIdsAreTagged(keys: readonly string[]): void {
   }
 }
 
+export function assertIdIsTagged(key: string): void {
+  if (key.indexOf(tagDelimiter) === -1) {
+    throw new Error(`Key is not tagged ${key}`);
+  }
+}
+
 /** Tags a potentially untagged id, while our API inputs still accept either tagged or untagged ids. */
 export function tagId(meta: HasTagName, id: string | number): string;
 export function tagId(cstr: EntityConstructor<any>, id: string | number): string;


### PR DESCRIPTION
Avoid allocating a few lists.

Before:

![image](https://user-images.githubusercontent.com/6401/214433446-fcdb8924-90b2-43d8-8c6e-6a5d4d3a98d2.png)

After:

![image](https://user-images.githubusercontent.com/6401/214433535-b0297a88-e656-4cd9-b67d-ccdbd050fcd0.png)
