### PR TITLE
fix: Fix setPartial a collection to undefined should be ignored.

### DIFF
--- a/docs/docs/querying/partial-update-apis.md
+++ b/docs/docs/querying/partial-update-apis.md
@@ -52,12 +52,16 @@ Specifically, the semantics of `Entity.setPartial` is that:
 
 - For a required field `firstName`: 
   - `{ firstName: "foo" }` will update `firstName`
-  - `{ firstName: undefined }` or `{}` will do nothing
-  - `{ firstName: null }` will be a runtime error b/c `firstName` is required and cannot be `null`
+  - `{ firstName: undefined }` will do nothing
+  - `{ firstName: null }` will cause a validation error b/c `firstName` is required and cannot be `null`
 - For an optional field `lastName`: 
   - `{ lastName: "bar" }` will update `lastName`
-  - `{ lastName: undefined }` or `{}` will do nothing
+  - `{ lastName: undefined }` will do nothing
   - `{ lastName: null }` will unset `lastName` (i.e. set it as `undefined`)
+- For collections like `books`:
+  - `{ books: [b1] }` will set the collection to *just* `b1`
+  - `{ books: null }` will set the collection to `[]`
+  - `{ books: undefined }` will do nothing
 
 The `EntityManager.createPartial` and `EntityManager.createOrUpdatePartial` methods both have these semantics as well.
 

--- a/packages/integration-tests/src/EntityManager.createOrUpdatePartial.test.ts
+++ b/packages/integration-tests/src/EntityManager.createOrUpdatePartial.test.ts
@@ -133,7 +133,7 @@ describe("EntityManager.createOrUpdatePartial", () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: ["1"] });
+    const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: ["1"] });
     expect((await a1.books.load())[0].title).toEqual("b1");
   });
 
@@ -141,7 +141,7 @@ describe("EntityManager.createOrUpdatePartial", () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", bookIds: ["1"] });
+    const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", bookIds: ["1"] });
     expect((await a1.books.load())[0].title).toEqual("b1");
   });
 
@@ -149,7 +149,7 @@ describe("EntityManager.createOrUpdatePartial", () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: null });
+    const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: null });
     expect(await a1.books.load()).toEqual([]);
   });
 
@@ -157,8 +157,8 @@ describe("EntityManager.createOrUpdatePartial", () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });
     const em = newEntityManager();
-    const a1 = await em.createOrUpdatePartial(Author, { firstName: "a2", books: undefined });
-    expect(await a1.books.load()).toEqual([]);
+    const a1 = await em.createOrUpdatePartial(Author, { id: "a:1", firstName: "a2", books: undefined });
+    expect(await a1.books.load()).toHaveLength(1);
   });
 
   it("collections are not upserted", async () => {

--- a/packages/integration-tests/src/toMatchEntity.test.ts
+++ b/packages/integration-tests/src/toMatchEntity.test.ts
@@ -308,5 +308,18 @@ describe("toMatchEntity", () => {
       -   "a#2",
         ]
     `);
+    expect(() => expect([] as any).toMatchEntity([{ author1: a1 }])).toThrowErrorMatchingInlineSnapshot(`
+      expect(received).toMatchObject(expected)
+
+      - Expected  - 3
+      + Received  + 1
+
+        Array [
+      -   Object {
+      -     "author1": "a#1",
+      -   },
+      +   Object {},
+        ]
+    `);
   });
 });

--- a/packages/orm/src/createOrUpdatePartial.ts
+++ b/packages/orm/src/createOrUpdatePartial.ts
@@ -112,6 +112,11 @@ export async function createOrUpdatePartial<T extends Entity>(
     } else if (field.kind === "o2m" || field.kind === "m2m") {
       // Look for one-to-many/many-to-many partials
 
+      // `null` is handled later, and treated as `[]`, which needs the collection loaded
+      if (value === undefined) {
+        return [name, undefined];
+      }
+
       // We allow `delete` and `remove` commands but only if they don't collide with existing fields
       // Also we trust the API layer, i.e. GraphQL, to not let these fields leak unless explicitly allowed.
       const allowDelete = !field.otherMetadata().fields["delete"];

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -119,6 +119,10 @@ export function setField<T extends Entity>(entity: T, fieldName: keyof T & strin
  * However, if you pass `ignoreUndefined: true`, then any opt that is `undefined` will be treated
  * as "do not set", and `null` will still mean "set to `undefined`". This is useful for implementing
  * APIs were an input of `undefined` means "do not set / noop" and `null` means "unset".
+ *
+ * Note that constructors _always_ call this method, but if the call is coming from `em.hydrate`, we
+ * use `values` being a primary key to short-circuit and let `hydrate` set the fields via the serde
+ * `setOnEntity` methods.
  */
 export function setOpts<T extends Entity>(
   entity: T,

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -34,7 +34,7 @@ export function toMatchEntity<T>(actual: Entity, expected: MatchedEntity<T>): Cu
       actual instanceof Array ? [...Array(Math.max(actual.length, expected.length)).keys()] : Object.keys(expected);
 
     for (const key of keys) {
-      let actualValue = actual[key];
+      let actualValue = actual ? actual[key] : undefined;
       const expectedValue = expected?.[key];
 
       // We assume the test is asserting already-loaded / DeepNew entities, so just call .get
@@ -82,7 +82,7 @@ export function toMatchEntity<T>(actual: Entity, expected: MatchedEntity<T>): Cu
         // We've hit a non-list/non-object literal expected value, so clean both
         // expected+clean keys to make sure they're not entities, and stop recursion.
         if (key in expected) expected[key] = maybeTestId(expectedValue);
-        if (key in actual) clean[key] = maybeTestId(actualValue);
+        if (actual && key in actual) clean[key] = maybeTestId(actualValue);
       }
     }
   }


### PR DESCRIPTION
The overall semantics of `undefined` in partial APIs is "ignore".

Setting the collection to `null` will still clear it.