### PR TITLE
fix: Fix defaults for polys looking for all parent types.

### DIFF
--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -440,14 +440,14 @@ describe("EntityManager.factories", () => {
         parent: {},
       });
       expect(ft1.parent.isSet).toBeTruthy();
-      expect(await ft1.parent.load()).toBeInstanceOf(Author);
+      expect(ft1.parent.get).toBeInstanceOf(Author);
     });
 
     it("creates a new entity if needed without an opt passed", async () => {
       const em = newEntityManager();
       const ft1 = newTestInstance(em, Comment, {});
       expect(ft1.parent.isSet).toBeTruthy();
-      expect(await ft1.parent.load()).toBeInstanceOf(Author);
+      expect(ft1.parent.get).toBeInstanceOf(Author);
     });
 
     it("reuse an entity if possible without an opt passed", async () => {
@@ -455,7 +455,7 @@ describe("EntityManager.factories", () => {
       const p = newSmallPublisher(em);
       const ft1 = newTestInstance(em, Comment, {});
       expect(ft1.parent.isSet).toBeTruthy();
-      expect(await ft1.parent.load()).toBeInstanceOf(SmallPublisher);
+      expect(ft1.parent.get).toBeInstanceOf(SmallPublisher);
     });
 
     it("creates a new entity when configured not to search for books as a possible default", async () => {
@@ -467,7 +467,7 @@ describe("EntityManager.factories", () => {
         }),
       });
       expect(ft1.parent.isSet).toBeTruthy();
-      expect(await ft1.parent.load()).toBeInstanceOf(Author);
+      expect(ft1.parent.get).toBeInstanceOf(Author);
     });
 
     it("uses an if-only-one entity", async () => {

--- a/packages/integration-tests/src/EntityManager.factories.test.ts
+++ b/packages/integration-tests/src/EntityManager.factories.test.ts
@@ -17,6 +17,7 @@ import {
   newImage,
   newLargePublisher,
   newPublisher,
+  newSmallPublisher,
   Publisher,
   PublisherType,
   SmallPublisher,
@@ -447,6 +448,14 @@ describe("EntityManager.factories", () => {
       const ft1 = newTestInstance(em, Comment, {});
       expect(ft1.parent.isSet).toBeTruthy();
       expect(await ft1.parent.load()).toBeInstanceOf(Author);
+    });
+
+    it("reuse an entity if possible without an opt passed", async () => {
+      const em = newEntityManager();
+      const p = newSmallPublisher(em);
+      const ft1 = newTestInstance(em, Comment, {});
+      expect(ft1.parent.isSet).toBeTruthy();
+      expect(await ft1.parent.load()).toBeInstanceOf(SmallPublisher);
     });
 
     it("creates a new entity when configured not to search for books as a possible default", async () => {


### PR DESCRIPTION
If a polymorphic ref wasn't set, the factory would not look for all existing types of any parent.