### PR TITLE
fix: Don't skip derived fields in the FieldsOf type.

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -633,10 +633,7 @@ function generateOptsFields(config: Config, meta: EntityDbMetadata): Code[] {
 // Make our fields type
 function generateFieldsType(config: Config, meta: EntityDbMetadata): Code[] {
   const primitives = meta.primitives.map((field) => {
-    const { fieldName, fieldType, notNull, derived } = field;
-    if (derived) {
-      return code``;
-    }
+    const { fieldName, fieldType, notNull } = field;
     return code`${fieldName}: ${fieldType}${maybeUndefined(notNull)};`;
   });
   const enums = meta.enums.map((field) => {

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -47,6 +47,7 @@ export class Author extends AuthorCodegen {
     { publisher: "comments", comments: {} },
     (author) => author.publisher.get?.comments.get[0] ?? author.comments.get[0],
   );
+  // Example of persisted property depending on another persisted property
   readonly numberOfPublicReviews: PersistedAsyncProperty<Author, number> = hasPersistedAsyncProperty(
     "numberOfPublicReviews",
     { books: { reviews: ["isPublic", "rating"] } },

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -71,12 +71,18 @@ export type AuthorId = Flavor<string, "Author">;
 export interface AuthorFields {
   firstName: string;
   lastName: string | undefined;
+  initials: string;
+  numberOfBooks: number;
+  bookComments: string | undefined;
   isPopular: boolean | undefined;
   age: number | undefined;
   graduated: Date | undefined;
   wasEverPopular: boolean | undefined;
   address: Address | undefined;
   deletedAt: Date | undefined;
+  numberOfPublicReviews: number | undefined;
+  createdAt: Date;
+  updatedAt: Date;
   favoriteColors: Color[];
   favoriteShape: FavoriteShape | undefined;
   mentor: Author | undefined;

--- a/packages/integration-tests/src/entities/AuthorStatCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorStatCodegen.ts
@@ -38,6 +38,8 @@ export interface AuthorStatFields {
   bigserial: number;
   doublePrecision: number;
   nullableText: string | undefined;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface AuthorStatOpts {

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -49,6 +49,8 @@ import type { EntityManager } from "./entities";
 export type BookAdvanceId = Flavor<string, "BookAdvance">;
 
 export interface BookAdvanceFields {
+  createdAt: Date;
+  updatedAt: Date;
   status: AdvanceStatus;
   book: Book;
   publisher: Publisher;

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -64,6 +64,8 @@ export interface BookFields {
   title: string;
   order: number;
   deletedAt: Date | undefined;
+  createdAt: Date;
+  updatedAt: Date;
   author: Author;
 }
 

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -50,6 +50,9 @@ export type BookReviewId = Flavor<string, "BookReview">;
 
 export interface BookReviewFields {
   rating: number;
+  isPublic: boolean;
+  createdAt: Date;
+  updatedAt: Date;
   book: Book;
 }
 

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -44,6 +44,8 @@ export function isCommentParent(maybeEntity: Entity | undefined | null): maybeEn
 
 export interface CommentFields {
   text: string | undefined;
+  createdAt: Date;
+  updatedAt: Date;
   parent: CommentParent;
 }
 

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -51,6 +51,8 @@ export type CriticId = Flavor<string, "Critic">;
 
 export interface CriticFields {
   name: string;
+  createdAt: Date;
+  updatedAt: Date;
   favoriteLargePublisher: LargePublisher | undefined;
   group: PublisherGroup | undefined;
 }

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -34,6 +34,8 @@ export type CriticColumnId = Flavor<string, "CriticColumn">;
 
 export interface CriticColumnFields {
   name: string;
+  createdAt: Date;
+  updatedAt: Date;
   critic: Critic;
 }
 

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -54,6 +54,8 @@ export type ImageId = Flavor<string, "Image">;
 
 export interface ImageFields {
   fileName: string;
+  createdAt: Date;
+  updatedAt: Date;
   type: ImageType;
   author: Author | undefined;
   book: Book | undefined;

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -73,6 +73,8 @@ export interface PublisherFields {
   latitude: number | undefined;
   longitude: number | undefined;
   hugeNumber: number | undefined;
+  createdAt: Date;
+  updatedAt: Date;
   size: PublisherSize | undefined;
   type: PublisherType;
   group: PublisherGroup | undefined;

--- a/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
@@ -41,6 +41,8 @@ export type PublisherGroupId = Flavor<string, "PublisherGroup">;
 
 export interface PublisherGroupFields {
   name: string | undefined;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface PublisherGroupOpts {

--- a/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
@@ -39,6 +39,7 @@ export type SmallPublisherId = Flavor<string, "SmallPublisher"> & Flavor<string,
 
 export interface SmallPublisherFields extends PublisherFields {
   city: string;
+  allAuthorNames: string | undefined;
 }
 
 export interface SmallPublisherOpts extends PublisherOpts {

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -44,6 +44,8 @@ export type TagId = Flavor<string, "Tag">;
 
 export interface TagFields {
   name: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface TagOpts {

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -31,6 +31,8 @@ export type ArtistId = Flavor<string, "Artist">;
 export interface ArtistFields {
   firstName: string;
   lastName: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface ArtistOpts {

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -31,6 +31,8 @@ export type AuthorId = Flavor<string, "Author">;
 export interface AuthorFields {
   firstName: string;
   lastName: string | undefined;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface AuthorOpts {

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -34,6 +34,8 @@ export type PaintingId = Flavor<string, "Painting">;
 
 export interface PaintingFields {
   title: string;
+  createdAt: Date;
+  updatedAt: Date;
   artist: Artist;
 }
 

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -32,6 +32,8 @@ export type AuthorId = Flavor<string, "Author">;
 export interface AuthorFields {
   firstName: string;
   lastName: string | undefined;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface AuthorOpts {

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -35,6 +35,8 @@ export type BookId = Flavor<string, "Book">;
 
 export interface BookFields {
   title: string;
+  createdAt: Date;
+  updatedAt: Date;
   author: Author;
 }
 

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -31,6 +31,8 @@ export type AuthorId = Flavor<string, "Author">;
 export interface AuthorFields {
   firstName: string;
   lastName: string | undefined;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface AuthorOpts {

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -34,6 +34,8 @@ export type BookId = Flavor<string, "Book">;
 
 export interface BookFields {
   title: string;
+  createdAt: Date;
+  updatedAt: Date;
   author: Author;
 }
 


### PR DESCRIPTION
Because then they're not visible to Reactive hints.

Honestly I forget the rationale for skipping them in the first place, so maybe there is a good reason and I'm not remembering?