### PR TITLE
fix: Allow buildQuery to keep joins.

### DIFF
--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -18,12 +18,12 @@ import QueryBuilder = Knex.QueryBuilder;
 export function buildQuery<T extends Entity>(
   knex: Knex,
   type: EntityConstructor<T>,
-  filter: FilterAndSettings<T>,
+  filter: FilterAndSettings<T> & { pruneJoins?: boolean },
 ): Knex.QueryBuilder<{}, unknown[]> {
   const meta = getMetadata(type);
-  const { where, conditions, orderBy, limit, offset } = filter;
+  const { where, conditions, orderBy, limit, offset, pruneJoins = true } = filter;
 
-  const parsed = parseFindQuery(meta, where, conditions, orderBy);
+  const parsed = parseFindQuery(meta, where, conditions, orderBy, pruneJoins);
 
   // If we're doing o2m joins, add a `DISTINCT` clause to avoid duplicates
   const needsDistinct = parsed.tables.some((t) => t.join === "outer" && t.distinct !== false);

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -62,6 +62,7 @@ export function parseFindQuery(
   filter: any,
   expression: ExpressionFilter | undefined = undefined,
   orderBy: any = {},
+  pruneJoins = true,
 ): ParsedFindQuery {
   const selects: string[] = [];
   const tables: ParsedTable[] = [];
@@ -249,7 +250,9 @@ export function parseFindQuery(
   if (complexConditions.length > 0) {
     Object.assign(parsed, { complexConditions });
   }
-  pruneUnusedJoins(parsed);
+  if (pruneJoins) {
+    pruneUnusedJoins(parsed);
+  }
   return parsed;
 }
 


### PR DESCRIPTION
Since callers may add their own conditions after the fact.