### PR TITLE
feat: Allow aliases to be entity filters.

### DIFF
--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -1521,6 +1521,26 @@ describe("EntityManager.queries", () => {
       });
     });
 
+    it("can use aliases as an m2o entity filter", async () => {
+      await insertLargePublisher({ name: "p1" });
+      await insertAuthor({ first_name: "a1", publisher_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      const em = newEntityManager();
+      const p = alias(Publisher);
+      const authors = await em.find(Author, { publisher: p }, { conditions: { and: [p.name.eq("p1")] } });
+      expect(authors.length).toEqual(1);
+    });
+
+    it("can use aliases as an o2m entity filter", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      const em = newEntityManager();
+      const b = alias(Book);
+      const authors = await em.find(Author, { books: b }, { conditions: { and: [b.title.eq("b1")] } });
+      expect(authors.length).toEqual(1);
+    });
+
     it("can use aliases for or with nested and", async () => {
       await insertAuthor({ first_name: "a1" });
       await insertAuthor({ first_name: "a2", age: 30 });

--- a/packages/orm/src/Aliases.ts
+++ b/packages/orm/src/Aliases.ts
@@ -1,3 +1,4 @@
+import { fail } from "src/utils";
 import { Entity } from "./Entity";
 import { FieldsOf, IdOf, MaybeAbstractEntityConstructor } from "./EntityManager";
 import { getMetadata } from "./EntityMetadata";
@@ -80,6 +81,11 @@ export function newAliasProxy<T extends Entity>(cstr: MaybeAbstractEntityConstru
       }
     },
   }) as any;
+}
+
+export function isAlias(obj: any): obj is Alias<any> & { [aliasMgmt]: AliasMgmt } {
+  // Oddly enough `typeof` will be a function b/c we are proxying the constructors
+  return obj && typeof obj === "function" && obj[aliasMgmt] !== undefined;
 }
 
 class PrimitiveAliasImpl<V> implements PrimitiveAlias<V> {

--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -34,7 +34,8 @@ export type EntityFilter<T extends Entity, I, F, N> =
   | I[]
   | ({ as?: Alias<T> } & F)
   | N
-  | { ne: T | I | N };
+  | { ne: T | I | N }
+  | Alias<T>;
 
 export type BooleanFilter<N> = true | false | N;
 

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -1,5 +1,6 @@
 import DataLoader from "dataloader";
 import hash from "object-hash";
+import { isAlias } from "../Aliases";
 import { Entity, isEntity } from "../Entity";
 import { FilterAndSettings } from "../EntityFilter";
 import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager";
@@ -28,9 +29,8 @@ function replacer(v: any) {
     return v.id;
   }
   // Strip out `{ as: ...alias proxy... }` from the `em.find` inline conditions
-  if (v && typeof v === "object" && Object.keys(v).includes("as")) {
-    const { as, ...others } = v;
-    return others;
+  if (isAlias(v)) {
+    return "alias";
   }
   return v;
 }


### PR DESCRIPTION
I.e. instead of:

```
const b = alias(Book);
em.find(Author, { books: { as: b } });
```

We can bind it directly w/o the `as`:

```
const b = alias(Book);
em.find(Author, { books: b });
```

Granted, this only works for leaf tables; tables that are used for subsequent joins will still use the `as` syntax.