### PR TITLE
feat: Remove 1st generic from Relation/Reference/Collection

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -227,7 +227,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
     const { fieldName, otherEntity, otherFieldName, notNull } = m2o;
     const maybeOptional = notNull ? "never" : "undefined";
     return code`
-      readonly ${fieldName}: ${ManyToOneReference}<${entity.type}, ${otherEntity.type}, ${maybeOptional}> =
+      readonly ${fieldName}: ${ManyToOneReference}<${otherEntity.type}, ${maybeOptional}> =
         ${hasOne}(
           ${otherEntity.metaType},
           "${fieldName}",
@@ -240,7 +240,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   const o2m = meta.oneToManys.map((o2m) => {
     const { fieldName, otherFieldName, otherColumnName, otherEntity } = o2m;
     return code`
-      readonly ${fieldName}: ${Collection}<${entity.type}, ${otherEntity.type}> = ${hasMany}(
+      readonly ${fieldName}: ${Collection}<${otherEntity.type}> = ${hasMany}(
         ${otherEntity.metaType},
         "${fieldName}",
         "${otherFieldName}",
@@ -253,7 +253,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   const lo2m = meta.largeOneToManys.map((o2m) => {
     const { fieldName, otherFieldName, otherColumnName, otherEntity } = o2m;
     return code`
-      readonly ${fieldName}: ${LargeCollection}<${entity.type}, ${otherEntity.type}> = ${hasLargeMany}(
+      readonly ${fieldName}: ${LargeCollection}<${otherEntity.type}> = ${hasLargeMany}(
         ${otherEntity.metaType},
         "${fieldName}",
         "${otherFieldName}",
@@ -266,7 +266,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   const o2o = meta.oneToOnes.map((o2o) => {
     const { fieldName, otherEntity, otherFieldName, otherColumnName } = o2o;
     return code`
-      readonly ${fieldName}: ${OneToOneReference}<${entity.type}, ${otherEntity.type}> =
+      readonly ${fieldName}: ${OneToOneReference}<${otherEntity.type}> =
         ${hasOneToOne}(
           ${otherEntity.metaType},
           "${fieldName}",
@@ -280,7 +280,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   const m2m = meta.manyToManys.map((m2m) => {
     const { joinTableName, fieldName, columnName, otherEntity, otherFieldName, otherColumnName } = m2m;
     return code`
-      readonly ${fieldName}: ${Collection}<${entity.type}, ${otherEntity.type}> = ${hasManyToMany}(
+      readonly ${fieldName}: ${Collection}<${otherEntity.type}> = ${hasManyToMany}(
         "${joinTableName}",
         "${fieldName}",
         "${columnName}",
@@ -295,7 +295,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   const lm2m = meta.largeManyToManys.map((m2m) => {
     const { joinTableName, fieldName, columnName, otherEntity, otherFieldName, otherColumnName } = m2m;
     return code`
-      readonly ${fieldName}: ${LargeCollection}<${entity.type}, ${otherEntity.type}> = ${hasLargeManyToMany}(
+      readonly ${fieldName}: ${LargeCollection}<${otherEntity.type}> = ${hasLargeManyToMany}(
         "${joinTableName}",
         "${fieldName}",
         "${columnName}",
@@ -311,7 +311,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
     const { fieldName, notNull, fieldType } = p;
     const maybeOptional = notNull ? "never" : "undefined";
     return code`
-      readonly ${fieldName}: ${PolymorphicReference}<${entity.type}, ${fieldType}, ${maybeOptional}> = ${hasOnePolymorphic}(
+      readonly ${fieldName}: ${PolymorphicReference}<${fieldType}, ${maybeOptional}> = ${hasOnePolymorphic}(
         "${fieldName}",
       );
     `;

--- a/packages/integration-tests/src/entities/Author.ts
+++ b/packages/integration-tests/src/entities/Author.ts
@@ -15,8 +15,10 @@ import {
 import { AuthorCodegen, authorConfig as config, Book, BookReview, Comment } from "./entities";
 
 export class Author extends AuthorCodegen {
-  readonly reviews: Collection<Author, BookReview> = hasManyThrough((author) => author.books.reviews);
-  readonly reviewedBooks: Collection<Author, Book> = hasManyDerived(
+  readonly reviews2 = r.hasManyBooksThrough((a) => a.books.reviews);
+  readonly reviews3 = r.asyncProperty<number>((a) => a.whatever);
+  readonly reviews: Collection<BookReview> = hasManyThrough((author) => author.books.reviews);
+  readonly reviewedBooks: Collection<Book> = hasManyDerived(
     { books: "reviews" },
     {
       get: (author) => author.books.get.filter((b) => b.reviews.get.length > 0),
@@ -43,7 +45,7 @@ export class Author extends AuthorCodegen {
       },
     },
   );
-  readonly latestComment: Reference<Author, Comment, undefined> = hasOneDerived(
+  readonly latestComment: Reference<Comment, undefined> = hasOneDerived(
     { publisher: "comments", comments: {} },
     (author) => author.publisher.get?.comments.get[0] ?? author.comments.get[0],
   );

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -222,32 +222,25 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
 
-  readonly authors: Collection<Author, Author> = hasMany(authorMeta, "authors", "mentor", "mentor_id");
+  readonly authors: Collection<Author> = hasMany(authorMeta, "authors", "mentor", "mentor_id");
 
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id");
+  readonly books: Collection<Book> = hasMany(bookMeta, "books", "author", "author_id");
 
-  readonly comments: Collection<Author, Comment> = hasMany(commentMeta, "comments", "parent", "parent_author_id");
+  readonly comments: Collection<Comment> = hasMany(commentMeta, "comments", "parent", "parent_author_id");
 
-  readonly mentor: ManyToOneReference<Author, Author, undefined> = hasOne(authorMeta, "mentor", "authors");
+  readonly mentor: ManyToOneReference<Author, undefined> = hasOne(authorMeta, "mentor", "authors");
 
-  readonly currentDraftBook: ManyToOneReference<Author, Book, undefined> = hasOne(
+  readonly currentDraftBook: ManyToOneReference<Book, undefined> = hasOne(
     bookMeta,
     "currentDraftBook",
     "currentDraftAuthor",
   );
 
-  readonly publisher: ManyToOneReference<Author, Publisher, undefined> = hasOne(publisherMeta, "publisher", "authors");
+  readonly publisher: ManyToOneReference<Publisher, undefined> = hasOne(publisherMeta, "publisher", "authors");
 
-  readonly image: OneToOneReference<Author, Image> = hasOneToOne(imageMeta, "image", "author", "author_id");
+  readonly image: OneToOneReference<Image> = hasOneToOne(imageMeta, "image", "author", "author_id");
 
-  readonly tags: Collection<Author, Tag> = hasManyToMany(
-    "authors_to_tags",
-    "tags",
-    "author_id",
-    tagMeta,
-    "authors",
-    "tag_id",
-  );
+  readonly tags: Collection<Tag> = hasManyToMany("authors_to_tags", "tags", "author_id", tagMeta, "authors", "tag_id");
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -115,13 +115,9 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newBookAdvance>[1];
   };
 
-  readonly book: ManyToOneReference<BookAdvance, Book, never> = hasOne(bookMeta, "book", "advances");
+  readonly book: ManyToOneReference<Book, never> = hasOne(bookMeta, "book", "advances");
 
-  readonly publisher: ManyToOneReference<BookAdvance, Publisher, never> = hasOne(
-    publisherMeta,
-    "publisher",
-    "bookAdvances",
-  );
+  readonly publisher: ManyToOneReference<Publisher, never> = hasOne(publisherMeta, "publisher", "bookAdvances");
 
   constructor(em: EntityManager, opts: BookAdvanceOpts) {
     super(em, bookAdvanceMeta, BookAdvanceCodegen.defaultValues, opts);

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -155,24 +155,24 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newBook>[1];
   };
 
-  readonly advances: Collection<Book, BookAdvance> = hasMany(bookAdvanceMeta, "advances", "book", "book_id");
+  readonly advances: Collection<BookAdvance> = hasMany(bookAdvanceMeta, "advances", "book", "book_id");
 
-  readonly reviews: Collection<Book, BookReview> = hasMany(bookReviewMeta, "reviews", "book", "book_id");
+  readonly reviews: Collection<BookReview> = hasMany(bookReviewMeta, "reviews", "book", "book_id");
 
-  readonly comments: Collection<Book, Comment> = hasMany(commentMeta, "comments", "parent", "parent_book_id");
+  readonly comments: Collection<Comment> = hasMany(commentMeta, "comments", "parent", "parent_book_id");
 
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  readonly author: ManyToOneReference<Author, never> = hasOne(authorMeta, "author", "books");
 
-  readonly currentDraftAuthor: OneToOneReference<Book, Author> = hasOneToOne(
+  readonly currentDraftAuthor: OneToOneReference<Author> = hasOneToOne(
     authorMeta,
     "currentDraftAuthor",
     "currentDraftBook",
     "current_draft_book_id",
   );
 
-  readonly image: OneToOneReference<Book, Image> = hasOneToOne(imageMeta, "image", "book", "book_id");
+  readonly image: OneToOneReference<Image> = hasOneToOne(imageMeta, "image", "book", "book_id");
 
-  readonly tags: Collection<Book, Tag> = hasManyToMany("books_to_tags", "tags", "book_id", tagMeta, "books", "tag_id");
+  readonly tags: Collection<Tag> = hasManyToMany("books_to_tags", "tags", "book_id", tagMeta, "books", "tag_id");
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -117,14 +117,9 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newBookReview>[1];
   };
 
-  readonly book: ManyToOneReference<BookReview, Book, never> = hasOne(bookMeta, "book", "reviews");
+  readonly book: ManyToOneReference<Book, never> = hasOne(bookMeta, "book", "reviews");
 
-  readonly comment: OneToOneReference<BookReview, Comment> = hasOneToOne(
-    commentMeta,
-    "comment",
-    "parent",
-    "parent_book_review_id",
-  );
+  readonly comment: OneToOneReference<Comment> = hasOneToOne(commentMeta, "comment", "parent", "parent_book_review_id");
 
   constructor(em: EntityManager, opts: BookReviewOpts) {
     super(em, bookReviewMeta, BookReviewCodegen.defaultValues, opts);

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -100,7 +100,7 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newComment>[1];
   };
 
-  readonly parent: PolymorphicReference<Comment, CommentParent, never> = hasOnePolymorphic("parent");
+  readonly parent: PolymorphicReference<CommentParent, never> = hasOnePolymorphic("parent");
 
   constructor(em: EntityManager, opts: CommentOpts) {
     super(em, commentMeta, CommentCodegen.defaultValues, opts);

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -118,19 +118,15 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newCritic>[1];
   };
 
-  readonly favoriteLargePublisher: ManyToOneReference<Critic, LargePublisher, undefined> = hasOne(
+  readonly favoriteLargePublisher: ManyToOneReference<LargePublisher, undefined> = hasOne(
     largePublisherMeta,
     "favoriteLargePublisher",
     "critics",
   );
 
-  readonly group: ManyToOneReference<Critic, PublisherGroup, undefined> = hasOne(
-    publisherGroupMeta,
-    "group",
-    "critics",
-  );
+  readonly group: ManyToOneReference<PublisherGroup, undefined> = hasOne(publisherGroupMeta, "group", "critics");
 
-  readonly criticColumn: OneToOneReference<Critic, CriticColumn> = hasOneToOne(
+  readonly criticColumn: OneToOneReference<CriticColumn> = hasOneToOne(
     criticColumnMeta,
     "criticColumn",
     "critic",

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -92,7 +92,7 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newCriticColumn>[1];
   };
 
-  readonly critic: ManyToOneReference<CriticColumn, Critic, never> = hasOne(criticMeta, "critic", "criticColumn");
+  readonly critic: ManyToOneReference<Critic, never> = hasOne(criticMeta, "critic", "criticColumn");
 
   constructor(em: EntityManager, opts: CriticColumnOpts) {
     super(em, criticColumnMeta, CriticColumnCodegen.defaultValues, opts);

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -129,11 +129,11 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newImage>[1];
   };
 
-  readonly author: ManyToOneReference<Image, Author, undefined> = hasOne(authorMeta, "author", "image");
+  readonly author: ManyToOneReference<Author, undefined> = hasOne(authorMeta, "author", "image");
 
-  readonly book: ManyToOneReference<Image, Book, undefined> = hasOne(bookMeta, "book", "image");
+  readonly book: ManyToOneReference<Book, undefined> = hasOne(bookMeta, "book", "image");
 
-  readonly publisher: ManyToOneReference<Image, Publisher, undefined> = hasOne(publisherMeta, "publisher", "images");
+  readonly publisher: ManyToOneReference<Publisher, undefined> = hasOne(publisherMeta, "publisher", "images");
 
   constructor(em: EntityManager, opts: ImageOpts) {
     super(em, imageMeta, ImageCodegen.defaultValues, opts);

--- a/packages/integration-tests/src/entities/LargePublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/LargePublisherCodegen.ts
@@ -85,7 +85,7 @@ export abstract class LargePublisherCodegen extends Publisher {
     factoryOptsType: Parameters<typeof newLargePublisher>[1];
   };
 
-  readonly critics: Collection<LargePublisher, Critic> = hasMany(
+  readonly critics: Collection<Critic> = hasMany(
     criticMeta,
     "critics",
     "favoriteLargePublisher",

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -173,26 +173,22 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newPublisher>[1];
   };
 
-  readonly authors: Collection<Publisher, Author> = hasMany(authorMeta, "authors", "publisher", "publisher_id");
+  readonly authors: Collection<Author> = hasMany(authorMeta, "authors", "publisher", "publisher_id");
 
-  readonly bookAdvances: Collection<Publisher, BookAdvance> = hasMany(
+  readonly bookAdvances: Collection<BookAdvance> = hasMany(
     bookAdvanceMeta,
     "bookAdvances",
     "publisher",
     "publisher_id",
   );
 
-  readonly comments: Collection<Publisher, Comment> = hasMany(commentMeta, "comments", "parent", "parent_publisher_id");
+  readonly comments: Collection<Comment> = hasMany(commentMeta, "comments", "parent", "parent_publisher_id");
 
-  readonly images: Collection<Publisher, Image> = hasMany(imageMeta, "images", "publisher", "publisher_id");
+  readonly images: Collection<Image> = hasMany(imageMeta, "images", "publisher", "publisher_id");
 
-  readonly group: ManyToOneReference<Publisher, PublisherGroup, undefined> = hasOne(
-    publisherGroupMeta,
-    "group",
-    "publishers",
-  );
+  readonly group: ManyToOneReference<PublisherGroup, undefined> = hasOne(publisherGroupMeta, "group", "publishers");
 
-  readonly tags: Collection<Publisher, Tag> = hasManyToMany(
+  readonly tags: Collection<Tag> = hasManyToMany(
     "publishers_to_tags",
     "tags",
     "publisher_id",

--- a/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
@@ -98,14 +98,9 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newPublisherGroup>[1];
   };
 
-  readonly publishers: Collection<PublisherGroup, Publisher> = hasMany(
-    publisherMeta,
-    "publishers",
-    "group",
-    "group_id",
-  );
+  readonly publishers: Collection<Publisher> = hasMany(publisherMeta, "publishers", "group", "group_id");
 
-  readonly critics: LargeCollection<PublisherGroup, Critic> = hasLargeMany(criticMeta, "critics", "group", "group_id");
+  readonly critics: LargeCollection<Critic> = hasLargeMany(criticMeta, "critics", "group", "group_id");
 
   constructor(em: EntityManager, opts: PublisherGroupOpts) {
     super(em, publisherGroupMeta, PublisherGroupCodegen.defaultValues, opts);

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -105,16 +105,9 @@ export abstract class TagCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newTag>[1];
   };
 
-  readonly books: Collection<Tag, Book> = hasManyToMany(
-    "books_to_tags",
-    "books",
-    "tag_id",
-    bookMeta,
-    "tags",
-    "book_id",
-  );
+  readonly books: Collection<Book> = hasManyToMany("books_to_tags", "books", "tag_id", bookMeta, "tags", "book_id");
 
-  readonly publishers: Collection<Tag, Publisher> = hasManyToMany(
+  readonly publishers: Collection<Publisher> = hasManyToMany(
     "publishers_to_tags",
     "publishers",
     "tag_id",
@@ -123,7 +116,7 @@ export abstract class TagCodegen extends BaseEntity<EntityManager> {
     "publisher_id",
   );
 
-  readonly authors: LargeCollection<Tag, Author> = hasLargeManyToMany(
+  readonly authors: LargeCollection<Author> = hasLargeManyToMany(
     "authors_to_tags",
     "authors",
     "tag_id",

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -348,7 +348,7 @@ export function getConstructorFromTaggedId(id: string): MaybeAbstractEntityConst
 }
 
 export function maybeGetConstructorFromReference(
-  value: string | Entity | Reference<any, any, any> | undefined,
+  value: string | Entity | Reference<any, any> | undefined,
 ): MaybeAbstractEntityConstructor<any> | undefined {
   const id = maybeResolveReferenceToId(value);
   return id ? getConstructorFromTaggedId(id) : undefined;

--- a/packages/orm/src/loadHints.ts
+++ b/packages/orm/src/loadHints.ts
@@ -28,12 +28,12 @@ type DeepLoadHint<T extends Entity> = NestedLoadHint<T> & { [deepLoad]: true };
 type MaybeBaseType = any;
 
 /** Marks a given `T[K]` field as the loaded/synchronous version of the collection. */
-export type MarkLoaded<T extends Entity, P, UH = {}> = P extends OneToOneReference<MaybeBaseType, infer U>
-  ? LoadedOneToOneReference<T, Loaded<U, UH>>
-  : P extends Reference<MaybeBaseType, infer U, infer N>
-  ? LoadedReference<T, Loaded<U, UH>, N>
-  : P extends Collection<MaybeBaseType, infer U>
-  ? LoadedCollection<T, Loaded<U, UH>>
+export type MarkLoaded<T extends Entity, P, UH = {}> = P extends OneToOneReference<infer U>
+  ? LoadedOneToOneReference<Loaded<U, UH>>
+  : P extends Reference<infer U, infer N>
+  ? LoadedReference<Loaded<U, UH>, N>
+  : P extends Collection<infer U>
+  ? LoadedCollection<Loaded<U, UH>>
   : P extends AsyncProperty<MaybeBaseType, infer V>
   ? // prettier-ignore
     [V] extends [(infer U extends Entity) | undefined]
@@ -44,12 +44,12 @@ export type MarkLoaded<T extends Entity, P, UH = {}> = P extends OneToOneReferen
   : unknown;
 
 /** A version of MarkLoaded the uses `DeepLoadHint` for tests. */
-type MarkDeepLoaded<T extends Entity, P> = P extends OneToOneReference<MaybeBaseType, infer U>
-  ? LoadedOneToOneReference<T, Loaded<U, DeepLoadHint<U>>>
-  : P extends Reference<MaybeBaseType, infer U, infer N>
-  ? LoadedReference<T, Loaded<U, DeepLoadHint<U>>, N>
-  : P extends Collection<MaybeBaseType, infer U>
-  ? LoadedCollection<T, Loaded<U, DeepLoadHint<U>>>
+type MarkDeepLoaded<T extends Entity, P> = P extends OneToOneReference<infer U>
+  ? LoadedOneToOneReference<Loaded<U, DeepLoadHint<U>>>
+  : P extends Reference<infer U, infer N>
+  ? LoadedReference<Loaded<U, DeepLoadHint<U>>, N>
+  : P extends Collection<infer U>
+  ? LoadedCollection<Loaded<U, DeepLoadHint<U>>>
   : P extends AsyncProperty<MaybeBaseType, infer V>
   ? // prettier-ignore
     [V] extends [(infer U extends Entity) | undefined]
@@ -74,15 +74,15 @@ type MarkDeepLoaded<T extends Entity, P> = P extends OneToOneReference<MaybeBase
  */
 type MaybeUseOptsType<T extends Entity, O, K extends keyof T & keyof O> = O[K] extends NullOrDefinedOr<infer OK>
   ? OK extends Entity
-    ? T[K] extends OneToOneReference<T, infer U>
-      ? LoadedOneToOneReference<T, U>
-      : T[K] extends Reference<T, infer U, infer N>
-      ? LoadedReference<T, OK, N>
+    ? T[K] extends OneToOneReference<infer U>
+      ? LoadedOneToOneReference<U>
+      : T[K] extends Reference<infer U, infer N>
+      ? LoadedReference<OK, N>
       : never
     : OK extends Array<infer OU>
     ? OU extends Entity
-      ? T[K] extends Collection<T, infer U>
-        ? LoadedCollection<T, OU>
+      ? T[K] extends Collection<infer U>
+        ? LoadedCollection<OU>
         : never
       : T[K]
     : T[K]
@@ -137,9 +137,9 @@ export type Loadable<T extends Entity> = {
  * Note that we usually return entities, but for AsyncProperties it could be
  * a calculated primitive value like number or string.
  */
-export type LoadableValue<V> = V extends Reference<any, infer U, any>
+export type LoadableValue<V> = V extends Reference<infer U, any>
   ? U
-  : V extends Collection<any, infer U>
+  : V extends Collection<infer U>
   ? U
   : V extends AsyncProperty<any, infer P>
   ? // If the AsyncProperty returns `Comment | undefined`, then we want to return `Comment`
@@ -209,7 +209,7 @@ export function ensureLoadedThen<T extends Entity, H extends LoadHint<T>, R>(
 }
 
 /** From any `Relations` field in `T`, i.e. for loader hints. */
-export type RelationsIn<T extends Entity> = SubType<T, Relation<any, any>>;
+export type RelationsIn<T extends Entity> = SubType<T, Relation<any>>;
 
 // https://medium.com/dailyjs/typescript-create-a-condition-based-subset-types-9d902cea5b8c
 type SubType<T, C> = Pick<T, { [K in keyof T]: T[K] extends C ? K : never }[keyof T]>;

--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -49,10 +49,10 @@ export type NestedReactiveHint<T extends Entity> = {
 export type Reacted<T extends Entity, H> = Entity & {
   [K in keyof NormalizeHint<T, H> & keyof T]: T[K] extends OneToOneReference<any, infer U>
     ? LoadedOneToOneReference<T, Entity & Reacted<U, NormalizeHint<T, H>[K]>>
-    : T[K] extends Reference<any, infer U, infer N>
-    ? LoadedReference<T, Entity & Reacted<U, NormalizeHint<T, H>[K]>, N>
-    : T[K] extends Collection<any, infer U>
-    ? LoadedCollection<T, Entity & Reacted<U, NormalizeHint<T, H>[K]>>
+    : T[K] extends Reference<infer U, infer N>
+    ? LoadedReference<Entity & Reacted<U, NormalizeHint<T, H>[K]>, N>
+    : T[K] extends Collection<infer U>
+    ? LoadedCollection<Entity & Reacted<U, NormalizeHint<T, H>[K]>>
     : T[K] extends AsyncProperty<any, infer V>
     ? LoadedProperty<any, V>
     : T[K];

--- a/packages/orm/src/relations/Collection.ts
+++ b/packages/orm/src/relations/Collection.ts
@@ -6,7 +6,7 @@ import { OneToManyCollection } from "./OneToManyCollection";
 import { Relation } from "./Relation";
 
 /** A collection of `U` within `T`, either one-to-many or many-to-many. */
-export interface Collection<T extends Entity, U extends Entity> extends Relation<T, U> {
+export interface Collection<U extends Entity> extends Relation<U> {
   load(opts?: { withDeleted: boolean }): Promise<ReadonlyArray<U>>;
 
   /** Looks up the specific `id` without fully loading the collection. */
@@ -23,7 +23,7 @@ export interface Collection<T extends Entity, U extends Entity> extends Relation
 }
 
 /** Adds a known-safe `get` accessor. */
-export interface LoadedCollection<T extends Entity, U extends Entity> extends Collection<T, U> {
+export interface LoadedCollection<U extends Entity> extends Collection<U> {
   get: ReadonlyArray<U>;
 
   getWithDeleted: ReadonlyArray<U>;
@@ -34,7 +34,7 @@ export interface LoadedCollection<T extends Entity, U extends Entity> extends Co
 }
 
 /** Type guard utility for determining if an entity field is a Collection. */
-export function isCollection(maybeCollection: any): maybeCollection is Collection<any, any> {
+export function isCollection(maybeCollection: any): maybeCollection is Collection<any> {
   return (
     maybeCollection instanceof OneToManyCollection ||
     maybeCollection instanceof ManyToManyCollection ||
@@ -43,8 +43,6 @@ export function isCollection(maybeCollection: any): maybeCollection is Collectio
 }
 
 /** Type guard utility for determining if an entity field is a loaded Collection. */
-export function isLoadedCollection(
-  maybeCollection: any,
-): maybeCollection is Collection<any, any> & LoadedCollection<any, any> {
+export function isLoadedCollection(maybeCollection: any): maybeCollection is Collection<any> & LoadedCollection<any> {
   return isCollection(maybeCollection) && maybeCollection.isLoaded;
 }

--- a/packages/orm/src/relations/CustomCollection.ts
+++ b/packages/orm/src/relations/CustomCollection.ts
@@ -2,7 +2,7 @@ import { Entity } from "../Entity";
 import { IdOf } from "../EntityManager";
 import { Collection, ensureNotDeleted, fail } from "../index";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 export type CustomCollectionOpts<T extends Entity, U extends Entity> = {
   // We purposefully don't capture the return value of `load` b/c we want `get` to re-calc from `entity`
@@ -30,7 +30,7 @@ export type CustomCollectionOpts<T extends Entity, U extends Entity> = {
  */
 export class CustomCollection<T extends Entity, U extends Entity>
   extends AbstractRelationImpl<U[]>
-  implements Collection<T, U>
+  implements Collection<U>
 {
   readonly #entity: T;
   // We keep both a promise+loaded flag and not an actual `this.loaded = await load` because
@@ -161,6 +161,5 @@ export class CustomCollection<T extends Entity, U extends Entity>
     fail(`${this.#entity}.${this.fieldName} was not loaded`);
   }
 
-  [RelationT]: T = null!;
   [RelationU]: U = null!;
 }

--- a/packages/orm/src/relations/CustomReference.ts
+++ b/packages/orm/src/relations/CustomReference.ts
@@ -3,7 +3,7 @@ import { IdOf } from "../EntityManager";
 import { ensureNotDeleted, fail, Reference, unsafeDeTagIds } from "../index";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { ReferenceN } from "./Reference";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 export type CustomReferenceOpts<T extends Entity, U extends Entity, N extends never | undefined> = {
   // We purposefully don't capture the return value of `load` b/c we want `get` to re-calc from `entity`
@@ -28,7 +28,7 @@ export type CustomReferenceOpts<T extends Entity, U extends Entity, N extends ne
  */
 export class CustomReference<T extends Entity, U extends Entity, N extends never | undefined>
   extends AbstractRelationImpl<U>
-  implements Reference<T, U, N>
+  implements Reference<U, N>
 {
   readonly #entity: T;
   // We keep both a promise+loaded flag and not an actual `this.loaded = await load` because
@@ -146,7 +146,6 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
     fail(`${this.#entity}.${this.fieldName} was not loaded`);
   }
 
-  [RelationT]: T = null!;
   [RelationU]: U = null!;
   [ReferenceN]: N = null!;
 }

--- a/packages/orm/src/relations/LargeCollection.ts
+++ b/packages/orm/src/relations/LargeCollection.ts
@@ -9,7 +9,7 @@ import { Relation } from "./Relation";
  * We consider this a `Relation`, but not a true `Collection` b/c it cannot be
  * loaded.
  */
-export interface LargeCollection<T extends Entity, U extends Entity> extends Relation<T, U> {
+export interface LargeCollection<U extends Entity> extends Relation<U> {
   /** Looks up the specific `id` without fully loading the collection. */
   find(id: IdOf<U>): Promise<U | undefined>;
 

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -12,7 +12,7 @@ import { manyToManyDataLoader } from "../dataloaders/manyToManyDataLoader";
 import { manyToManyFindDataLoader } from "../dataloaders/manyToManyFindDataLoader";
 import { getOrSet, remove } from "../utils";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 /** An alias for creating `ManyToManyCollections`s. */
 export function hasManyToMany<T extends Entity, U extends Entity>(
@@ -22,7 +22,7 @@ export function hasManyToMany<T extends Entity, U extends Entity>(
   otherMeta: EntityMetadata<U>,
   otherFieldName: keyof U & string,
   otherColumnName: string,
-): Collection<T, U> {
+): Collection<U> {
   const entity = currentlyInstantiatingEntity as T;
   return new ManyToManyCollection<T, U>(
     joinTableName,
@@ -37,7 +37,7 @@ export function hasManyToMany<T extends Entity, U extends Entity>(
 
 export class ManyToManyCollection<T extends Entity, U extends Entity>
   extends AbstractRelationImpl<U[]>
-  implements Collection<T, U>
+  implements Collection<U>
 {
   readonly #entity: T;
   readonly #fieldName: keyof T & string;
@@ -300,7 +300,6 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     }, otherFieldName: ${this.otherFieldName})`;
   }
 
-  [RelationT]: T = null!;
   [RelationU]: U = null!;
 }
 

--- a/packages/orm/src/relations/ManyToManyLargeCollection.ts
+++ b/packages/orm/src/relations/ManyToManyLargeCollection.ts
@@ -5,7 +5,7 @@ import { EntityMetadata } from "../EntityMetadata";
 import { ensureNotDeleted, getMetadata, ManyToManyCollection } from "../index";
 import { remove } from "../utils";
 import { LargeCollection } from "./LargeCollection";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 /** An alias for creating `ManyToManyLargeCollection`s. */
 export function hasLargeManyToMany<T extends Entity, U extends Entity>(
@@ -15,7 +15,7 @@ export function hasLargeManyToMany<T extends Entity, U extends Entity>(
   otherMeta: EntityMetadata<U>,
   otherFieldName: keyof U & string,
   otherColumnName: string,
-): LargeCollection<T, U> {
+): LargeCollection<U> {
   const entity = currentlyInstantiatingEntity as T;
   return new ManyToManyLargeCollection(
     joinTableName,
@@ -28,7 +28,7 @@ export function hasLargeManyToMany<T extends Entity, U extends Entity>(
   );
 }
 
-export class ManyToManyLargeCollection<T extends Entity, U extends Entity> implements LargeCollection<T, U> {
+export class ManyToManyLargeCollection<T extends Entity, U extends Entity> implements LargeCollection<U> {
   // Even though a large collection can never be loaded, we do track local
   // mutations so that `find` can be accurate.
   private locallyAdded: U[] = [];
@@ -120,6 +120,5 @@ export class ManyToManyLargeCollection<T extends Entity, U extends Entity> imple
 
   isLoaded = false;
 
-  [RelationT]: T = null!;
   [RelationU]: U = null!;
 }

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -14,25 +14,24 @@ import {
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { OneToManyCollection } from "./OneToManyCollection";
 import { ReferenceN } from "./Reference";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 /** An alias for creating `ManyToOneReference`s. */
 export function hasOne<T extends Entity, U extends Entity, N extends never | undefined>(
   otherMeta: EntityMetadata<U>,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
-): ManyToOneReference<T, U, N> {
+): ManyToOneReference<U, N> {
   const entity = currentlyInstantiatingEntity as T;
   return new ManyToOneReferenceImpl<T, U, N>(entity, otherMeta, fieldName, otherFieldName);
 }
 
 /** Type guard utility for determining if an entity field is a ManyToOneReference. */
-export function isManyToOneReference(maybeReference: any): maybeReference is ManyToOneReference<any, any, any> {
+export function isManyToOneReference(maybeReference: any): maybeReference is ManyToOneReference<any, any> {
   return maybeReference instanceof ManyToOneReferenceImpl;
 }
 
-export interface ManyToOneReference<T extends Entity, U extends Entity, N extends never | undefined>
-  extends Reference<T, U, N> {
+export interface ManyToOneReference<U extends Entity, N extends never | undefined> extends Reference<U, N> {
   /** Returns the id of the current assigned entity (or `undefined` if its new and has no id yet), or `undefined` if this column is nullable and currently unset. */
   id: IdOf<U> | undefined;
 
@@ -60,7 +59,7 @@ export interface ManyToOneReference<T extends Entity, U extends Entity, N extend
  */
 export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extends never | undefined>
   extends AbstractRelationImpl<U>
-  implements ManyToOneReference<T, U, N>
+  implements ManyToOneReference<U, N>
 {
   readonly #entity: T;
   readonly #fieldName: keyof T & string;
@@ -327,7 +326,6 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     return this.loaded ?? (this.id !== undefined ? this.#entity.em.getEntity(this.id) : undefined);
   }
 
-  [RelationT]: T = null!;
   [RelationU]: U = null!;
   [ReferenceN]: N = null!;
 }

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -15,7 +15,7 @@ import {
 import { remove } from "../utils";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { ManyToOneReferenceImpl } from "./ManyToOneReference";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 /** An alias for creating `OneToManyCollection`s. */
 export function hasMany<T extends Entity, U extends Entity>(
@@ -23,14 +23,14 @@ export function hasMany<T extends Entity, U extends Entity>(
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,
-): Collection<T, U> {
+): Collection<U> {
   const entity = currentlyInstantiatingEntity as T;
   return new OneToManyCollection(entity, otherMeta, fieldName, otherFieldName, otherColumnName);
 }
 
 export class OneToManyCollection<T extends Entity, U extends Entity>
   extends AbstractRelationImpl<U[]>
-  implements Collection<T, U>
+  implements Collection<U>
 {
   readonly #entity: T;
   readonly #fieldName: keyof T & string;
@@ -279,6 +279,5 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     return getMetadata(this.#entity).config.__data.cascadeDeleteFields.includes(this.#fieldName as any);
   }
 
-  [RelationT]: T = null!;
   [RelationU]: U = null!;
 }

--- a/packages/orm/src/relations/OneToManyLargeCollection.ts
+++ b/packages/orm/src/relations/OneToManyLargeCollection.ts
@@ -5,7 +5,7 @@ import { EntityMetadata } from "../EntityMetadata";
 import { ensureNotDeleted, getMetadata, ManyToOneReferenceImpl } from "../index";
 import { remove } from "../utils";
 import { LargeCollection } from "./LargeCollection";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 /** An alias for creating `OneToManyLargeCollection`s. */
 export function hasLargeMany<T extends Entity, U extends Entity>(
@@ -13,12 +13,12 @@ export function hasLargeMany<T extends Entity, U extends Entity>(
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,
-): LargeCollection<T, U> {
+): LargeCollection<U> {
   const entity = currentlyInstantiatingEntity as T;
   return new OneToManyLargeCollection(entity, otherMeta, fieldName, otherFieldName, otherColumnName);
 }
 
-export class OneToManyLargeCollection<T extends Entity, U extends Entity> implements LargeCollection<T, U> {
+export class OneToManyLargeCollection<T extends Entity, U extends Entity> implements LargeCollection<U> {
   // Even though a large collection can never be loaded, we do track local
   // mutations so that `find` can be accurate.
   private locallyAdded: U[] = [];
@@ -94,6 +94,5 @@ export class OneToManyLargeCollection<T extends Entity, U extends Entity> implem
 
   isLoaded = false;
 
-  [RelationT]: T = null!;
   [RelationU]: U = null!;
 }

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -5,18 +5,18 @@ import { EntityMetadata, getMetadata } from "../EntityMetadata";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { ManyToOneReference } from "./ManyToOneReference";
 import { Reference, ReferenceN } from "./Reference";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 const OneToOne = Symbol();
 
 /** The lazy-loaded/lookup side of a one-to-one, i.e. the side w/o the unique foreign key column. */
-export interface OneToOneReference<T extends Entity, U extends Entity> extends Reference<T, U, undefined> {
+export interface OneToOneReference<U extends Entity> extends Reference<U, undefined> {
   // Need to differentiate OneToOneReference from Reference
-  [OneToOne]: T;
+  [OneToOne]: U;
 }
 
 /** Adds a known-safe `get` accessor. */
-export interface LoadedOneToOneReference<T extends Entity, U extends Entity> extends LoadedReference<T, U, undefined> {
+export interface LoadedOneToOneReference<U extends Entity> extends LoadedReference<U, undefined> {
   get: U | undefined;
 
   getWithDeleted: U | undefined;
@@ -36,14 +36,14 @@ export interface LoadedOneToOneReference<T extends Entity, U extends Entity> ext
 }
 
 /** Type guard utility for determining if an entity field is a Reference. */
-export function isOneToOneReference(maybeReference: any): maybeReference is OneToOneReference<any, any> {
+export function isOneToOneReference(maybeReference: any): maybeReference is OneToOneReference<any> {
   return maybeReference instanceof OneToOneReferenceImpl;
 }
 
 /** Type guard utility for determining if an entity field is a loaded Reference. */
 export function isLoadedOneToOneReference(
   maybeReference: any,
-): maybeReference is Reference<any, any, any> & LoadedOneToOneReference<any, any> {
+): maybeReference is Reference<any, any> & LoadedOneToOneReference<any> {
   return isOneToOneReference(maybeReference) && maybeReference.isLoaded;
 }
 
@@ -53,7 +53,7 @@ export function hasOneToOne<T extends Entity, U extends Entity>(
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,
-): OneToOneReference<T, U> {
+): OneToOneReference<U> {
   const entity = currentlyInstantiatingEntity as T;
   return new OneToOneReferenceImpl<T, U>(entity, otherMeta, fieldName, otherFieldName, otherColumnName);
 }
@@ -77,7 +77,7 @@ export function hasOneToOne<T extends Entity, U extends Entity>(
  */
 export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
   extends AbstractRelationImpl<U>
-  implements OneToOneReference<T, U>
+  implements OneToOneReference<U>
 {
   private loaded: U | undefined;
   private _isLoaded: boolean = false;
@@ -221,11 +221,10 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
   }
 
   /** Returns the other relation that points back at us, i.e. we're `Author.image` and this is `Image.author_id`. */
-  private getOtherRelation(other: U): ManyToOneReference<U, T, any> {
+  private getOtherRelation(other: U): ManyToOneReference<T, any> {
     return (other as U)[this.otherFieldName] as any;
   }
 
-  [RelationT] = null!;
   [RelationU] = null!;
   [ReferenceN] = null!;
   [OneToOne] = null!;

--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -16,7 +16,7 @@ import {
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { OneToManyCollection } from "./OneToManyCollection";
 import { ReferenceN } from "./Reference";
-import { RelationT, RelationU } from "./Relation";
+import { RelationU } from "./Relation";
 
 export function hasOnePolymorphic<T extends Entity, U extends Entity, N extends never | undefined>(
   fieldName: keyof T & string,
@@ -31,7 +31,7 @@ export function isPolymorphicReference(maybeReference: any): maybeReference is P
 }
 
 export interface PolymorphicReference<T extends Entity, U extends Entity, N extends never | undefined>
-  extends Reference<T, U, N> {
+  extends Reference<U, N> {
   /** Returns the id of the current assigned entity (or `undefined` if its new and has no id yet), or `undefined` if this column is nullable and currently unset. */
   id: IdOf<U> | undefined;
 
@@ -266,7 +266,6 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
     return this.id !== undefined ? this.entity.em.getEntity(this.id) : undefined;
   }
 
-  [RelationT]: T = null!;
   [RelationU]: U = null!;
   [ReferenceN]: N = null!;
 }

--- a/packages/orm/src/relations/Reference.ts
+++ b/packages/orm/src/relations/Reference.ts
@@ -17,7 +17,7 @@ export const ReferenceN = Symbol();
  * `U | undefined`. If it is not optional, `N` will be `never`, making the return types
  * `U | never` which becomes just `U`.
  */
-export interface Reference<T extends Entity, U extends Entity, N extends never | undefined> extends Relation<T, U> {
+export interface Reference<U extends Entity, N extends never | undefined> extends Relation<U> {
   readonly isLoaded: boolean;
 
   load(opts?: { withDeleted?: boolean; forceReload?: true }): Promise<U | N>;
@@ -28,8 +28,7 @@ export interface Reference<T extends Entity, U extends Entity, N extends never |
 }
 
 /** Adds a known-safe `get` accessor. */
-export interface LoadedReference<T extends Entity, U extends Entity, N extends never | undefined>
-  extends Reference<T, U, N> {
+export interface LoadedReference<U extends Entity, N extends never | undefined> extends Reference<U, N> {
   // Since we've fetched the entity from the db, we're going to omit out the "| undefined" from Reference.id
   // which handles "this reference is set to a new entity" and just assume the id is there (or else N which
   // is for nullable references, which will just always be potentially `undefined`).
@@ -49,7 +48,7 @@ export interface LoadedReference<T extends Entity, U extends Entity, N extends n
 }
 
 /** Type guard utility for determining if an entity field is a Reference. */
-export function isReference(maybeReference: any): maybeReference is Reference<any, any, any> {
+export function isReference(maybeReference: any): maybeReference is Reference<any, any> {
   return (
     maybeReference instanceof OneToOneReferenceImpl ||
     maybeReference instanceof ManyToOneReferenceImpl ||
@@ -61,6 +60,6 @@ export function isReference(maybeReference: any): maybeReference is Reference<an
 /** Type guard utility for determining if an entity field is a loaded Reference. */
 export function isLoadedReference(
   maybeReference: any,
-): maybeReference is Reference<any, any, any> & LoadedReference<any, any, any> {
+): maybeReference is Reference<any, any> & LoadedReference<any, any> {
   return isReference(maybeReference) && maybeReference.isLoaded;
 }

--- a/packages/orm/src/relations/Relation.ts
+++ b/packages/orm/src/relations/Relation.ts
@@ -2,23 +2,21 @@ import { Entity } from "../Entity";
 import { isCollection } from "./Collection";
 import { isReference } from "./Reference";
 
-export const RelationT = Symbol();
 export const RelationU = Symbol();
 
 /** A relationship from `T` to `U`, could be any of many-to-one, one-to-many, or many-to-many. */
-export interface Relation<T extends Entity, U extends Entity> {
+export interface Relation<U extends Entity> {
   // Make our Relation somewhat non-structural, otherwise since it's a marker interface,
   // types like `number` or `string` will match it. This also seems to nudge the type
   // inference inside of `LoadHint` to go beyond "this generic T of Entity has id and __orm"
   // to "no really this generic T has fields firstName, title, etc.".
   // See https://stackoverflow.com/questions/53448100/generic-type-of-extended-interface-not-inferred
   // And https://github.com/microsoft/TypeScript/issues/47213
-  [RelationT]: T;
   [RelationU]: U;
   isLoaded: boolean;
 }
 
 /** Type guard utility for determining if an entity field is a Relation. */
-export function isRelation(maybeRelation: any): maybeRelation is Relation<any, any> {
+export function isRelation(maybeRelation: any): maybeRelation is Relation<any> {
   return isReference(maybeRelation) || isCollection(maybeRelation);
 }

--- a/packages/orm/src/relations/hasManyDerived.ts
+++ b/packages/orm/src/relations/hasManyDerived.ts
@@ -11,7 +11,7 @@ type HasManyDerivedOpts<T extends Entity, U extends Entity, H extends LoadHint<T
   remove?: (entity: Loaded<T, H>, value: U) => void;
 };
 
-/**
+/*react*
  * Creates a CustomCollection that can conditionally walk across references in the object graph.
  *
  * I.e. An Author "has many reviews" through the `author -> books -> reviews` relation.
@@ -21,7 +21,7 @@ type HasManyDerivedOpts<T extends Entity, U extends Entity, H extends LoadHint<T
 export function hasManyDerived<T extends Entity, U extends Entity, H extends LoadHint<T>>(
   loadHint: H,
   opts: HasManyDerivedOpts<T, U, H>,
-): Collection<T, U> {
+): Collection<U> {
   const entity: T = currentlyInstantiatingEntity as T;
   const { load, ...rest } = opts;
   return new CustomCollection<T, U>(entity, {

--- a/packages/orm/src/relations/hasManyThrough.ts
+++ b/packages/orm/src/relations/hasManyThrough.ts
@@ -18,7 +18,7 @@ import {
  */
 export function hasManyThrough<T extends Entity, U extends Entity>(
   lens: (lens: Lens<T>) => Lens<U, U[]>,
-): Collection<T, U> {
+): Collection<U> {
   const entity: T = currentlyInstantiatingEntity as T;
   return new CustomCollection<T, U>(entity, {
     load: async (entity, opts) => {

--- a/packages/orm/src/relations/hasOneDerived.ts
+++ b/packages/orm/src/relations/hasOneDerived.ts
@@ -17,7 +17,7 @@ export function hasOneDerived<
   N extends never | undefined,
   V extends U | N,
   H extends LoadHint<T>,
->(loadHint: Const<H>, get: (entity: Loaded<T, H>) => V): Reference<T, U, N> {
+>(loadHint: Const<H>, get: (entity: Loaded<T, H>) => V): Reference<U, N> {
   const entity: T = currentlyInstantiatingEntity as T;
   return new CustomReference<T, U, N>(entity, {
     load: (entity, opts) => entity.em.populate(entity, { hint: loadHint, ...opts }),

--- a/packages/orm/src/relations/hasOneThrough.ts
+++ b/packages/orm/src/relations/hasOneThrough.ts
@@ -18,7 +18,7 @@ import {
  */
 export function hasOneThrough<T extends Entity, U extends Entity, N extends never | undefined, V extends U | N>(
   lens: (lens: Lens<T>) => Lens<V>,
-): Reference<T, U, N> {
+): Reference<U, N> {
   const entity: T = currentlyInstantiatingEntity as T;
   return new CustomReference<T, U, N>(entity, {
     load: async (entity, opts) => {

--- a/packages/orm/src/withLoaded.ts
+++ b/packages/orm/src/withLoaded.ts
@@ -16,14 +16,14 @@ import { MaybePromise, maybePromiseThen } from "./utils";
 // undefined references are properly propagated and that polymorphic references don't overwhelm the type system.
 export type WithLoaded<T extends Entity, H extends LoadHint<T>, L extends Loaded<T, H>> = T & {
   [K in keyof L]: L[K] extends PolymorphicReference<T, infer U, infer N>
-    ? L[K] extends LoadedReference<T, U, N>
+    ? L[K] extends LoadedReference<U, N>
       ? U | N
       : L[K]
-    : L[K] extends LoadedReference<T, infer U, never>
+    : L[K] extends LoadedReference<infer U, never>
     ? U
-    : L[K] extends LoadedReference<T, infer U, undefined>
+    : L[K] extends LoadedReference<infer U, undefined>
     ? U | undefined
-    : L[K] extends LoadedCollection<T, infer U>
+    : L[K] extends LoadedCollection<infer U>
     ? U[]
     : L[K] extends LoadedProperty<T, infer V>
     ? V

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -117,9 +117,9 @@ function getTestId(em: EntityManager, entity: Entity): string {
 export type MatchedEntity<T> =
   | T
   | {
-      [K in keyof T]?: T[K] extends Reference<any, infer U, any>
+      [K in keyof T]?: T[K] extends Reference<infer U, any>
         ? MatchedEntity<U> | U
-        : T[K] extends Collection<any, infer U>
+        : T[K] extends Collection<infer U>
         ? Array<MatchedEntity<U> | U>
         : T[K] extends AsyncProperty<any, infer V>
         ? V

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -94,7 +94,7 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newArtist>[1];
   };
 
-  readonly paintings: Collection<Artist, Painting> = hasMany(paintingMeta, "paintings", "artist", "artistId");
+  readonly paintings: Collection<Painting> = hasMany(paintingMeta, "paintings", "artist", "artistId");
 
   constructor(em: EntityManager, opts: ArtistOpts) {
     super(em, artistMeta, ArtistCodegen.defaultValues, opts);

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -93,7 +93,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
 
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "authorId");
+  readonly books: Collection<Book> = hasMany(bookMeta, "books", "author", "authorId");
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -82,7 +82,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newBook>[1];
   };
 
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  readonly author: ManyToOneReference<Author, never> = hasOne(authorMeta, "author", "books");
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -92,7 +92,7 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newPainting>[1];
   };
 
-  readonly artist: ManyToOneReference<Painting, Artist, never> = hasOne(artistMeta, "artist", "paintings");
+  readonly artist: ManyToOneReference<Artist, never> = hasOne(artistMeta, "artist", "paintings");
 
   constructor(em: EntityManager, opts: PaintingOpts) {
     super(em, paintingMeta, PaintingCodegen.defaultValues, opts);

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -94,7 +94,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
 
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id");
+  readonly books: Collection<Book> = hasMany(bookMeta, "books", "author", "author_id");
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -93,7 +93,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newBook>[1];
   };
 
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  readonly author: ManyToOneReference<Author, never> = hasOne(authorMeta, "author", "books");
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -93,7 +93,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
 
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id");
+  readonly books: Collection<Book> = hasMany(bookMeta, "books", "author", "author_id");
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -92,7 +92,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     factoryOptsType: Parameters<typeof newBook>[1];
   };
 
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  readonly author: ManyToOneReference<Author, never> = hasOne(authorMeta, "author", "books");
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);


### PR DESCRIPTION
...but we can't do it b/c rely on the type inference / breaking the circular typing cycles:

```
  readonly reviews: Collection<Author, BookReview> = hasManyThrough((author) => author.books.reviews);
  readonly reviewedBooks: Collection<Author, Book> = hasManyDerived(
```

