### PR TITLE
feat: Support loading lens via SQL joins

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -501,8 +501,8 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
 
       ${maybeIsSoftDeleted}
 
-      load<U, V>(fn: (lens: ${Lens}<${entity.type}>) => ${Lens}<U, V>): Promise<V> {
-        return ${loadLens}(this as any as ${entityName}, fn);
+      load<U, V>(fn: (lens: ${Lens}<${entity.type}>) => ${Lens}<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+        return ${loadLens}(this as any as ${entityName}, fn, opts);
       }
 
       populate<H extends ${LoadHint}<${entityName}>>(hint: H): Promise<${Loaded}<${entityName}, H>>;

--- a/packages/integration-tests/src/EntityManager.lens.test.ts
+++ b/packages/integration-tests/src/EntityManager.lens.test.ts
@@ -39,6 +39,7 @@ describe("EntityManager.lens", () => {
     const [p1, p2] = await Promise.all([b1, b2].map((book) => book.load((b) => b.author.publisher)));
     expect(p1?.name).toEqual("p1");
     expect(p2?.name).toEqual("p2");
+    // 2 = 1 for authors, 1 for publishers
     expect(numberOfQueries).toEqual(2);
   });
 
@@ -138,8 +139,6 @@ describe("EntityManager.lens", () => {
     const publishers = await t1.load((t) => t.books.author.publisher);
     // Use `toStrictEqual` to ensure the list is not `[undefined]`
     expect(publishers).toStrictEqual([]);
-    // Explicitly populate so we can test getLens
-    await t1.populate({ books: { author: "publisher" } });
     expect(getLens(t1, (t) => t.books.author.publisher)).toStrictEqual([]);
   });
 
@@ -150,8 +149,6 @@ describe("EntityManager.lens", () => {
     const b1 = await em.load(Book, "b:1");
     const books = await b1.load((b) => b.author.books);
     expect(books).toMatchEntity([]);
-    // Explicitly populate so we can test getLens
-    await b1.populate({ author: "books" });
     expect(getLens(b1, (b) => b.author.books)).toMatchEntity([]);
   });
 

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -413,8 +413,8 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     return this.__orm.data.deletedAt !== undefined;
   }
 
-  load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Author, fn);
+  load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Author, fn, opts);
   }
 
   populate<H extends LoadHint<Author>>(hint: H): Promise<Loaded<Author, H>>;

--- a/packages/integration-tests/src/entities/AuthorStatCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorStatCodegen.ts
@@ -266,8 +266,8 @@ export abstract class AuthorStatCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<AuthorStat>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as AuthorStat, fn);
+  load<U, V>(fn: (lens: Lens<AuthorStat>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as AuthorStat, fn, opts);
   }
 
   populate<H extends LoadHint<AuthorStat>>(hint: H): Promise<Loaded<AuthorStat, H>>;

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -188,8 +188,8 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<BookAdvance>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as BookAdvance, fn);
+  load<U, V>(fn: (lens: Lens<BookAdvance>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as BookAdvance, fn, opts);
   }
 
   populate<H extends LoadHint<BookAdvance>>(hint: H): Promise<Loaded<BookAdvance, H>>;

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -243,8 +243,8 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     return this.__orm.data.deletedAt !== undefined;
   }
 
-  load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Book, fn);
+  load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Book, fn, opts);
   }
 
   populate<H extends LoadHint<Book>>(hint: H): Promise<Loaded<Book, H>>;

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -177,8 +177,8 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<BookReview>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as BookReview, fn);
+  load<U, V>(fn: (lens: Lens<BookReview>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as BookReview, fn, opts);
   }
 
   populate<H extends LoadHint<BookReview>>(hint: H): Promise<Loaded<BookReview, H>>;

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -151,8 +151,8 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Comment>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Comment, fn);
+  load<U, V>(fn: (lens: Lens<Comment>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Comment, fn, opts);
   }
 
   populate<H extends LoadHint<Comment>>(hint: H): Promise<Loaded<Comment, H>>;

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -186,8 +186,8 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Critic>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Critic, fn);
+  load<U, V>(fn: (lens: Lens<Critic>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Critic, fn, opts);
   }
 
   populate<H extends LoadHint<Critic>>(hint: H): Promise<Loaded<Critic, H>>;

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -143,8 +143,8 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<CriticColumn>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as CriticColumn, fn);
+  load<U, V>(fn: (lens: Lens<CriticColumn>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as CriticColumn, fn, opts);
   }
 
   populate<H extends LoadHint<CriticColumn>>(hint: H): Promise<Loaded<CriticColumn, H>>;

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -208,8 +208,8 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Image>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Image, fn);
+  load<U, V>(fn: (lens: Lens<Image>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Image, fn, opts);
   }
 
   populate<H extends LoadHint<Image>>(hint: H): Promise<Loaded<Image, H>>;

--- a/packages/integration-tests/src/entities/LargePublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/LargePublisherCodegen.ts
@@ -134,8 +134,8 @@ export abstract class LargePublisherCodegen extends Publisher {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<LargePublisher>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as LargePublisher, fn);
+  load<U, V>(fn: (lens: Lens<LargePublisher>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as LargePublisher, fn, opts);
   }
 
   populate<H extends LoadHint<LargePublisher>>(hint: H): Promise<Loaded<LargePublisher, H>>;

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -326,8 +326,8 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Publisher>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Publisher, fn);
+  load<U, V>(fn: (lens: Lens<Publisher>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Publisher, fn, opts);
   }
 
   populate<H extends LoadHint<Publisher>>(hint: H): Promise<Loaded<Publisher, H>>;

--- a/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
@@ -156,8 +156,8 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<PublisherGroup>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as PublisherGroup, fn);
+  load<U, V>(fn: (lens: Lens<PublisherGroup>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as PublisherGroup, fn, opts);
   }
 
   populate<H extends LoadHint<PublisherGroup>>(hint: H): Promise<Loaded<PublisherGroup, H>>;

--- a/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
@@ -125,8 +125,8 @@ export abstract class SmallPublisherCodegen extends Publisher {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<SmallPublisher>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as SmallPublisher, fn);
+  load<U, V>(fn: (lens: Lens<SmallPublisher>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as SmallPublisher, fn, opts);
   }
 
   populate<H extends LoadHint<SmallPublisher>>(hint: H): Promise<Loaded<SmallPublisher, H>>;

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -181,8 +181,8 @@ export abstract class TagCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Tag>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Tag, fn);
+  load<U, V>(fn: (lens: Lens<Tag>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Tag, fn, opts);
   }
 
   populate<H extends LoadHint<Tag>>(hint: H): Promise<Loaded<Tag, H>>;

--- a/packages/integration-tests/src/setupDbTests.ts
+++ b/packages/integration-tests/src/setupDbTests.ts
@@ -59,3 +59,7 @@ export function maybeBeginAndCommit(): number {
   // the query count will be lower by two than the real pg driver
   return testDriver.isInMemory ? 0 : 2;
 }
+
+export function lastQuery(): string {
+  return queries[queries.length - 1];
+}

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -478,7 +478,7 @@ export class EntityManager<C = unknown> {
 
     // 3. Now mutate the m2o relations. We focus on only m2o's because they "own" the field/column,
     // and will drive percolation to keep the other-side o2m & o2o updated.
-    clones.forEach(([entity, clone]) => {
+    clones.forEach(([, clone]) => {
       Object.entries(clone).forEach(([fieldName, value]) => {
         if (value instanceof ManyToOneReferenceImpl || value instanceof PolymorphicReferenceImpl) {
           // What's the existing entity? Have we cloned it?

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -4,7 +4,7 @@ import { FilterAndSettings } from "./EntityFilter";
 import { opToFn } from "./EntityGraphQLFilter";
 import { EntityConstructor, entityLimit } from "./EntityManager";
 import { getMetadata } from "./EntityMetadata";
-import { ColumnCondition, ParsedExpressionFilter, parseFindQuery } from "./index";
+import { ColumnCondition, ParsedExpressionFilter, ParsedFindQuery, parseFindQuery } from "./index";
 import { assertNever, fail } from "./utils";
 import QueryBuilder = Knex.QueryBuilder;
 
@@ -32,6 +32,17 @@ export function buildQuery<T extends Entity>(
   const { where, conditions, orderBy, limit, offset, pruneJoins = true, keepAliases = [] } = filter;
 
   const parsed = parseFindQuery(meta, where, conditions, orderBy, pruneJoins, keepAliases);
+
+  return buildFindQuery(knex, parsed, { limit, offset });
+}
+
+// Probably move this to the Driver interface
+export function buildFindQuery<T extends Entity>(
+  knex: Knex,
+  parsed: ParsedFindQuery,
+  settings: { limit?: number; offset?: number },
+): Knex.QueryBuilder<{}, unknown[]> {
+  const { limit, offset } = settings;
 
   // If we're doing o2m joins, add a `DISTINCT` clause to avoid duplicates
   const needsDistinct = parsed.tables.some((t) => t.join === "outer" && t.distinct !== false);

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -29,13 +29,13 @@ export interface ColumnCondition {
 /** A marker condition for alias methods to indicate they should be skipped/pruned. */
 export const skipCondition: ColumnCondition = { alias: "skip", column: "skip", cond: undefined as any };
 
-interface PrimaryTable {
+export interface PrimaryTable {
   join: "primary";
   alias: string;
   table: string;
 }
 
-interface JoinTable {
+export interface JoinTable {
   join: "inner" | "outer";
   alias: string;
   table: string;
@@ -44,7 +44,7 @@ interface JoinTable {
   distinct?: boolean;
 }
 
-type ParsedTable = PrimaryTable | JoinTable;
+export type ParsedTable = PrimaryTable | JoinTable;
 
 interface ParsedOrderBy {
   alias: string;
@@ -53,7 +53,7 @@ interface ParsedOrderBy {
 }
 
 /** The result of parsing an `em.find` filter. */
-interface ParsedFindQuery {
+export interface ParsedFindQuery {
   selects: string[];
   /** The primary table plus any joins. */
   tables: ParsedTable[];
@@ -421,9 +421,9 @@ export function parseEntityFilter(filter: any): ParsedEntityFilter | undefined {
  */
 export type ParsedValueFilter<V> =
   | { kind: "eq"; value: V }
-  | { kind: "in"; value: V[] }
-  | { kind: "nin"; value: V[] }
-  | { kind: "@>"; value: V[] }
+  | { kind: "in"; value: readonly V[] }
+  | { kind: "nin"; value: readonly V[] }
+  | { kind: "@>"; value: readonly V[] }
   | { kind: "gt"; value: V }
   | { kind: "gte"; value: V }
   | { kind: "ne"; value: V }
@@ -548,7 +548,7 @@ export function mapToDb(column: Column, filter: ParsedValueFilter<any>): ParsedV
   }
 }
 
-function addTablePerClassJoinsAndClassTag(
+export function addTablePerClassJoinsAndClassTag(
   selects: string[],
   tables: ParsedTable[],
   meta: EntityMetadata<any>,

--- a/packages/orm/src/drivers/PostgresDriver.ts
+++ b/packages/orm/src/drivers/PostgresDriver.ts
@@ -597,7 +597,7 @@ function groupEntitiesByTable(entities: Entity[]): Array<[EntityMetadata<any>, E
   return [...entitiesByType.entries()];
 }
 
-export function addTablePerClassJoinsAndClassTag(
+function addTablePerClassJoinsAndClassTag(
   knex: Knex,
   meta: EntityMetadata<any>,
   q: QueryBuilder,

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -9,6 +9,7 @@ import {
 import { EntityMetadata, getAllMetas, getMetadata } from "./EntityMetadata";
 import { getFakeInstance } from "./getProperties";
 import { maybeResolveReferenceToId, tagFromId } from "./keys";
+import { isAllSqlPaths } from "./loadLens";
 import { abbreviation } from "./QueryBuilder";
 import { convertToLoadHint, reverseReactiveHint } from "./reactiveHints";
 import { Reference } from "./relations";
@@ -17,6 +18,7 @@ import { PersistedAsyncPropertyImpl } from "./relations/hasPersistedAsyncPropert
 import { isCannotBeUpdatedRule } from "./rules";
 import { fail } from "./utils";
 
+export const testing = { isAllSqlPaths };
 export { newPgConnectionConfig } from "joist-utils";
 export * from "./Aliases";
 export { BaseEntity } from "./BaseEntity";

--- a/packages/orm/src/relations/CustomReference.ts
+++ b/packages/orm/src/relations/CustomReference.ts
@@ -8,7 +8,7 @@ import { RelationT, RelationU } from "./Relation";
 export type CustomReferenceOpts<T extends Entity, U extends Entity, N extends never | undefined> = {
   // We purposefully don't capture the return value of `load` b/c we want `get` to re-calc from `entity`
   // each time it's invoked so that it reflects any changed values.
-  load: (entity: T, opts: { forceReload?: boolean }) => Promise<void>;
+  load: (entity: T, opts: { forceReload?: boolean }) => Promise<unknown>;
   get: (entity: T) => U | N;
   set?: (entity: T, other: U) => void;
   /** Whether the reference is loaded, even w/o an explicit `.load` call, i.e. for DeepNew test instances. */
@@ -33,7 +33,7 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
   readonly #entity: T;
   // We keep both a promise+loaded flag and not an actual `this.loaded = await load` because
   // the value can become stale; we want to each `.get` call to repeatedly evaluate the latest value.
-  private loadPromise: Promise<void> | undefined;
+  private loadPromise: Promise<unknown> | undefined;
   private _isLoaded = false;
 
   constructor(entity: T, private opts: CustomReferenceOpts<T, U, N>) {

--- a/packages/orm/src/relations/hasManyThrough.ts
+++ b/packages/orm/src/relations/hasManyThrough.ts
@@ -21,9 +21,7 @@ export function hasManyThrough<T extends Entity, U extends Entity>(
 ): Collection<T, U> {
   const entity: T = currentlyInstantiatingEntity as T;
   return new CustomCollection<T, U>(entity, {
-    load: async (entity, opts) => {
-      await loadLens(entity, lens, opts);
-    },
+    load: (entity, opts) => loadLens(entity, lens, opts),
     get: () => getLens(entity, lens),
     isLoaded: () => isLensLoaded(entity, lens),
   });

--- a/packages/orm/src/relations/hasOneThrough.ts
+++ b/packages/orm/src/relations/hasOneThrough.ts
@@ -21,9 +21,7 @@ export function hasOneThrough<T extends Entity, U extends Entity, N extends neve
 ): Reference<T, U, N> {
   const entity: T = currentlyInstantiatingEntity as T;
   return new CustomReference<T, U, N>(entity, {
-    load: async (entity, opts) => {
-      await loadLens(entity, lens, opts);
-    },
+    load: (entity, opts) => loadLens(entity, lens, opts),
     get: () => getLens(entity, lens),
     isLoaded: () => isLensLoaded(entity, lens),
   });

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -153,8 +153,8 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Artist>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Artist, fn);
+  load<U, V>(fn: (lens: Lens<Artist>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Artist, fn, opts);
   }
 
   populate<H extends LoadHint<Artist>>(hint: H): Promise<Loaded<Artist, H>>;

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -152,8 +152,8 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Author, fn);
+  load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Author, fn, opts);
   }
 
   populate<H extends LoadHint<Author>>(hint: H): Promise<Loaded<Author, H>>;

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -125,8 +125,8 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Book, fn);
+  load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Book, fn, opts);
   }
 
   populate<H extends LoadHint<Book>>(hint: H): Promise<Loaded<Book, H>>;

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -143,8 +143,8 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Painting>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Painting, fn);
+  load<U, V>(fn: (lens: Lens<Painting>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Painting, fn, opts);
   }
 
   populate<H extends LoadHint<Painting>>(hint: H): Promise<Loaded<Painting, H>>;

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -153,8 +153,8 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Author, fn);
+  load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Author, fn, opts);
   }
 
   populate<H extends LoadHint<Author>>(hint: H): Promise<Loaded<Author, H>>;

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -144,8 +144,8 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Book, fn);
+  load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Book, fn, opts);
   }
 
   populate<H extends LoadHint<Book>>(hint: H): Promise<Loaded<Book, H>>;

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -152,8 +152,8 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Author, fn);
+  load<U, V>(fn: (lens: Lens<Author>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Author, fn, opts);
   }
 
   populate<H extends LoadHint<Author>>(hint: H): Promise<Loaded<Author, H>>;

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -143,8 +143,8 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     return newChangesProxy(this) as any;
   }
 
-  load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>): Promise<V> {
-    return loadLens(this as any as Book, fn);
+  load<U, V>(fn: (lens: Lens<Book>) => Lens<U, V>, opts: { sql?: boolean } = {}): Promise<V> {
+    return loadLens(this as any as Book, fn, opts);
   }
 
   populate<H extends LoadHint<Book>>(hint: H): Promise<Loaded<Book, H>>;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,7 +4,11 @@ export function fail(message?: string): never {
   throw new Error(message || "Failed");
 }
 
-export function groupBy<T, Y = T>(list: T[], fn: (x: T) => string, valueFn?: (x: T) => Y): Record<string, Y[]> {
+export function groupBy<T, Y = T>(
+  list: readonly T[],
+  fn: (x: T) => string,
+  valueFn?: (x: T) => Y,
+): Record<string, Y[]> {
   const result: Record<string, Y[]> = {};
   list.forEach((o) => {
     const group = fn(o);


### PR DESCRIPTION
Currently only opt-in via:

* `author.load(a => a.books.reviews, { sql: true })`

Currently does not detect WIP mutations, i.e. if a new `BookReview` was created in the EM pointing to one of the unload `Book`s (or even a loaded `Book`), it will not show up in the collection.

Eventually I'd like to handle this by having a `{ sql: "maybe" }` sort of behavior that does the fast-path SQL if we can detect no mutations, and fallbacks to the current slower "load all collections" to ensure correctness.

Unfortunately a big wrinkle with embedded lens usages like `hasOneThrough` and `hasManyThrough` would be doing a SQL-based load during the `CustomReference/Collection.load()` phase (populate), returning the cached SQL-based value from `.get`s, _but_ if we later detected a mutation, we would probably want to fail the `.get` with an error that the results may be incorrect.

Kind of fixes #524 

Doesn't support polys yet, but m2o/o2m/m2m are supported.

Supports soft deletes.

Needs docs.