### PR TITLE
chore: Add Driver.executeFind(ParsedFindQuery) method.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -5,7 +5,7 @@ import { constraintNameToValidationError } from "./config";
 import { createOrUpdatePartial } from "./createOrUpdatePartial";
 import { findDataLoader } from "./dataloaders/findDataLoader";
 import { loadDataLoader } from "./dataloaders/loadDataLoader";
-import { Driver } from "./drivers/driver";
+import { Driver } from "./drivers/Driver";
 import { Entity, isEntity } from "./Entity";
 import {
   asConcreteCstr,

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -1,11 +1,10 @@
 import { Knex } from "knex";
+import { buildKnexQuery } from "./drivers/buildKnexQuery";
 import { Entity } from "./Entity";
 import { FilterAndSettings } from "./EntityFilter";
-import { opToFn } from "./EntityGraphQLFilter";
-import { EntityConstructor, entityLimit } from "./EntityManager";
+import { EntityConstructor } from "./EntityManager";
 import { getMetadata } from "./EntityMetadata";
-import { ColumnCondition, ParsedExpressionFilter, ParsedFindQuery, parseFindQuery } from "./index";
-import { assertNever, fail } from "./utils";
+import { parseFindQuery } from "./index";
 import QueryBuilder = Knex.QueryBuilder;
 
 /**
@@ -30,73 +29,8 @@ export function buildQuery<T extends Entity>(
 ): Knex.QueryBuilder<{}, unknown[]> {
   const meta = getMetadata(type);
   const { where, conditions, orderBy, limit, offset, pruneJoins = true, keepAliases = [] } = filter;
-
   const parsed = parseFindQuery(meta, where, conditions, orderBy, pruneJoins, keepAliases);
-
-  return buildFindQuery(knex, parsed, { limit, offset });
-}
-
-// Probably move this to the Driver interface
-export function buildFindQuery<T extends Entity>(
-  knex: Knex,
-  parsed: ParsedFindQuery,
-  settings: { limit?: number; offset?: number },
-): Knex.QueryBuilder<{}, unknown[]> {
-  const { limit, offset } = settings;
-
-  // If we're doing o2m joins, add a `DISTINCT` clause to avoid duplicates
-  const needsDistinct = parsed.tables.some((t) => t.join === "outer" && t.distinct !== false);
-
-  const primary = parsed.tables.find((t) => t.join === "primary")!;
-  let query: Knex.QueryBuilder<any, any> = knex.from(`${primary.table} AS ${primary.alias}`);
-
-  parsed.selects.forEach((s, i) => {
-    const maybeDistinct = i === 0 && needsDistinct ? "distinct " : "";
-    query.select(knex.raw(`${maybeDistinct}${s}`));
-  });
-
-  parsed.tables.forEach((t) => {
-    switch (t.join) {
-      case "inner":
-        query.join(`${t.table} AS ${t.alias}`, t.col1, t.col2);
-        break;
-      case "outer":
-        query.leftOuterJoin(`${t.table} AS ${t.alias}`, t.col1, t.col2);
-        break;
-      case "primary":
-        // ignore
-        break;
-      default:
-        assertNever(t);
-    }
-  });
-
-  parsed.conditions.forEach((c) => {
-    addColumnCondition(query, c);
-  });
-
-  parsed.complexConditions &&
-    parsed.complexConditions.forEach((c) => {
-      addComplexCondition(query, c);
-    });
-
-  parsed.orderBys &&
-    parsed.orderBys.forEach(({ alias, column, order }) => {
-      // If we're doing "select distinct" for o2m joins, then all order bys must be selects
-      if (needsDistinct) {
-        query.select(`${alias}.${column}`);
-      }
-      query.orderBy(`${alias}.${column}`, order);
-    });
-
-  // Even if they already added orders, add id as the last one to get deterministic output
-  query.orderBy(`${primary.alias}.id`);
-  query.limit(limit || entityLimit);
-  if (offset) {
-    query.offset(offset);
-  }
-
-  return query as Knex.QueryBuilder<{}, unknown[]>;
+  return buildKnexQuery(knex, parsed, { limit, offset });
 }
 
 export function abbreviation(tableName: string): string {
@@ -104,57 +38,4 @@ export function abbreviation(tableName: string): string {
     .split("_")
     .map((w) => w[0])
     .join("");
-}
-
-function addComplexCondition(query: QueryBuilder, complex: ParsedExpressionFilter): void {
-  query.where((q) => {
-    const op = complex.op === "and" ? "andWhere" : "orWhere";
-    complex.conditions.forEach((c) => {
-      if ("op" in c) {
-        q[op]((q) => addComplexCondition(q, c));
-      } else {
-        q[op]((q) => addColumnCondition(q, c));
-      }
-    });
-  });
-}
-
-function addColumnCondition(query: QueryBuilder, cc: ColumnCondition) {
-  const { alias, column, cond } = cc;
-  const columnName = `${alias}.${column}`;
-  switch (cond.kind) {
-    case "eq":
-    case "ne":
-    case "gte":
-    case "gt":
-    case "lte":
-    case "lt":
-    case "like":
-    case "ilike":
-      const fn = opToFn[cond.kind] ?? fail(`Invalid operator ${cond.kind}`);
-      query.where(columnName, fn, cond.value);
-      break;
-    case "is-null":
-      query.whereNull(columnName);
-      break;
-    case "not-null":
-      query.whereNotNull(columnName);
-      break;
-    case "in":
-      query.whereIn(columnName, cond.value);
-      break;
-    case "nin":
-      query.whereNotIn(columnName, cond.value);
-      break;
-    case "@>":
-      query.where(columnName, "@>", cond.value);
-      break;
-    case "between":
-      const [min, max] = cond.value;
-      query.where(columnName, ">=", min);
-      query.where(columnName, "<=", max);
-      break;
-    default:
-      assertNever(cond);
-  }
 }

--- a/packages/orm/src/dataloaders/lensDataLoader.ts
+++ b/packages/orm/src/dataloaders/lensDataLoader.ts
@@ -4,7 +4,7 @@ import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager"
 import { EntityMetadata, getMetadata, ManyToOneField } from "../EntityMetadata";
 import { deTagIds, tagId } from "../keys";
 import { mapPathsToTarget } from "../loadLens";
-import { abbreviation, buildFindQuery } from "../QueryBuilder";
+import { abbreviation } from "../QueryBuilder";
 import { addTablePerClassJoinsAndClassTag, ColumnCondition, ParsedFindQuery, ParsedTable } from "../QueryParser";
 import { getOrSet, groupBy } from "../utils";
 
@@ -154,7 +154,7 @@ export function lensDataLoader<T extends Entity>(
 
       // Get back `__source_id, target.*`
       const parsed: ParsedFindQuery = { selects, tables, conditions };
-      const rows = await buildFindQuery((em.ctx as any).knex, parsed, {});
+      const rows = await em.driver.executeFind(em, parsed, {});
 
       // Group the target entities (i.e. BookReview) by the source id we reached them from.
       const entitiesBySourceId = new Map(

--- a/packages/orm/src/drivers/Driver.ts
+++ b/packages/orm/src/drivers/Driver.ts
@@ -3,6 +3,7 @@ import { Entity } from "../Entity";
 import { FilterAndSettings } from "../EntityFilter";
 import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager";
 import { EntityMetadata } from "../EntityMetadata";
+import { ParsedFindQuery } from "../QueryParser";
 import {
   ManyToManyCollection,
   ManyToManyLargeCollection,
@@ -65,6 +66,13 @@ export interface Driver {
     type: MaybeAbstractEntityConstructor<T>,
     queries: readonly FilterAndSettings<T>[],
   ): Promise<unknown[][]>;
+
+  /** Executes a low-level `ParsedFindQuery` against the database and returns the rows. */
+  executeFind(
+    em: EntityManager,
+    parsed: ParsedFindQuery,
+    settings: { limit?: number; offset?: number },
+  ): Promise<any[]>;
 
   transaction<T>(
     em: EntityManager,

--- a/packages/orm/src/drivers/InMemoryDriver.ts
+++ b/packages/orm/src/drivers/InMemoryDriver.ts
@@ -4,13 +4,13 @@ import { FilterAndSettings, ValueFilter } from "../EntityFilter";
 import { EntityConstructor, entityLimit, EntityManager } from "../EntityManager";
 import { EntityMetadata, getMetadata } from "../EntityMetadata";
 import { deTagId, keyToNumber, keyToString, maybeResolveReferenceToId, tagId, unsafeDeTagIds } from "../keys";
-import { parseEntityFilter, parseValueFilter } from "../QueryParser";
+import { ParsedFindQuery, parseEntityFilter, parseValueFilter } from "../QueryParser";
 import { ManyToManyCollection, OneToManyCollection, OneToOneReferenceImpl } from "../relations";
 import { JoinRow } from "../relations/ManyToManyCollection";
 import { hasSerde } from "../serde";
 import { JoinRowTodo, Todo } from "../Todo";
 import { fail, partition } from "../utils";
-import { Driver } from "./driver";
+import { Driver } from "./Driver";
 
 export class InMemoryDriver implements Driver {
   // Map from table name --> string untagged id --> record
@@ -71,6 +71,14 @@ export class InMemoryDriver implements Driver {
       const sorted = !orderBy ? matched : matched.sort((a, b) => sort(this, meta, orderBy as any, a, b));
       return ensureUnderLimit(sorted.slice(offset, offset + (limit ?? sorted.length)));
     });
+  }
+
+  async executeFind(
+    em: EntityManager,
+    parsed: ParsedFindQuery,
+    settings: { limit?: number; offset?: number },
+  ): Promise<any[]> {
+    throw new Error("Not implemented");
   }
 
   async assignNewIds(em: EntityManager, todos: Record<string, Todo>): Promise<void> {

--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -1,0 +1,131 @@
+import { Knex } from "knex";
+import { opToFn } from "../EntityGraphQLFilter";
+import { entityLimit } from "../EntityManager";
+import { ColumnCondition, ParsedExpressionFilter, ParsedFindQuery } from "../QueryParser";
+import { assertNever, fail } from "../utils";
+import QueryBuilder = Knex.QueryBuilder;
+
+/**
+ * Transforms `ParsedFindQuery` into a Knex query.
+ *
+ * In theory this should be implemented within each Driver, because it's generally
+ * a private API, but:
+ *
+ * a) Multiple drivers will likely be based on Knex, and
+ * b) We've already leaked the `QueryBuilder.ts` `buildQuery` API for letting Joist
+ * do the boilerplate joins/conditions, and then letting the user had more as needed.
+ */
+export function buildKnexQuery(
+  knex: Knex,
+  parsed: ParsedFindQuery,
+  settings: { limit?: number; offset?: number },
+): QueryBuilder<{}, unknown[]> {
+  const { limit, offset } = settings;
+
+  // If we're doing o2m joins, add a `DISTINCT` clause to avoid duplicates
+  const needsDistinct = parsed.tables.some((t) => t.join === "outer" && t.distinct !== false);
+
+  const primary = parsed.tables.find((t) => t.join === "primary")!;
+  let query: Knex.QueryBuilder<any, any> = knex.from(`${primary.table} AS ${primary.alias}`);
+
+  parsed.selects.forEach((s, i) => {
+    const maybeDistinct = i === 0 && needsDistinct ? "distinct " : "";
+    query.select(knex.raw(`${maybeDistinct}${s}`));
+  });
+
+  parsed.tables.forEach((t) => {
+    switch (t.join) {
+      case "inner":
+        query.join(`${t.table} AS ${t.alias}`, t.col1, t.col2);
+        break;
+      case "outer":
+        query.leftOuterJoin(`${t.table} AS ${t.alias}`, t.col1, t.col2);
+        break;
+      case "primary":
+        // ignore
+        break;
+      default:
+        assertNever(t);
+    }
+  });
+
+  parsed.conditions.forEach((c) => {
+    addColumnCondition(query, c);
+  });
+
+  parsed.complexConditions &&
+    parsed.complexConditions.forEach((c) => {
+      addComplexCondition(query, c);
+    });
+
+  parsed.orderBys &&
+    parsed.orderBys.forEach(({ alias, column, order }) => {
+      // If we're doing "select distinct" for o2m joins, then all order bys must be selects
+      if (needsDistinct) {
+        query.select(`${alias}.${column}`);
+      }
+      query.orderBy(`${alias}.${column}`, order);
+    });
+
+  // Even if they already added orders, add id as the last one to get deterministic output
+  query.orderBy(`${primary.alias}.id`);
+  query.limit(limit || entityLimit);
+  if (offset) {
+    query.offset(offset);
+  }
+
+  return query;
+}
+
+function addComplexCondition(query: QueryBuilder, complex: ParsedExpressionFilter): void {
+  query.where((q) => {
+    const op = complex.op === "and" ? "andWhere" : "orWhere";
+    complex.conditions.forEach((c) => {
+      if ("op" in c) {
+        q[op]((q) => addComplexCondition(q, c));
+      } else {
+        q[op]((q) => addColumnCondition(q, c));
+      }
+    });
+  });
+}
+
+function addColumnCondition(query: QueryBuilder, cc: ColumnCondition) {
+  const { alias, column, cond } = cc;
+  const columnName = `${alias}.${column}`;
+  switch (cond.kind) {
+    case "eq":
+    case "ne":
+    case "gte":
+    case "gt":
+    case "lte":
+    case "lt":
+    case "like":
+    case "ilike":
+      const fn = opToFn[cond.kind] ?? fail(`Invalid operator ${cond.kind}`);
+      query.where(columnName, fn, cond.value);
+      break;
+    case "is-null":
+      query.whereNull(columnName);
+      break;
+    case "not-null":
+      query.whereNotNull(columnName);
+      break;
+    case "in":
+      query.whereIn(columnName, cond.value);
+      break;
+    case "nin":
+      query.whereNotIn(columnName, cond.value);
+      break;
+    case "@>":
+      query.where(columnName, "@>", cond.value);
+      break;
+    case "between":
+      const [min, max] = cond.value;
+      query.where(columnName, ">=", min);
+      query.where(columnName, "<=", max);
+      break;
+    default:
+      assertNever(cond);
+  }
+}

--- a/packages/orm/src/drivers/index.ts
+++ b/packages/orm/src/drivers/index.ts
@@ -1,4 +1,4 @@
-export * from "./driver";
+export * from "./Driver";
 export * from "./IdAssigner";
 export * from "./InMemoryDriver";
 export * from "./PostgresDriver";


### PR DESCRIPTION
This lets lensDataLoader ask the driver to execute its ParsedFindQuery.

PostgresDriver implements the new executeFind method by calling the same QueryBuilder buildQuery function, but now moved/extracted into a dedicated buildKnexQuery file/method.