### PR TITLE
feat: add assertLoaded 

### DIFF
--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -34,15 +34,16 @@ export * from "./EntityMetadata";
 export * from "./getProperties";
 export * from "./keys";
 export {
+  assertLoaded,
   DeepNew,
   ensureLoaded,
-  ensureLoadedThen,
   isLoaded,
   isNew,
   Loadable,
   Loaded,
   LoadHint,
   MarkLoaded,
+  maybePopulateThen,
   New,
   RelationsIn,
 } from "./loadHints";
@@ -66,7 +67,7 @@ export {
 } from "./rules";
 export * from "./serde";
 export { asNew, fail } from "./utils";
-export { withLoaded } from "./withLoaded";
+export { ensureWithLoaded, withLoaded, WithLoaded } from "./withLoaded";
 
 // https://spin.atomicobject.com/2018/01/15/typescript-flexible-nominal-typing/
 interface Flavoring<FlavorT> {

--- a/packages/orm/src/withLoaded.ts
+++ b/packages/orm/src/withLoaded.ts
@@ -1,5 +1,5 @@
 import { Entity } from "./Entity";
-import { Loaded, LoadHint } from "./loadHints";
+import { assertLoaded, Loaded, LoadHint } from "./loadHints";
 import {
   isLoadedAsyncProperty,
   isLoadedCollection,
@@ -51,7 +51,7 @@ export type WithLoaded<T extends Entity, H extends LoadHint<T>, L extends Loaded
  * them inadvertently being stored and passed to code that expects a real entity.
  */
 export function withLoaded<T extends Entity, H extends LoadHint<T>, L extends Loaded<T, H>>(
-  loaded: Promise<L>,
+  promise: Promise<L>,
 ): Promise<WithLoaded<T, H, L>>;
 export function withLoaded<T extends Entity, H extends LoadHint<T>, L extends Loaded<T, H>>(
   loaded: L,
@@ -74,4 +74,12 @@ export function withLoaded<T extends Entity, H extends LoadHint<T>, L extends Lo
         },
       }) as WithLoaded<T, H, L>,
   );
+}
+
+export function ensureWithLoaded<T extends Entity, H extends LoadHint<T>, L extends Loaded<T, H>>(
+  entity: T,
+  hint: H,
+): WithLoaded<T, H, L> {
+  assertLoaded<T, H, L>(entity, hint);
+  return withLoaded<T, H, L>(entity);
 }


### PR DESCRIPTION
* Added `assertLoaded` that fails if the entity isn't loaded for its hint
* Added `ensureWithLoaded` that returns a `WithLoaded` after calling `assertLoaded` 

### Breaking Changes

* Renamed `ensureLoadedThen` to `maybePopulateThen` as the naming was non-obvious
* Repurposed unused `ensureLoaded` to `assertLoaded` then return its entity