### PR TITLE
feat: Implement oneToManyDataLoader with executeFind.

### DIFF
--- a/packages/integration-tests/src/drivers/Driver.test.tsx
+++ b/packages/integration-tests/src/drivers/Driver.test.tsx
@@ -1,13 +1,5 @@
-import { Author, Book, newBook, newTag, SmallPublisher, Tag } from "@src/entities";
-import {
-  insertAuthor,
-  insertBook,
-  insertBookToTag,
-  insertImage,
-  insertPublisher,
-  insertTag,
-  select,
-} from "@src/entities/inserts";
+import { Author, Book, newBook, newTag, Tag } from "@src/entities";
+import { insertAuthor, insertBook, insertBookToTag, insertImage, insertTag, select } from "@src/entities/inserts";
 import { driver, newEntityManager } from "@src/setupDbTests";
 import { getMetadata, setField } from "joist-orm";
 
@@ -106,19 +98,6 @@ describe("Driver", () => {
       const rows = await select("books_to_tags");
       expect(rows).toMatchObject([]);
     });
-  });
-
-  it("can loadOneToMany", async () => {
-    // Given a publisher with two authors
-    await insertPublisher({ name: "p1" });
-    await insertAuthor({ first_name: "a1", publisher_id: 1 });
-    await insertAuthor({ first_name: "a2", publisher_id: 1 });
-    // And we create a dummy publisher to get the authors
-    const em = newEntityManager();
-    const p2 = em.create(SmallPublisher, { name: "p2", city: "C1" });
-    // Purposefully using the non-dummy id 1
-    const rows = await driver.loadOneToMany(em, p2.authors as any, ["1"]);
-    expect(rows.length).toEqual(2);
   });
 
   it("can loadManyToMany", async () => {

--- a/packages/orm/src/dataloaders/lensDataLoader.ts
+++ b/packages/orm/src/dataloaders/lensDataLoader.ts
@@ -54,8 +54,9 @@ export function lensDataLoader<T extends Entity>(
       const alias = getAlias(target.tableName);
       const selects = [`${alias}.*`];
       const tables: ParsedTable[] = [{ alias, join: "primary", table: target.tableName }];
-      addTablePerClassJoinsAndClassTag(selects, tables, target, alias, true);
       const conditions: ColumnCondition[] = [];
+      const query: ParsedFindQuery = { selects, tables, conditions };
+      addTablePerClassJoinsAndClassTag(query, target, alias, true);
 
       function maybeAddNotSoftDeleted(other: EntityMetadata<any>, alias: string): void {
         if (other.timestampFields.deletedAt) {
@@ -153,8 +154,7 @@ export function lensDataLoader<T extends Entity>(
       });
 
       // Get back `__source_id, target.*`
-      const parsed: ParsedFindQuery = { selects, tables, conditions };
-      const rows = await em.driver.executeFind(em, parsed, {});
+      const rows = await em.driver.executeFind(em, query, {});
 
       // Group the target entities (i.e. BookReview) by the source id we reached them from.
       const entitiesBySourceId = new Map(

--- a/packages/orm/src/drivers/Driver.ts
+++ b/packages/orm/src/drivers/Driver.ts
@@ -39,13 +39,6 @@ export interface Driver {
     keys: readonly string[],
   ): Promise<JoinRow[]>;
 
-  /** Bulk loads all rows in a m2o, for all entities in `untaggedIds`. */
-  loadOneToMany<T extends Entity, U extends Entity>(
-    em: EntityManager,
-    collection: OneToManyCollection<T, U>,
-    untaggedIds: readonly string[],
-  ): Promise<unknown[]>;
-
   /** Bulk loads selective rows in a m2o, for all entities encoded in `untaggedIds`. */
   findOneToMany<T extends Entity, U extends Entity>(
     em: EntityManager,

--- a/packages/orm/src/drivers/InMemoryDriver.ts
+++ b/packages/orm/src/drivers/InMemoryDriver.ts
@@ -222,16 +222,6 @@ export class InMemoryDriver implements Driver {
     });
   }
 
-  async loadOneToMany<T extends Entity, U extends Entity>(
-    em: EntityManager,
-    collection: OneToManyCollection<T, U>,
-    untaggedIds: readonly string[],
-  ): Promise<unknown[]> {
-    this.onQuery();
-    const rows = Object.values(this.rowsOfTable(collection.otherMeta.tableName));
-    return rows.filter((row) => untaggedIds.includes(String(row[collection.otherColumnName])));
-  }
-
   async findOneToMany<T extends Entity, U extends Entity>(
     em: EntityManager,
     collection: OneToManyCollection<T, U>,

--- a/packages/orm/src/drivers/PostgresDriver.ts
+++ b/packages/orm/src/drivers/PostgresDriver.ts
@@ -127,23 +127,6 @@ export class PostgresDriver implements Driver {
     return query.orderBy("id");
   }
 
-  loadOneToMany<T extends Entity, U extends Entity>(
-    em: EntityManager,
-    collection: OneToManyCollection<T, U>,
-    untaggedIds: readonly string[],
-  ): Promise<unknown[]> {
-    const meta = collection.otherMeta;
-    const knex = this.getMaybeInTxnKnex(em);
-    if (!needsClassPerTableJoins(meta)) {
-      return knex.select("*").from(meta.tableName).whereIn(collection.otherColumnName, untaggedIds).orderBy("id");
-    } else {
-      const q = knex.select("*").from(`${meta.tableName} AS b`);
-      addTablePerClassJoinsAndClassTag(knex, meta, q);
-      q.whereIn(collection.otherColumnName, untaggedIds).orderBy("b.id");
-      return q;
-    }
-  }
-
   findOneToMany<T extends Entity, U extends Entity>(
     em: EntityManager,
     collection: OneToManyCollection<T, U>,


### PR DESCRIPTION
Now that we have the `ParsedFindQuery` ADT, we can do more in the data loaders and make the drivers more lean.

At first I was thinking it was a good idea the drivers could be "more logical" i.e. execute domain operations like "load this o2m" than dropping down to SQL and parsing SQL.

But given drivers will have to implement `executeFind` anyway, and how simple the ADT is (no real parsing overhead), it seems better to pull this logic back out of drivers.