### PR TITLE
feat: Generate a const for enum details.

### DIFF
--- a/packages/codegen/src/generateEnumFile.ts
+++ b/packages/codegen/src/generateEnumFile.ts
@@ -7,6 +7,8 @@ import { EnumTableData } from "./index";
 export function generateEnumFile(config: Config, enumData: EnumTableData, enumName: string): Code {
   const { rows, extraPrimitives } = enumData;
   const detailsName = `${enumName}Details`;
+
+  // Create the `const fooDetails = code -> literal` mapping
   const detailsDefinition = [
     "id: number;",
     `code: ${enumName};`,
@@ -23,6 +25,7 @@ export function generateEnumFile(config: Config, enumData: EnumTableData, enumNa
       return `${primitive.fieldName}: ${primitive.fieldType};`;
     }),
   ].join(" ");
+
   return code`
     export enum ${enumName} {
       ${rows.map((row) => `${pascalCase(row.code)} = '${row.code}'`).join(",\n")}
@@ -42,6 +45,10 @@ export function generateEnumFile(config: Config, enumData: EnumTableData, enumNa
         })
         .join(",")}
     };
+    
+    export const ${detailsName} = {
+      ${rows.map((row) => `${pascalCase(row.code)}: details[${enumName}.${pascalCase(row.code)}]`).join(",")}
+    }
 
     export const ${pluralize(enumName)} = {
       getByCode(code: ${enumName}): ${detailsName} {

--- a/packages/codegen/src/generateEnumFile.ts
+++ b/packages/codegen/src/generateEnumFile.ts
@@ -46,9 +46,9 @@ export function generateEnumFile(config: Config, enumData: EnumTableData, enumNa
         .join(",")}
     };
     
-    export const ${detailsName} = {
+    export const ${detailsName}: Record<${enumName}[0], ${detailsName}> = {
       ${rows.map((row) => `${pascalCase(row.code)}: details[${enumName}.${pascalCase(row.code)}]`).join(",")}
-    }
+    };
 
     export const ${pluralize(enumName)} = {
       getByCode(code: ${enumName}): ${detailsName} {

--- a/packages/integration-tests/src/entities/AdvanceStatus.ts
+++ b/packages/integration-tests/src/entities/AdvanceStatus.ts
@@ -12,7 +12,7 @@ const details: Record<AdvanceStatus, AdvanceStatusDetails> = {
   [AdvanceStatus.Paid]: { id: 3, code: AdvanceStatus.Paid, name: "Paid" },
 };
 
-export const AdvanceStatusDetails = {
+export const AdvanceStatusDetails: Record<AdvanceStatus[0], AdvanceStatusDetails> = {
   Pending: details[AdvanceStatus.Pending],
   Signed: details[AdvanceStatus.Signed],
   Paid: details[AdvanceStatus.Paid],

--- a/packages/integration-tests/src/entities/AdvanceStatus.ts
+++ b/packages/integration-tests/src/entities/AdvanceStatus.ts
@@ -12,6 +12,12 @@ const details: Record<AdvanceStatus, AdvanceStatusDetails> = {
   [AdvanceStatus.Paid]: { id: 3, code: AdvanceStatus.Paid, name: "Paid" },
 };
 
+export const AdvanceStatusDetails = {
+  Pending: details[AdvanceStatus.Pending],
+  Signed: details[AdvanceStatus.Signed],
+  Paid: details[AdvanceStatus.Paid],
+};
+
 export const AdvanceStatuses = {
   getByCode(code: AdvanceStatus): AdvanceStatusDetails {
     return details[code];

--- a/packages/integration-tests/src/entities/Color.ts
+++ b/packages/integration-tests/src/entities/Color.ts
@@ -12,6 +12,8 @@ const details: Record<Color, ColorDetails> = {
   [Color.Blue]: { id: 3, code: Color.Blue, name: "Blue" },
 };
 
+export const ColorDetails = { Red: details[Color.Red], Green: details[Color.Green], Blue: details[Color.Blue] };
+
 export const Colors = {
   getByCode(code: Color): ColorDetails {
     return details[code];

--- a/packages/integration-tests/src/entities/Color.ts
+++ b/packages/integration-tests/src/entities/Color.ts
@@ -12,7 +12,11 @@ const details: Record<Color, ColorDetails> = {
   [Color.Blue]: { id: 3, code: Color.Blue, name: "Blue" },
 };
 
-export const ColorDetails = { Red: details[Color.Red], Green: details[Color.Green], Blue: details[Color.Blue] };
+export const ColorDetails: Record<Color[0], ColorDetails> = {
+  Red: details[Color.Red],
+  Green: details[Color.Green],
+  Blue: details[Color.Blue],
+};
 
 export const Colors = {
   getByCode(code: Color): ColorDetails {

--- a/packages/integration-tests/src/entities/ImageType.ts
+++ b/packages/integration-tests/src/entities/ImageType.ts
@@ -40,6 +40,12 @@ const details: Record<ImageType, ImageTypeDetails> = {
   },
 };
 
+export const ImageTypeDetails = {
+  BookImage: details[ImageType.BookImage],
+  AuthorImage: details[ImageType.AuthorImage],
+  PublisherImage: details[ImageType.PublisherImage],
+};
+
 export const ImageTypes = {
   getByCode(code: ImageType): ImageTypeDetails {
     return details[code];

--- a/packages/integration-tests/src/entities/ImageType.ts
+++ b/packages/integration-tests/src/entities/ImageType.ts
@@ -40,7 +40,7 @@ const details: Record<ImageType, ImageTypeDetails> = {
   },
 };
 
-export const ImageTypeDetails = {
+export const ImageTypeDetails: Record<ImageType[0], ImageTypeDetails> = {
   BookImage: details[ImageType.BookImage],
   AuthorImage: details[ImageType.AuthorImage],
   PublisherImage: details[ImageType.PublisherImage],

--- a/packages/integration-tests/src/entities/PublisherSize.ts
+++ b/packages/integration-tests/src/entities/PublisherSize.ts
@@ -10,7 +10,10 @@ const details: Record<PublisherSize, PublisherSizeDetails> = {
   [PublisherSize.Large]: { id: 2, code: PublisherSize.Large, name: "Large" },
 };
 
-export const PublisherSizeDetails = { Small: details[PublisherSize.Small], Large: details[PublisherSize.Large] };
+export const PublisherSizeDetails: Record<PublisherSize[0], PublisherSizeDetails> = {
+  Small: details[PublisherSize.Small],
+  Large: details[PublisherSize.Large],
+};
 
 export const PublisherSizes = {
   getByCode(code: PublisherSize): PublisherSizeDetails {

--- a/packages/integration-tests/src/entities/PublisherSize.ts
+++ b/packages/integration-tests/src/entities/PublisherSize.ts
@@ -10,6 +10,8 @@ const details: Record<PublisherSize, PublisherSizeDetails> = {
   [PublisherSize.Large]: { id: 2, code: PublisherSize.Large, name: "Large" },
 };
 
+export const PublisherSizeDetails = { Small: details[PublisherSize.Small], Large: details[PublisherSize.Large] };
+
 export const PublisherSizes = {
   getByCode(code: PublisherSize): PublisherSizeDetails {
     return details[code];

--- a/packages/integration-tests/src/entities/PublisherType.ts
+++ b/packages/integration-tests/src/entities/PublisherType.ts
@@ -10,6 +10,8 @@ const details: Record<PublisherType, PublisherTypeDetails> = {
   [PublisherType.Big]: { id: 2, code: PublisherType.Big, name: "Big" },
 };
 
+export const PublisherTypeDetails = { Small: details[PublisherType.Small], Big: details[PublisherType.Big] };
+
 export const PublisherTypes = {
   getByCode(code: PublisherType): PublisherTypeDetails {
     return details[code];

--- a/packages/integration-tests/src/entities/PublisherType.ts
+++ b/packages/integration-tests/src/entities/PublisherType.ts
@@ -10,7 +10,10 @@ const details: Record<PublisherType, PublisherTypeDetails> = {
   [PublisherType.Big]: { id: 2, code: PublisherType.Big, name: "Big" },
 };
 
-export const PublisherTypeDetails = { Small: details[PublisherType.Small], Big: details[PublisherType.Big] };
+export const PublisherTypeDetails: Record<PublisherType[0], PublisherTypeDetails> = {
+  Small: details[PublisherType.Small],
+  Big: details[PublisherType.Big],
+};
 
 export const PublisherTypes = {
   getByCode(code: PublisherType): PublisherTypeDetails {


### PR DESCRIPTION
Allows getting the ids more succinctly, i.e. instead of:

```
PublisherSizes.getByCode(PubliserSize.Small).id;
```

You can now do:

```
PublisherSizeDetails.Small.id;
```

I've gone done the slippery slope of de-`enum`-ing `PublisherSize` before, i.e. to allow just `PublisherSize.Small.id` but that's been too distrupting to existing codebases + various tooling like putting the enums on the wire for GraphQL/JSON/etc.