### PR TITLE
docs: Updates to Docs

### DIFF
--- a/docs/docs/features/loading-entities.md
+++ b/docs/docs/features/loading-entities.md
@@ -7,7 +7,7 @@ Joist has several ways to load entities, and which to use depends on how much co
 
 :::tip
 
-Joist's primary focus is not "_never_ having to hand-write SQL", so it is not a full-fledged query builder (like [Knex](https://knexjs.org/) or [Kelsey](https://github.com/koskimas/kysely)); instead it focuses on robust domain modeling, with validation rules, reactive derived values, etc.
+Joist's primary focus is not "_never_ having to hand-write SQL", so it is not a full-fledged query builder (like [Knex](https://knexjs.org/) or [Kysely](https://github.com/koskimas/kysely)); instead it focuses on robust domain modeling, with validation rules, reactive derived values, etc.
 
 So it's expected to, for advanced/complicated queries, occasionally use a 3rd party query builder in addition to Joist, as covered in Approach 3.
 
@@ -61,9 +61,9 @@ See [Find Queries](./queries-find) for more documentation and examples.
 
 ### 3. Other Query Builders
 
-For query that grow outside what `em.find` can provide, then it's perfectly fine to use a 3rd-party query builder like [Knex](https://knexjs.org/) or [Kelsey](https://github.com/koskimas/kysely).
+For queries that grow outside what `em.find` can provide, then it's perfectly fine to use a 3rd-party query builder like [Knex](https://knexjs.org/) or [Kysely](https://github.com/koskimas/kysely).
 
-Knex would be a natural choice, because Joist uses Knex as an internal dependency, but Kelsey would be fine too.
+Knex would be a natural choice, because Joist uses Knex as an internal dependency, but Kysely would be fine too.
 
 In particular, any queries that need to:
 

--- a/docs/docs/testing/entity-matcher.md
+++ b/docs/docs/testing/entity-matcher.md
@@ -10,6 +10,12 @@ There are two main benefits:
 - Automatic loading of relations
 - Prettier actual vs. expected output
 
+:::info
+
+To use `toMatchEntity`, you must have `joist-test-utils` installed, which is not installed by default with Joist.
+
+:::
+
 ### Automatic Loading of Relations
 
 A potentially unwieldy pattern in tests is asserting against a "subtree" of data that was not initially loaded, i.e.:
@@ -88,7 +94,7 @@ Note that if an entity is new, i.e. the test has not done `em.flush` (which is f
 In your `setupTests.ts`, add:
 
 ```typescript
-import { toMatchEntity } from "joist-test-utils.md";
+import { toMatchEntity } from "joist-test-utils";
 
 expect.extend({ toMatchEntity });
 ```


### PR DESCRIPTION
Made two updates to doc:

* Added a note that `joist-test-utils` is a separate package that needs to be installed to use the test helpers. Fixed a type in the example. 
* Fixed some typos (Kelsey -> Kysely) and grammar in the docs. 