### PR TITLE
fix: Provide default generics for EntityFilter.

### DIFF
--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   alias,
   aliases,
+  EntityFilter,
   ExpressionFilter,
   getMetadata,
   jan1,
@@ -1853,7 +1854,7 @@ describe("EntityManager.queries", () => {
 
     it("allows undefined expressions", async () => {
       const a = alias(Author);
-      const where = { as: a };
+      const where: EntityFilter<Author> = { as: a };
       const conditionalFilter: ExpressionFilter | undefined = undefined;
       expect(
         parseFindQuery(am, where, {

--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -1,6 +1,6 @@
 import { Alias } from "./Aliases";
 import { Entity } from "./Entity";
-import { FieldsOf, FilterOf, OrderOf } from "./EntityManager";
+import { FieldsOf, FilterOf, IdOf, OrderOf } from "./EntityManager";
 import { ColumnCondition } from "./QueryParser";
 
 /**
@@ -28,7 +28,7 @@ export type OrderBy = "ASC" | "DESC";
  * @typeparam F The filter type for the entity, i.e. `AuthorFilter`
  * @typeparam N Either `null | undefined` if the entity can be null, or `never` if it cannot.
  */
-export type EntityFilter<T extends Entity, I, F, N> =
+export type EntityFilter<T extends Entity, I = IdOf<T>, F = FilterOf<T>, N = never> =
   | T
   | T[]
   | I


### PR DESCRIPTION
This makes it a suitable substition for FilterOf<Author> when you also want to include an `as: a` alias binding.