### PR TITLE
feat: Add hasReactiveAsyncProperty to fix reactivity on properties.

### DIFF
--- a/packages/integration-tests/src/entities/BookReview.ts
+++ b/packages/integration-tests/src/entities/BookReview.ts
@@ -1,8 +1,10 @@
 import {
+  AsyncProperty,
   cannotBeUpdated,
   hasOneDerived,
   hasOneThrough,
   hasPersistedAsyncProperty,
+  hasReactiveAsyncProperty,
   PersistedAsyncProperty,
   Reference,
 } from "joist-orm";
@@ -28,6 +30,11 @@ export class BookReview extends BookReviewCodegen {
       return !!author.age && author.age >= 21 && !!author.graduated;
     },
   );
+
+  // Used to test reactivity to hasReactiveAsyncProperty results changing.
+  readonly isPublic2: AsyncProperty<BookReview, boolean> = hasReactiveAsyncProperty({ comment: "text" }, (review) => {
+    return !review.comment.get?.text?.includes("Ignore");
+  });
 }
 
 // Example of cannotBeUpdated on a m2o so "it won't be reactive" (but really is b/c of creates & deletes)

--- a/packages/integration-tests/src/reactiveHints.test.ts
+++ b/packages/integration-tests/src/reactiveHints.test.ts
@@ -4,18 +4,20 @@ import { convertToLoadHint } from "joist-orm/build/src/reactiveHints";
 
 describe("reactiveHints", () => {
   it("can do immediate primitive field names", () => {
-    expect(reverseReactiveHint(Author, "firstName")).toEqual([{ entity: Author, fields: ["firstName"], path: [] }]);
+    expect(reverseReactiveHint(Author, Author, "firstName")).toEqual([
+      { entity: Author, fields: ["firstName"], path: [] },
+    ]);
   });
 
   it("can do parent primitive field names", () => {
-    expect(reverseReactiveHint(Book, { author: ["firstName", "lastName"] })).toEqual([
+    expect(reverseReactiveHint(Book, Book, { author: ["firstName", "lastName"] })).toEqual([
       { entity: Book, fields: ["author"], path: [] },
       { entity: Author, fields: ["firstName", "lastName"], path: ["books"] },
     ]);
   });
 
   it("can do grand-parent primitive field names", () => {
-    expect(reverseReactiveHint(BookReview, { book: { author: ["firstName", "lastName"] } })).toEqual([
+    expect(reverseReactiveHint(BookReview, BookReview, { book: { author: ["firstName", "lastName"] } })).toEqual([
       { entity: BookReview, fields: [], path: [] },
       { entity: Book, fields: ["author"], path: ["reviews"] },
       { entity: Author, fields: ["firstName", "lastName"], path: ["books", "reviews"] },
@@ -23,7 +25,9 @@ describe("reactiveHints", () => {
   });
 
   it("can do parent and grand-parent primitive field names", () => {
-    expect(reverseReactiveHint(BookReview, { book: { title: {}, author: ["firstName", "lastName"] } })).toEqual([
+    expect(
+      reverseReactiveHint(BookReview, BookReview, { book: { title: {}, author: ["firstName", "lastName"] } }),
+    ).toEqual([
       { entity: BookReview, fields: [], path: [] },
       { entity: Book, fields: ["title", "author"], path: ["reviews"] },
       { entity: Author, fields: ["firstName", "lastName"], path: ["books", "reviews"] },
@@ -31,7 +35,7 @@ describe("reactiveHints", () => {
   });
 
   it("can do child o2m with primitive field names", () => {
-    expect(reverseReactiveHint(Author, { books: "title" })).toEqual([
+    expect(reverseReactiveHint(Author, Author, { books: "title" })).toEqual([
       // Include the Author so that if no books are added, the rule still rules on create
       { entity: Author, fields: [], path: [] },
       { entity: Book, fields: ["author", "title"], path: ["author"] },
@@ -39,21 +43,21 @@ describe("reactiveHints", () => {
   });
 
   it("can do child o2m with w/o any fields", () => {
-    expect(reverseReactiveHint(Author, "books")).toEqual([
+    expect(reverseReactiveHint(Author, Author, "books")).toEqual([
       { entity: Author, fields: [], path: [] },
       { entity: Book, fields: ["author"], path: ["author"] },
     ]);
   });
 
   it("can do child o2o with primitive field names", () => {
-    expect(reverseReactiveHint(Author, { image: "fileName" })).toEqual([
+    expect(reverseReactiveHint(Author, Author, { image: "fileName" })).toEqual([
       { entity: Author, fields: [], path: [] },
       { entity: Image, fields: ["author", "fileName"], path: ["author"] },
     ]);
   });
 
   it("can do via polymorphic reference", () => {
-    expect(reverseReactiveHint(Author, { books: { comments: "text" } })).toEqual([
+    expect(reverseReactiveHint(Author, Author, { books: { comments: "text" } })).toEqual([
       { entity: Author, fields: [], path: [] },
       { entity: Book, fields: ["author"], path: ["author"] },
       { entity: Comment, fields: ["parent", "text"], path: ["parent@Book", "author"] },
@@ -61,32 +65,34 @@ describe("reactiveHints", () => {
   });
 
   it("skips read-only m2o parents", () => {
-    expect(reverseReactiveHint(Book, { author_ro: "firstName:ro" })).toEqual([{ entity: Book, fields: [], path: [] }]);
+    expect(reverseReactiveHint(Book, Book, { author_ro: "firstName:ro" })).toEqual([
+      { entity: Book, fields: [], path: [] },
+    ]);
   });
 
   it("skips read-only o2m children and grand-children", () => {
-    expect(reverseReactiveHint(Author, { books_ro: "reviews:ro", firstName_ro: {} })).toEqual([
+    expect(reverseReactiveHint(Author, Author, { books_ro: "reviews:ro", firstName_ro: {} })).toEqual([
       { entity: Author, fields: [], path: [] },
     ]);
   });
 
   it("can do read-only string hint", () => {
     // expect(reverseHint(Author, "books:ro")).toEqual([{ entity: Book, fields: ["author"], path: ["author"] }]);
-    expect(reverseReactiveHint(Author, "publisher:ro")).toEqual([{ entity: Author, fields: [], path: [] }]);
+    expect(reverseReactiveHint(Author, Author, "publisher:ro")).toEqual([{ entity: Author, fields: [], path: [] }]);
   });
 
   it("can do array of read-only string hints", () => {
-    expect(reverseReactiveHint(Author, ["firstName:ro", "publisher:ro"])).toEqual([
+    expect(reverseReactiveHint(Author, Author, ["firstName:ro", "publisher:ro"])).toEqual([
       { entity: Author, fields: [], path: [] },
     ]);
   });
 
   it("can do hash of read-only hints", () => {
     // TODO Enforce that `name` must be `name:ro`
-    expect(reverseReactiveHint(Author, { publisher_ro: "name:ro" })).toEqual([
+    expect(reverseReactiveHint(Author, Author, { publisher_ro: "name:ro" })).toEqual([
       { entity: Author, fields: [], path: [] },
     ]);
-    expect(reverseReactiveHint(BookReview, { book: "author:ro" })).toEqual([
+    expect(reverseReactiveHint(BookReview, BookReview, { book: "author:ro" })).toEqual([
       { entity: BookReview, fields: [], path: [] },
     ]);
   });

--- a/packages/orm/src/relations/index.ts
+++ b/packages/orm/src/relations/index.ts
@@ -4,6 +4,7 @@ export { CustomReference } from "./CustomReference";
 export {
   AsyncProperty,
   hasAsyncProperty,
+  hasReactiveAsyncProperty,
   isAsyncProperty,
   isLoadedAsyncProperty,
   LoadedProperty,


### PR DESCRIPTION
Previously, reactive rules and reactive fields were allowed to depend on async properties.

There were tests against this behavior that seemed reactive, in that they showed reactivity to gross mutations to the object graph, i.e. _anything that was presented in the load hint_.

For example, given an async property such as:

class BookReview {
  readonly isPublic2 = hasAsyncProperty("comment", br =>
    return !br.comment.get?.text.includes("Ignore");
  });
}

Any reactive rules/fields that depended on this `isPublic2` would be recalculated if the `BookReview.comment` field ever changed. Because we passed the load hint along as a reactive hint.

However, any _non-graph-mutating_ changes, such as simple changes to primitive fields that were used within the hasAsyncProperty lambda, would not trigger reactivity.

There were two potential approaches to fix this:

1. Keep the "reactives rules/fields can use async properties w/just load hints" but embellish the load hint with the primitive of every possible field the lamba could read.

I.e. a load hint like `{ book: "review" }` would be embellished to be

```
{ book: { "title": {}, review: { "rating", "otherFieldA", "otherFieldB" } }
```

Even if the lambda only accessed `rating`.

2. Instead of "embellishing load hints into reactive hints", break any usage of a reactive rule/field on a load-hint-using hasAsyncProperty, and force the user to rewrite the property with a new hasReactiveAsyncProperty.

The new hasReactiveAsyncProperty is semantically exactly the same as hasAsyncProperty, except that it takes a reactive hint, and hence it's lambda is forced to specify which fields it actually will access.

Given that hasReactiveAsyncProperty has a user-provided reactive hint, there is no need for "embellishment", and we can hook up reactivity now with assurances that even primitive field changes will trigger the appropriate reactivity.

This PR implements the 2nd option.