### PR TITLE
chore: Show that promise deadlock doesn't repro.

### DIFF
--- a/packages/tests/integration/src/EntityManager.joins.test.ts
+++ b/packages/tests/integration/src/EntityManager.joins.test.ts
@@ -1,4 +1,4 @@
-import { RecursiveCycleError, testing } from "joist-orm";
+import { testing } from "joist-orm";
 import {
   insertAuthor,
   insertBook,
@@ -215,27 +215,6 @@ describe("EntityManager.joins", () => {
       a1.favoriteBook.load(),
       em.populate(a1, "favoriteBook"),
     ]);
-  });
-
-  it("doesn't deadlock on recursive properties", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2", mentor_id: 1 });
-    const em = newEntityManager();
-    const authors = await em.find(Author, {});
-    const [a1Loaded, a2Loaded] = await em.populate(authors, "reputationScore");
-    expect(a1Loaded.reputationScore.get).toBe(0);
-    expect(a2Loaded.reputationScore.get).toBe(0);
-  });
-
-  it("doesn't stack overflow on cyclic recursive properties", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2", mentor_id: 1 });
-    await update("authors", { id: 1, mentor_id: 2 });
-
-    const em = newEntityManager();
-    const authors = await em.find(Author, {});
-
-    await expect(em.populate(authors, "reputationScore")).rejects.toThrow(RecursiveCycleError);
   });
 
   it("preloads em.find", async () => {

--- a/packages/tests/integration/src/EntityManager.populate.test.ts
+++ b/packages/tests/integration/src/EntityManager.populate.test.ts
@@ -1,4 +1,4 @@
-import { setDefaultEntityLimit } from "joist-orm";
+import { RecursiveCycleError, setDefaultEntityLimit } from "joist-orm";
 import { promiseHooks } from "node:v8";
 import { insertAuthor, insertBook, insertPublisher, update } from "src/entities/inserts";
 import { isPreloadingEnabled, newEntityManager, numberOfQueries, resetQueryCount } from "src/testEm";
@@ -244,5 +244,24 @@ describe("EntityManager.populate", () => {
     const p = await em.load(SmallPublisher, "p:1");
     // Then it does not blow up
     await em.populate(p, "spotlightAuthor");
+  });
+
+  it("doesn't deadlock on recursive properties", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2", mentor_id: 1 });
+    const em = newEntityManager();
+    const authors = await em.find(Author, {});
+    const [a1Loaded, a2Loaded] = await em.populate(authors, "reputationScore");
+    expect(a1Loaded.reputationScore.get).toBe(0);
+    expect(a2Loaded.reputationScore.get).toBe(0);
+  });
+
+  it("doesn't stack overflow on cyclic recursive properties", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2", mentor_id: 1 });
+    await update("authors", { id: 1, mentor_id: 2 });
+    const em = newEntityManager();
+    const authors = await em.find(Author, {});
+    await expect(em.populate(authors, "reputationScore")).rejects.toThrow(RecursiveCycleError);
   });
 });

--- a/packages/tests/integration/src/entities/Author.md
+++ b/packages/tests/integration/src/entities/Author.md
@@ -102,6 +102,10 @@ All reviews across all of this author's books.
 
 Example of a ReactiveField that watches through an o2o relation.
 
+### nameWithMentor
+
+Example of a Property that recursively loads the same property from its mentor.
+
 ## Notes
 
 Some additional notes the user might add here, with a code block:

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -314,6 +314,14 @@ export class Author extends AuthorCodegen {
   });
 
   /**
+   * Example of a Property that recursively loads the same property from its mentor.
+   * @generated Author.md
+   */
+  readonly nameWithMentor: Property<Author, string> = hasProperty({ mentor: "nameWithMentor" }, (a) => {
+    return a.mentor.get ? `${a.mentor.get.nameWithMentor.get}${a.firstName}` : a.firstName;
+  });
+
+  /**
    * Example of a derived async enum.
    * @generated Author.md
    */

--- a/packages/tests/integration/src/entities/codegen/metadata-docs.ts
+++ b/packages/tests/integration/src/entities/codegen/metadata-docs.ts
@@ -27,6 +27,7 @@ export const docs = {
       hasBooks: "Example of an async boolean that can be navigated via a lens.",
       reviews: "All reviews across all of this author's books.",
       imageFileName: "Example of a ReactiveField that watches through an o2o relation.",
+      nameWithMentor: "Example of a Property that recursively loads the same property from its mentor.",
     },
     operations: undefined,
   },

--- a/packages/tests/integration/src/relations/AsyncProperty.test.ts
+++ b/packages/tests/integration/src/relations/AsyncProperty.test.ts
@@ -1,7 +1,26 @@
 import { Author, SmallPublisher } from "src/entities";
+import { insertAuthor } from "src/entities/inserts";
 import { newEntityManager } from "src/testEm";
 
 describe("AsyncProperty", () => {
+  it("can load recursive properties", async () => {
+    await insertAuthor({ first_name: "m1" });
+    await insertAuthor({ first_name: "a1", mentor_id: 1 });
+    const em = newEntityManager();
+    const [mentor, author] = await em.loadAll(Author, ["a:1", "a:2"]);
+    const names = await Promise.all([mentor.nameWithMentor.load(), author.nameWithMentor.load()]);
+    expect(names).toEqual(["m1", "m1a1"]);
+  });
+
+  it("can load recursive properties with populate", async () => {
+    await insertAuthor({ first_name: "m1" });
+    await insertAuthor({ first_name: "a1", mentor_id: 1 });
+    const em = newEntityManager();
+    const [mentor, author] = await em.loadAll(Author, ["a:1", "a:2"], "nameWithMentor");
+    const names = [mentor.nameWithMentor.get, author.nameWithMentor.get];
+    expect(names).toEqual(["m1", "m1a1"]);
+  });
+
   it("throws when loading a new entity", async () => {
     const em = newEntityManager();
     const p = em.create(SmallPublisher, { name: "p1", city: "c1" });


### PR DESCRIPTION
what ends up happening is you ask a1.nameWithMentor and a2.nameWithMentor to populate; this dataloaders together into 1 promise.

a1.nameWithMentor can technically resolve, but a2.nameWithMentor requires a1.nameWithMentor, which it asks for, but in the process creates a promise that blocks on the dataloadered promise that is waiting for both a1 & a2 to resolve.

so promise deadlock and it just hangs.