### PR TITLE
feat: Use CTEs instead of UNIONs to batch queries. 

### DIFF
--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -1,0 +1,143 @@
+import { insertAuthor, insertPublisher } from "@src/entities/inserts";
+import { aliases } from "joist-orm";
+import { Author, Publisher } from "./entities";
+import { newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
+
+describe("EntityManager.find.batch", () => {
+  it.unlessInMemory("batches queries loaded at the same time", async () => {
+    await insertPublisher({ name: "p1" });
+    const em = newEntityManager();
+    resetQueryCount();
+    // Given two queries with exactly the same where clause
+    const q1p = em.find(Publisher, { id: "1" });
+    const q2p = em.find(Publisher, { id: "2" });
+    // When they are executed in the same event loop
+    const [q1, q2] = await Promise.all([q1p, q2p]);
+    // Then we issue a single SQL query
+    expect(numberOfQueries).toEqual(1);
+    // And it's the regular/sane query, i.e. not auto-batched
+    expect(queries).toEqual([
+      [
+        `WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )`,
+        ` SELECT array_agg(_find.tag) as _tags, "p".*, p_s0.*, p_s1.*, "p".id as id,`,
+        ` CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class`,
+        ` FROM publishers as p LEFT OUTER JOIN large_publishers p_s0 ON p.id = p_s0.id`,
+        ` LEFT OUTER JOIN small_publishers p_s1 ON p.id = p_s1.id`,
+        ` JOIN _find ON p.id = _find.arg0 GROUP BY "p".id, p_s0.id, p_s1.id`,
+        ` ORDER BY p.id ASC;`,
+      ].join(""),
+    ]);
+    expect(q1.length).toEqual(1);
+    expect(q2.length).toEqual(0);
+  });
+
+  it.unlessInMemory("batches queries with multiple conditions", async () => {
+    await insertAuthor({ first_name: "a1", last_name: "l1" });
+    await insertAuthor({ first_name: "a2", last_name: "l2" });
+    const em = newEntityManager();
+    resetQueryCount();
+    // Given two queries with exactly the same where clause
+    const q1p = em.find(Author, { firstName: "a1", lastName: "l1" });
+    const q2p = em.find(Author, { firstName: "a2", lastName: "l2" });
+    // When they are executed in the same event loop
+    const [q1, a2] = await Promise.all([q1p, q2p]);
+    // Then we issue a single SQL query
+    expect(numberOfQueries).toEqual(1);
+    expect(queries).toEqual([
+      [
+        `WITH _find (tag, arg0, arg1) AS (VALUES`,
+        ` ($1::int, $2::character varying, $3::character varying), ($4, $5, $6) )`,
+        ` SELECT array_agg(_find.tag) as _tags, "a".*`,
+        ` FROM authors as a`,
+        ` JOIN _find ON a.deleted_at IS NULL AND a.first_name = _find.arg0 AND a.last_name = _find.arg1`,
+        ` GROUP BY "a".id`,
+        ` ORDER BY a.id ASC;`,
+      ].join(""),
+    ]);
+  });
+
+  it.unlessInMemory("batches queries with complex expressions", async () => {
+    await insertAuthor({ first_name: "a1", last_name: "l1" });
+    await insertAuthor({ first_name: "a2", last_name: "l2" });
+    const em = newEntityManager();
+    resetQueryCount();
+    // Given two queries with exactly the same where clause
+    const [a1, a2] = aliases(Author, Author);
+    const q1p = em.find(Author, { as: a1 }, { conditions: { or: [a1.firstName.eq("a1"), a1.lastName.eq("l1")] } });
+    const q2p = em.find(Author, { as: a2 }, { conditions: { or: [a2.firstName.eq("a2"), a2.lastName.eq("l2")] } });
+    // When they are executed in the same event loop
+    const [q1, q2] = await Promise.all([q1p, q2p]);
+    // Then we issue a single SQL query
+    expect(numberOfQueries).toEqual(1);
+    expect(queries).toEqual([
+      [
+        `WITH _find (tag, arg0, arg1) AS (VALUES`,
+        ` ($1::int, $2::character varying, $3::character varying), ($4, $5, $6) )`,
+        ` SELECT array_agg(_find.tag) as _tags, "a".*`,
+        ` FROM authors as a`,
+        ` JOIN _find ON a.deleted_at IS NULL AND (a.first_name = _find.arg0 OR a.last_name = _find.arg1)`,
+        ` GROUP BY "a".id`,
+        ` ORDER BY a.id ASC;`,
+      ].join(""),
+    ]);
+  });
+
+  it.unlessInMemory("batches queries with no conditions", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+    const em = newEntityManager();
+    resetQueryCount();
+    // Given two queries with exactly the same where clause
+    const q1p = em.find(Author, {});
+    const q2p = em.find(Author, {});
+    // When they are executed in the same event loop
+    const [q1, q2] = await Promise.all([q1p, q2p]);
+    // Then we issue a single SQL query
+    expect(numberOfQueries).toEqual(1);
+    expect(queries).toEqual([
+      `select "a".* from "authors" as "a" where "a"."deleted_at" is null order by "a"."id" asc limit $1`,
+    ]);
+  });
+
+  it.unlessInMemory("batches queries with same order bys", async () => {
+    await insertPublisher({ name: "p1" });
+    await insertPublisher({ id: 2, name: "p2" });
+    const em = newEntityManager();
+    resetQueryCount();
+    // Given two queries with exactly the same where clause but different orders
+    const a1p = em.find(Author, { id: "1" }, { orderBy: { firstName: "DESC" }, softDeletes: "include" });
+    const a2p = em.find(Author, { id: "2" }, { orderBy: { firstName: "DESC" }, softDeletes: "include" });
+    // When they are executed in the same event loop
+    const [a1, a2] = await Promise.all([a1p, a2p]);
+    // Then we issue a single SQL query
+    expect(numberOfQueries).toEqual(1);
+    // And it is still auto-batched
+    expect(queries).toMatchInlineSnapshot(`
+      [
+        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.id = _find.arg0 GROUP BY "a".id ORDER BY a.first_name DESC;",
+      ]
+    `);
+    // And the results are the expected reverse of each other
+    expect(a1.reverse()).toEqual(a2);
+  });
+
+  it.unlessInMemory("batches queries with same order bys via m2os", async () => {
+    const em = newEntityManager();
+    resetQueryCount();
+    // Given two queries with exactly the same where clause but different orders
+    const a1p = em.find(Author, { id: "1" }, { orderBy: { publisher: { id: "ASC" } }, softDeletes: "include" });
+    const a2p = em.find(Author, { id: "2" }, { orderBy: { publisher: { id: "ASC" } }, softDeletes: "include" });
+    // When they are executed in the same event loop
+    const [a1, a2] = await Promise.all([a1p, a2p]);
+    // Then we issue a single SQL query
+    expect(numberOfQueries).toEqual(1);
+    // And it is still auto-batched
+    expect(queries).toMatchInlineSnapshot(`
+      [
+        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a LEFT OUTER JOIN publishers p ON a.publisher_id = p.id JOIN _find ON a.id = _find.arg0 GROUP BY "a".id, p.id ORDER BY p.id ASC;",
+      ]
+    `);
+    // And the results are the expected reverse of each other
+    expect(a1.reverse()).toEqual(a2);
+  });
+});

--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -155,26 +155,42 @@ describe("EntityManager.find.batch", () => {
     `);
   });
 
-  it("cannot batch queries with IN", async () => {
+  it("batches queries with IN", async () => {
+    await insertAuthor({ first_name: "a1", age: 20 });
+    await insertAuthor({ first_name: "a2", age: 30 });
+    await insertAuthor({ first_name: "a3", age: 40 });
+    resetQueryCount();
     const em = newEntityManager();
-    const q1 = em.find(Author, { age: { in: [20, 30] } });
-    const q2 = em.find(Author, { age: { in: [30, 40] } });
-    await expect(q1).rejects.toThrow("em.find does not support");
-    await expect(q2).rejects.toThrow("em.find does not support");
-    // findUnsafe works instead
-    const q3 = await em.findUnsafe(Author, { age: { in: [30, 40] } });
-    expect(q3).toHaveLength(0);
+    const [q1, q2] = await Promise.all([
+      em.find(Author, { age: { in: [20, 30] } }),
+      em.find(Author, { age: { in: [30, 40] } }),
+    ]);
+    expect(q1.length).toBe(2);
+    expect(q2.length).toBe(2);
+    expect(queries).toMatchInlineSnapshot(`
+      [
+        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int[]), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.age = ANY(_find.arg0) GROUP BY "a".id ORDER BY a.id ASC LIMIT 10000;",
+      ]
+    `);
   });
 
   it("cannot batch queries with NIN", async () => {
+    await insertAuthor({ first_name: "a1", age: 20 });
+    await insertAuthor({ first_name: "a2", age: 30 });
+    await insertAuthor({ first_name: "a3", age: 40 });
+    resetQueryCount();
     const em = newEntityManager();
-    const q1 = em.find(Author, { age: { nin: [20, 30] } });
-    const q2 = em.find(Author, { age: { nin: [30, 40] } });
-    await expect(q1).rejects.toThrow("em.find does not support");
-    await expect(q2).rejects.toThrow("em.find does not support");
-    // findUnsafe works instead
-    const q3 = await em.findUnsafe(Author, { age: { nin: [30, 40] } });
-    expect(q3).toHaveLength(0);
+    const [q1, q2] = await Promise.all([
+      em.find(Author, { age: { nin: [20, 30] } }),
+      em.find(Author, { age: { nin: [30, 40] } }),
+    ]);
+    expect(q1.length).toBe(1);
+    expect(q2.length).toBe(1);
+    expect(queries).toMatchInlineSnapshot(`
+      [
+        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int[]), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.age != ALL(_find.arg0) GROUP BY "a".id ORDER BY a.id ASC LIMIT 10000;",
+      ]
+    `);
   });
 
   it("can batch queries with like", async () => {

--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -4,7 +4,7 @@ import { Author, Publisher } from "./entities";
 import { newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
 
 describe("EntityManager.find.batch", () => {
-  it.unlessInMemory("batches queries loaded at the same time", async () => {
+  it("batches queries loaded at the same time", async () => {
     await insertPublisher({ name: "p1" });
     const em = newEntityManager();
     resetQueryCount();
@@ -31,7 +31,7 @@ describe("EntityManager.find.batch", () => {
     expect(q2.length).toEqual(0);
   });
 
-  it.unlessInMemory("batches queries with multiple conditions", async () => {
+  it("batches queries with multiple conditions", async () => {
     await insertAuthor({ first_name: "a1", last_name: "l1" });
     await insertAuthor({ first_name: "a2", last_name: "l2" });
     const em = newEntityManager();
@@ -56,7 +56,7 @@ describe("EntityManager.find.batch", () => {
     ]);
   });
 
-  it.unlessInMemory("batches queries with complex expressions", async () => {
+  it("batches queries with complex expressions", async () => {
     await insertAuthor({ first_name: "a1", last_name: "l1" });
     await insertAuthor({ first_name: "a2", last_name: "l2" });
     const em = newEntityManager();
@@ -82,7 +82,7 @@ describe("EntityManager.find.batch", () => {
     ]);
   });
 
-  it.unlessInMemory("batches queries with no conditions", async () => {
+  it("batches queries with no conditions", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });
     const em = newEntityManager();
@@ -99,7 +99,7 @@ describe("EntityManager.find.batch", () => {
     ]);
   });
 
-  it.unlessInMemory("batches queries with same order bys", async () => {
+  it("batches queries with same order bys", async () => {
     await insertPublisher({ name: "p1" });
     await insertPublisher({ id: 2, name: "p2" });
     const em = newEntityManager();
@@ -121,7 +121,7 @@ describe("EntityManager.find.batch", () => {
     expect(a1.reverse()).toEqual(a2);
   });
 
-  it.unlessInMemory("batches queries with same order bys via m2os", async () => {
+  it("batches queries with same order bys via m2os", async () => {
     const em = newEntityManager();
     resetQueryCount();
     // Given two queries with exactly the same where clause but different orders

--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -6,8 +6,8 @@ import { newEntityManager, numberOfQueries, queries, resetQueryCount } from "./s
 describe("EntityManager.find.batch", () => {
   it("batches queries loaded at the same time", async () => {
     await insertPublisher({ name: "p1" });
-    const em = newEntityManager();
     resetQueryCount();
+    const em = newEntityManager();
     // Given two queries with exactly the same where clause
     const q1p = em.find(Publisher, { id: "1" });
     const q2p = em.find(Publisher, { id: "2" });
@@ -34,8 +34,8 @@ describe("EntityManager.find.batch", () => {
   it("batches queries with multiple conditions", async () => {
     await insertAuthor({ first_name: "a1", last_name: "l1" });
     await insertAuthor({ first_name: "a2", last_name: "l2" });
-    const em = newEntityManager();
     resetQueryCount();
+    const em = newEntityManager();
     // Given two queries with exactly the same where clause
     const q1p = em.find(Author, { firstName: "a1", lastName: "l1" });
     const q2p = em.find(Author, { firstName: "a2", lastName: "l2" });
@@ -59,8 +59,8 @@ describe("EntityManager.find.batch", () => {
   it("batches queries with complex expressions", async () => {
     await insertAuthor({ first_name: "a1", last_name: "l1" });
     await insertAuthor({ first_name: "a2", last_name: "l2" });
-    const em = newEntityManager();
     resetQueryCount();
+    const em = newEntityManager();
     // Given two queries with exactly the same where clause
     const [a1, a2] = aliases(Author, Author);
     const q1p = em.find(Author, { as: a1 }, { conditions: { or: [a1.firstName.eq("a1"), a1.lastName.eq("l1")] } });
@@ -85,8 +85,8 @@ describe("EntityManager.find.batch", () => {
   it("batches queries with no conditions", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertAuthor({ first_name: "a2" });
-    const em = newEntityManager();
     resetQueryCount();
+    const em = newEntityManager();
     // Given two queries with exactly the same where clause
     const q1p = em.find(Author, {});
     const q2p = em.find(Author, {});
@@ -102,8 +102,8 @@ describe("EntityManager.find.batch", () => {
   it("batches queries with same order bys", async () => {
     await insertPublisher({ name: "p1" });
     await insertPublisher({ id: 2, name: "p2" });
-    const em = newEntityManager();
     resetQueryCount();
+    const em = newEntityManager();
     // Given two queries with exactly the same where clause but different orders
     const a1p = em.find(Author, { id: "1" }, { orderBy: { firstName: "DESC" }, softDeletes: "include" });
     const a2p = em.find(Author, { id: "2" }, { orderBy: { firstName: "DESC" }, softDeletes: "include" });
@@ -123,7 +123,6 @@ describe("EntityManager.find.batch", () => {
 
   it("batches queries with same order bys via m2os", async () => {
     const em = newEntityManager();
-    resetQueryCount();
     // Given two queries with exactly the same where clause but different orders
     const a1p = em.find(Author, { id: "1" }, { orderBy: { publisher: { id: "ASC" } }, softDeletes: "include" });
     const a2p = em.find(Author, { id: "2" }, { orderBy: { publisher: { id: "ASC" } }, softDeletes: "include" });
@@ -143,7 +142,6 @@ describe("EntityManager.find.batch", () => {
 
   it("batches queries with between", async () => {
     const em = newEntityManager();
-    resetQueryCount();
     const [q1, q2] = await Promise.all([
       em.find(Author, { age: { between: [20, 30] } }),
       em.find(Author, { age: { between: [30, 40] } }),
@@ -151,6 +149,38 @@ describe("EntityManager.find.batch", () => {
     expect(queries).toMatchInlineSnapshot(`
       [
         "WITH _find (tag, arg0, arg1) AS (VALUES ($1::int, $2::int, $3::int), ($4, $5, $6) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.age BETWEEN _find.arg0 AND _find.arg1 GROUP BY "a".id ORDER BY a.id ASC;",
+      ]
+    `);
+  });
+
+  it("cannot batch queries with IN", async () => {
+    const em = newEntityManager();
+    const q1 = em.find(Author, { age: { in: [20, 30] } });
+    const q2 = em.find(Author, { age: { in: [30, 40] } });
+    await expect(q1).rejects.toThrow("em.find cannot batch queries with 'IN' conditions");
+    await expect(q2).rejects.toThrow("em.find cannot batch queries with 'IN' conditions");
+  });
+
+  it("cannot batch queries with NIN", async () => {
+    const em = newEntityManager();
+    const q1 = em.find(Author, { age: { nin: [20, 30] } });
+    const q2 = em.find(Author, { age: { nin: [30, 40] } });
+    await expect(q1).rejects.toThrow("em.find cannot batch queries with 'NIN' conditions");
+    await expect(q2).rejects.toThrow("em.find cannot batch queries with 'NIN' conditions");
+  });
+
+  it("can batch queries with like", async () => {
+    await insertAuthor({ first_name: "a1", last_name: "l1" });
+    await insertAuthor({ first_name: "a2", last_name: "l2" });
+    resetQueryCount();
+    const em = newEntityManager();
+    const [q1, q2] = await Promise.all([
+      em.find(Author, { firstName: { like: "a1%" } }),
+      em.find(Author, { firstName: { like: "a2%" } }),
+    ]);
+    expect(queries).toMatchInlineSnapshot(`
+      [
+        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.first_name LIKE _find.arg0 GROUP BY "a".id ORDER BY a.id ASC;",
       ]
     `);
   });

--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -24,7 +24,8 @@ describe("EntityManager.find.batch", () => {
         ` FROM publishers as p LEFT OUTER JOIN large_publishers p_s0 ON p.id = p_s0.id`,
         ` LEFT OUTER JOIN small_publishers p_s1 ON p.id = p_s1.id`,
         ` JOIN _find ON p.id = _find.arg0 GROUP BY "p".id, p_s0.id, p_s1.id`,
-        ` ORDER BY p.id ASC;`,
+        ` ORDER BY p.id ASC`,
+        ` LIMIT 10000;`,
       ].join(""),
     ]);
     expect(q1.length).toEqual(1);
@@ -40,7 +41,7 @@ describe("EntityManager.find.batch", () => {
     const q1p = em.find(Author, { firstName: "a1", lastName: "l1" });
     const q2p = em.find(Author, { firstName: "a2", lastName: "l2" });
     // When they are executed in the same event loop
-    const [q1, a2] = await Promise.all([q1p, q2p]);
+    await Promise.all([q1p, q2p]);
     // Then we issue a single SQL query
     expect(numberOfQueries).toEqual(1);
     expect(queries).toEqual([
@@ -51,7 +52,8 @@ describe("EntityManager.find.batch", () => {
         ` FROM authors as a`,
         ` JOIN _find ON a.deleted_at IS NULL AND a.first_name = _find.arg0 AND a.last_name = _find.arg1`,
         ` GROUP BY "a".id`,
-        ` ORDER BY a.id ASC;`,
+        ` ORDER BY a.id ASC`,
+        ` LIMIT 10000;`,
       ].join(""),
     ]);
   });
@@ -66,7 +68,7 @@ describe("EntityManager.find.batch", () => {
     const q1p = em.find(Author, { as: a1 }, { conditions: { or: [a1.firstName.eq("a1"), a1.lastName.eq("l1")] } });
     const q2p = em.find(Author, { as: a2 }, { conditions: { or: [a2.firstName.eq("a2"), a2.lastName.eq("l2")] } });
     // When they are executed in the same event loop
-    const [q1, q2] = await Promise.all([q1p, q2p]);
+    await Promise.all([q1p, q2p]);
     // Then we issue a single SQL query
     expect(numberOfQueries).toEqual(1);
     expect(queries).toEqual([
@@ -77,7 +79,8 @@ describe("EntityManager.find.batch", () => {
         ` FROM authors as a`,
         ` JOIN _find ON a.deleted_at IS NULL AND (a.first_name = _find.arg0 OR a.last_name = _find.arg1)`,
         ` GROUP BY "a".id`,
-        ` ORDER BY a.id ASC;`,
+        ` ORDER BY a.id ASC`,
+        ` LIMIT 10000;`,
       ].join(""),
     ]);
   });
@@ -91,9 +94,8 @@ describe("EntityManager.find.batch", () => {
     const q1p = em.find(Author, {});
     const q2p = em.find(Author, {});
     // When they are executed in the same event loop
-    const [q1, q2] = await Promise.all([q1p, q2p]);
-    // Then we issue a single SQL query
-    expect(numberOfQueries).toEqual(1);
+    await Promise.all([q1p, q2p]);
+    // Then we issue a single SQL query without any of the CTE overhead
     expect(queries).toEqual([
       `select "a".* from "authors" as "a" where "a"."deleted_at" is null order by "a"."id" asc limit $1`,
     ]);
@@ -114,7 +116,7 @@ describe("EntityManager.find.batch", () => {
     // And it is still auto-batched
     expect(queries).toMatchInlineSnapshot(`
       [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.id = _find.arg0 GROUP BY "a".id ORDER BY a.first_name DESC;",
+        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.id = _find.arg0 GROUP BY "a".id ORDER BY a.first_name DESC LIMIT 10000;",
       ]
     `);
     // And the results are the expected reverse of each other
@@ -133,7 +135,7 @@ describe("EntityManager.find.batch", () => {
     // And it is still auto-batched
     expect(queries).toMatchInlineSnapshot(`
       [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a LEFT OUTER JOIN publishers p ON a.publisher_id = p.id JOIN _find ON a.id = _find.arg0 GROUP BY "a".id, p.id ORDER BY p.id ASC;",
+        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a LEFT OUTER JOIN publishers p ON a.publisher_id = p.id JOIN _find ON a.id = _find.arg0 GROUP BY "a".id, p.id ORDER BY p.id ASC LIMIT 10000;",
       ]
     `);
     // And the results are the expected reverse of each other
@@ -142,13 +144,13 @@ describe("EntityManager.find.batch", () => {
 
   it("batches queries with between", async () => {
     const em = newEntityManager();
-    const [q1, q2] = await Promise.all([
+    await Promise.all([
       em.find(Author, { age: { between: [20, 30] } }),
       em.find(Author, { age: { between: [30, 40] } }),
     ]);
     expect(queries).toMatchInlineSnapshot(`
       [
-        "WITH _find (tag, arg0, arg1) AS (VALUES ($1::int, $2::int, $3::int), ($4, $5, $6) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.age BETWEEN _find.arg0 AND _find.arg1 GROUP BY "a".id ORDER BY a.id ASC;",
+        "WITH _find (tag, arg0, arg1) AS (VALUES ($1::int, $2::int, $3::int), ($4, $5, $6) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.age BETWEEN _find.arg0 AND _find.arg1 GROUP BY "a".id ORDER BY a.id ASC LIMIT 10000;",
       ]
     `);
   });
@@ -174,13 +176,13 @@ describe("EntityManager.find.batch", () => {
     await insertAuthor({ first_name: "a2", last_name: "l2" });
     resetQueryCount();
     const em = newEntityManager();
-    const [q1, q2] = await Promise.all([
+    await Promise.all([
       em.find(Author, { firstName: { like: "a1%" } }),
       em.find(Author, { firstName: { like: "a2%" } }),
     ]);
     expect(queries).toMatchInlineSnapshot(`
       [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.first_name LIKE _find.arg0 GROUP BY "a".id ORDER BY a.id ASC;",
+        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::character varying), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.deleted_at IS NULL AND a.first_name LIKE _find.arg0 GROUP BY "a".id ORDER BY a.id ASC LIMIT 10000;",
       ]
     `);
   });

--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -159,8 +159,8 @@ describe("EntityManager.find.batch", () => {
     const em = newEntityManager();
     const q1 = em.find(Author, { age: { in: [20, 30] } });
     const q2 = em.find(Author, { age: { in: [30, 40] } });
-    await expect(q1).rejects.toThrow("em.find cannot batch queries with 'IN' conditions");
-    await expect(q2).rejects.toThrow("em.find cannot batch queries with 'IN' conditions");
+    await expect(q1).rejects.toThrow("em.find does not support");
+    await expect(q2).rejects.toThrow("em.find does not support");
     // findUnsafe works instead
     const q3 = await em.findUnsafe(Author, { age: { in: [30, 40] } });
     expect(q3).toHaveLength(0);
@@ -170,8 +170,8 @@ describe("EntityManager.find.batch", () => {
     const em = newEntityManager();
     const q1 = em.find(Author, { age: { nin: [20, 30] } });
     const q2 = em.find(Author, { age: { nin: [30, 40] } });
-    await expect(q1).rejects.toThrow("em.find cannot batch queries with 'NIN' conditions");
-    await expect(q2).rejects.toThrow("em.find cannot batch queries with 'NIN' conditions");
+    await expect(q1).rejects.toThrow("em.find does not support");
+    await expect(q2).rejects.toThrow("em.find does not support");
     // findUnsafe works instead
     const q3 = await em.findUnsafe(Author, { age: { nin: [30, 40] } });
     expect(q3).toHaveLength(0);

--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -161,6 +161,9 @@ describe("EntityManager.find.batch", () => {
     const q2 = em.find(Author, { age: { in: [30, 40] } });
     await expect(q1).rejects.toThrow("em.find cannot batch queries with 'IN' conditions");
     await expect(q2).rejects.toThrow("em.find cannot batch queries with 'IN' conditions");
+    // findUnsafe works instead
+    const q3 = await em.findUnsafe(Author, { age: { in: [30, 40] } });
+    expect(q3).toHaveLength(0);
   });
 
   it("cannot batch queries with NIN", async () => {
@@ -169,6 +172,9 @@ describe("EntityManager.find.batch", () => {
     const q2 = em.find(Author, { age: { nin: [30, 40] } });
     await expect(q1).rejects.toThrow("em.find cannot batch queries with 'NIN' conditions");
     await expect(q2).rejects.toThrow("em.find cannot batch queries with 'NIN' conditions");
+    // findUnsafe works instead
+    const q3 = await em.findUnsafe(Author, { age: { nin: [30, 40] } });
+    expect(q3).toHaveLength(0);
   });
 
   it("can batch queries with like", async () => {

--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -1,6 +1,6 @@
 import { insertAuthor, insertPublisher } from "@src/entities/inserts";
 import { aliases } from "joist-orm";
-import { Author, Publisher } from "./entities";
+import { Author, Color, Publisher } from "./entities";
 import { newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
 
 describe("EntityManager.find.batch", () => {
@@ -174,7 +174,7 @@ describe("EntityManager.find.batch", () => {
     `);
   });
 
-  it("cannot batch queries with NIN", async () => {
+  it("batches queries with NIN", async () => {
     await insertAuthor({ first_name: "a1", age: 20 });
     await insertAuthor({ first_name: "a2", age: 30 });
     await insertAuthor({ first_name: "a3", age: 40 });
@@ -193,7 +193,15 @@ describe("EntityManager.find.batch", () => {
     `);
   });
 
-  it("can batch queries with like", async () => {
+  it("batches queries with array in", async () => {
+    const em = newEntityManager();
+    const [q1, q2] = await Promise.all([
+      em.find(Author, { favoriteColors: [Color.Red] }),
+      em.find(Author, { favoriteColors: [Color.Blue] }),
+    ]);
+  });
+
+  it("batches queries with like", async () => {
     await insertAuthor({ first_name: "a1", last_name: "l1" });
     await insertAuthor({ first_name: "a2", last_name: "l2" });
     resetQueryCount();

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -1290,7 +1290,7 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ first_name: "a2", age: 2 });
     const em = newEntityManager();
     const gqlFilter: GraphQLAuthorFilter = { age: { gt: 0 } };
-    const authors = await em.findGql(Author, gqlFilter, { offset: 1, limit: 1 });
+    const authors = await em.findUnsafe(Author, gqlFilter, { offset: 1, limit: 1 });
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
   });
@@ -1301,12 +1301,12 @@ describe("EntityManager.queries", () => {
     await insertPublisher({ id: 3, name: "p3" });
     await insertPublisher({ id: 4, name: "p4" });
     const em = newEntityManager();
-    const p23 = await em.find(Publisher, {}, { orderBy: { name: "ASC" }, offset: 1, limit: 2 });
+    const p23 = await em.findUnsafe(Publisher, {}, { orderBy: { name: "ASC" }, offset: 1, limit: 2 });
     expect(p23.length).toEqual(2);
     expect(p23[0].name).toEqual("p2");
     expect(p23[1].name).toEqual("p3");
 
-    const p43 = await em.find(Publisher, {}, { orderBy: { name: "DESC" }, offset: 2, limit: 2 });
+    const p43 = await em.findUnsafe(Publisher, {}, { orderBy: { name: "DESC" }, offset: 2, limit: 2 });
     expect(p43.length).toEqual(2);
     expect(p43[0].name).toEqual("p2");
     expect(p43[1].name).toEqual("p1");

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -109,7 +109,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "last_name", cond: { kind: "is-null" } }],
+      conditions: [{ alias: "a", column: "last_name", dbType: "character varying", cond: { kind: "is-null" } }],
     });
   });
 
@@ -142,7 +142,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "last_name", cond: { kind: "not-null" } }],
+      conditions: [{ alias: "a", column: "last_name", dbType: "character varying", cond: { kind: "not-null" } }],
     });
   });
 
@@ -251,7 +251,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "is-null" } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "is-null" } }],
     });
   });
 
@@ -302,7 +302,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "not-null" } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "not-null" } }],
     });
   });
 
@@ -358,7 +358,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "in", value: [1] } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "in", value: [1] } }],
     });
   });
 
@@ -395,7 +395,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "nin", value: [1] } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "nin", value: [1] } }],
     });
   });
 
@@ -432,7 +432,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "in", value: [1] } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "in", value: [1] } }],
     });
   });
 
@@ -451,7 +451,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "in", value: [1] } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "in", value: [1] } }],
     });
   });
 
@@ -655,7 +655,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(bm, where, opts)).toEqual({
       selects: [`"b".*`],
       tables: [{ alias: "b", table: "books", join: "primary" }],
-      conditions: [{ alias: "b", column: "author_id", cond: { kind: "in", value: [4] } }],
+      conditions: [{ alias: "b", column: "author_id", dbType: "int", cond: { kind: "in", value: [4] } }],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -672,7 +672,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(pm, where)).toEqual({
       selects: [`"p".*`, "p_s0.*", "p_s1.*", `"p".id as id`, expect.anything()],
       tables: [{ alias: "p", table: "publishers", join: "primary" }, expect.anything(), expect.anything()],
-      conditions: [{ alias: "p", column: "id", cond: { kind: "in", value: [1, 2] } }],
+      conditions: [{ alias: "p", column: "id", dbType: "int", cond: { kind: "in", value: [1, 2] } }],
     });
   });
 
@@ -692,7 +692,7 @@ describe("EntityManager.queries", () => {
         { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
         { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
       ],
-      conditions: [{ alias: "p", column: "id", cond: { kind: "in", value: [1, 2] } }],
+      conditions: [{ alias: "p", column: "id", dbType: "int", cond: { kind: "in", value: [1, 2] } }],
     });
   });
 
@@ -708,7 +708,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(pm, where)).toEqual({
       selects: [`"p".*`, "p_s0.*", "p_s1.*", `"p".id as id`, expect.anything()],
       tables: [{ alias: "p", table: "publishers", join: "primary" }, expect.anything(), expect.anything()],
-      conditions: [{ alias: "p", column: "id", cond: { kind: "in", value: [1, 2] } }],
+      conditions: [{ alias: "p", column: "id", dbType: "int", cond: { kind: "in", value: [1, 2] } }],
     });
   });
 
@@ -806,7 +806,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "in", value: [1, 2] } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "in", value: [1, 2] } }],
     });
   });
 
@@ -823,7 +823,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "is-null" } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "is-null" } }],
     });
   });
 
@@ -840,7 +840,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "is-null" } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "is-null" } }],
     });
   });
 
@@ -928,7 +928,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "between", value: [2, 3] } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "between", value: [2, 3] } }],
     });
   });
 
@@ -1219,7 +1219,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, gqlFilter, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "not-null" } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "not-null" } }],
     });
   });
 
@@ -1398,10 +1398,10 @@ describe("EntityManager.queries", () => {
       selects: [`"c".*`],
       tables: [{ alias: "c", table: "comments", join: "primary" }],
       conditions: [
-        { alias: "c", column: "parent_author_id", cond: { kind: "is-null" } },
-        { alias: "c", column: "parent_book_id", cond: { kind: "is-null" } },
-        { alias: "c", column: "parent_book_review_id", cond: { kind: "is-null" } },
-        { alias: "c", column: "parent_publisher_id", cond: { kind: "is-null" } },
+        { alias: "c", column: "parent_author_id", dbType: "int", cond: { kind: "is-null" } },
+        { alias: "c", column: "parent_book_id", dbType: "int", cond: { kind: "is-null" } },
+        { alias: "c", column: "parent_book_review_id", dbType: "int", cond: { kind: "is-null" } },
+        { alias: "c", column: "parent_publisher_id", dbType: "int", cond: { kind: "is-null" } },
       ],
     });
   });
@@ -1430,8 +1430,8 @@ describe("EntityManager.queries", () => {
         {
           op: "or",
           conditions: [
-            { alias: "c", column: "parent_book_id", cond: { kind: "in", value: [1] } },
-            { alias: "c", column: "parent_book_review_id", cond: { kind: "in", value: [1] } },
+            { alias: "c", column: "parent_book_id", dbType: "int", cond: { kind: "in", value: [1] } },
+            { alias: "c", column: "parent_book_review_id", dbType: "int", cond: { kind: "in", value: [1] } },
           ],
         },
       ],
@@ -1559,7 +1559,7 @@ describe("EntityManager.queries", () => {
         { alias: "a", table: "authors", join: "primary" },
         { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
       ],
-      conditions: [{ alias: "b", column: "title", cond: { kind: "like", value: "b1%" } }],
+      conditions: [{ alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } }],
     });
   });
 
@@ -1670,8 +1670,8 @@ describe("EntityManager.queries", () => {
           {
             op: "or",
             conditions: [
-              { alias: "a", column: "first_name", cond: { kind: "eq", value: "a1" } },
-              { alias: "a", column: "first_name", cond: { kind: "eq", value: "a2" } },
+              { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
+              { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a2" } },
             ],
           },
         ],
@@ -1756,7 +1756,9 @@ describe("EntityManager.queries", () => {
           { alias: "t", table: "tags", join: "outer", col1: "att.tag_id", col2: "t.id" },
         ],
         conditions: [],
-        complexConditions: [{ op: "or", conditions: [{ alias: "t", column: "id", cond: { kind: "eq", value: 1 } }] }],
+        complexConditions: [
+          { op: "or", conditions: [{ alias: "t", column: "id", dbType: "int", cond: { kind: "eq", value: 1 } }] },
+        ],
         orderBys: [{ alias: "b", column: "title", order: "ASC" }],
       });
     });
@@ -1839,7 +1841,9 @@ describe("EntityManager.queries", () => {
         complexConditions: [
           {
             op: "or",
-            conditions: [{ alias: "a", column: "first_name", cond: { kind: "eq", value: "a1" } }],
+            conditions: [
+              { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
+            ],
           },
         ],
       });
@@ -1896,7 +1900,15 @@ describe("EntityManager.queries", () => {
       expect(parseFindQuery(am, where, { softDeletes: "exclude" })).toEqual({
         selects: [`"a".*`],
         tables: [{ alias: "a", table: "authors", join: "primary" }],
-        conditions: [{ alias: "a", column: "deleted_at", cond: { kind: "is-null" }, pruneable: true }],
+        conditions: [
+          {
+            alias: "a",
+            column: "deleted_at",
+            dbType: "timestamp with time zone",
+            cond: { kind: "is-null" },
+            pruneable: true,
+          },
+        ],
       });
     });
 
@@ -1911,7 +1923,15 @@ describe("EntityManager.queries", () => {
       ).toEqual({
         selects: [`"a".*`],
         tables: [{ alias: "a", table: "authors", join: "primary" }],
-        conditions: [{ alias: "a", column: "deleted_at", cond: { kind: "is-null" }, pruneable: true }],
+        conditions: [
+          {
+            alias: "a",
+            column: "deleted_at",
+            dbType: "timestamp with time zone",
+            cond: { kind: "is-null" },
+            pruneable: true,
+          },
+        ],
         complexConditions: [
           {
             conditions: [

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -90,7 +90,9 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "first_name", cond: { kind: "eq", value: "a2" } }],
+      conditions: [
+        { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a2" } },
+      ],
     });
   });
 
@@ -180,7 +182,9 @@ describe("EntityManager.queries", () => {
         { alias: "b", table: "books", join: "primary" },
         { alias: "a", table: "authors", join: "inner", col1: "b.author_id", col2: "a.id" },
       ],
-      conditions: [{ alias: "a", column: "first_name", cond: { kind: "eq", value: "a2" } }],
+      conditions: [
+        { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a2" } },
+      ],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -206,7 +210,7 @@ describe("EntityManager.queries", () => {
         { alias: "a", table: "authors", join: "inner", col1: "b.author_id", col2: "a.id" },
         { alias: "p", table: "publishers", join: "inner", col1: "a.publisher_id", col2: "p.id" },
       ],
-      conditions: [{ alias: "p", column: "name", cond: { kind: "eq", value: "p2" } }],
+      conditions: [{ alias: "p", column: "name", dbType: "character varying", cond: { kind: "eq", value: "p2" } }],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -228,7 +232,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(bm, where, opts)).toEqual({
       selects: [`"b".*`],
       tables: [{ alias: "b", table: "books", join: "primary" }],
-      conditions: [{ alias: "b", column: "author_id", cond: { kind: "eq", value: 2 } }],
+      conditions: [{ alias: "b", column: "author_id", dbType: "int", cond: { kind: "eq", value: 2 } }],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -280,7 +284,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "eq", value: -1 } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "eq", value: -1 } }],
     });
   });
 
@@ -335,7 +339,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "eq", value: 1 } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
     });
   });
 
@@ -364,7 +368,6 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
 
     const em = newEntityManager();
-    const publisherId: PublisherId = "1";
     const where = { publisher: { id: { in: undefined } } } satisfies AuthorFilter;
     const authors = await em.findGql(Author, where);
     expect(authors.length).toEqual(2);
@@ -403,7 +406,6 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ id: 3, first_name: "a2", publisher_id: 2 });
 
     const em = newEntityManager();
-    const publisherId: PublisherId = "1";
     const where = { publisher: { id: { nin: undefined } } } satisfies AuthorFilter;
     const authors = await em.findGql(Author, where);
     expect(authors.length).toEqual(2);
@@ -459,7 +461,6 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
 
     const em = newEntityManager();
-    const publisher = await em.load(Publisher, "p:1");
     const where = { publisher: undefined } satisfies AuthorFilter;
     const authors = await em.find(Author, where);
     expect(authors.length).toEqual(2);
@@ -486,7 +487,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "eq", value: 1 } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
     });
   });
 
@@ -518,7 +519,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "ne", value: 1 } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "ne", value: 1 } }],
     });
   });
 
@@ -543,7 +544,7 @@ describe("EntityManager.queries", () => {
         { alias: "b", table: "books", join: "primary" },
         { alias: "a", table: "authors", join: "inner", col1: "b.author_id", col2: "a.id" },
       ],
-      conditions: [{ alias: "a", column: "publisher_id", cond: { kind: "eq", value: 2 } }],
+      conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "eq", value: 2 } }],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -569,7 +570,7 @@ describe("EntityManager.queries", () => {
         { alias: "b", table: "books", join: "primary" },
         { alias: "i", table: "images", join: "outer", col1: "b.id", col2: "i.book_id" },
       ],
-      conditions: [{ alias: "i", column: "id", cond: { kind: "eq", value: 2 } }],
+      conditions: [{ alias: "i", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } }],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -594,7 +595,7 @@ describe("EntityManager.queries", () => {
         { alias: "b", table: "books", join: "primary" },
         { alias: "i", table: "images", join: "outer", col1: "b.id", col2: "i.book_id" },
       ],
-      conditions: [{ alias: "i", column: "type_id", cond: { kind: "eq", value: 1 } }],
+      conditions: [{ alias: "i", column: "type_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -614,7 +615,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(bm, where, opts)).toEqual({
       selects: [`"b".*`],
       tables: [{ alias: "b", table: "books", join: "primary" }],
-      conditions: [{ alias: "b", column: "author_id", cond: { kind: "eq", value: 4 } }],
+      conditions: [{ alias: "b", column: "author_id", dbType: "int", cond: { kind: "eq", value: 4 } }],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -634,7 +635,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(bm, where, opts)).toEqual({
       selects: [`"b".*`],
       tables: [{ alias: "b", table: "books", join: "primary" }],
-      conditions: [{ alias: "b", column: "author_id", cond: { kind: "eq", value: 4 } }],
+      conditions: [{ alias: "b", column: "author_id", dbType: "int", cond: { kind: "eq", value: 4 } }],
       orderBys: [{ alias: "b", column: "title", order: "ASC" }],
     });
   });
@@ -734,7 +735,7 @@ describe("EntityManager.queries", () => {
         { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
         { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
       ],
-      conditions: [{ alias: "p", column: "size_id", cond: { kind: "eq", value: 2 } }],
+      conditions: [{ alias: "p", column: "size_id", dbType: "int", cond: { kind: "eq", value: 2 } }],
     });
   });
 
@@ -755,7 +756,7 @@ describe("EntityManager.queries", () => {
         { alias: "p_s0", table: "large_publishers", join: "outer", col1: "p.id", col2: "p_s0.id", distinct: false },
         { alias: "p_s1", table: "small_publishers", join: "outer", col1: "p.id", col2: "p_s1.id", distinct: false },
       ],
-      conditions: [{ alias: "p", column: "size_id", cond: { kind: "ne", value: 2 } }],
+      conditions: [{ alias: "p", column: "size_id", dbType: "int", cond: { kind: "ne", value: 2 } }],
     });
   });
 
@@ -772,7 +773,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "eq", value: 2 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "eq", value: 2 } }],
     });
   });
 
@@ -789,7 +790,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "eq", value: 2 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "eq", value: 2 } }],
     });
   });
 
@@ -856,7 +857,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "gt", value: 1 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "gt", value: 1 } }],
     });
   });
 
@@ -873,7 +874,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "gte", value: 2 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "gte", value: 2 } }],
     });
   });
 
@@ -890,7 +891,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "lt", value: 2 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "lt", value: 2 } }],
     });
   });
 
@@ -907,7 +908,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "lte", value: 1 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "lte", value: 1 } }],
     });
   });
 
@@ -944,8 +945,8 @@ describe("EntityManager.queries", () => {
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       conditions: [
-        { alias: "a", column: "age", cond: { kind: "gt", value: 0 } },
-        { alias: "a", column: "age", cond: { kind: "lt", value: 3 } },
+        { alias: "a", column: "age", dbType: "int", cond: { kind: "gt", value: 0 } },
+        { alias: "a", column: "age", dbType: "int", cond: { kind: "lt", value: 3 } },
       ],
     });
   });
@@ -963,7 +964,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "ne", value: 1 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "ne", value: 1 } }],
     });
   });
 
@@ -979,7 +980,9 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "first_name", cond: { kind: "like", value: "a%" } }],
+      conditions: [
+        { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "like", value: "a%" } },
+      ],
     });
   });
 
@@ -995,7 +998,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "graduated", cond: { kind: "eq", value: jan2 } }],
+      conditions: [{ alias: "a", column: "graduated", dbType: "date", cond: { kind: "eq", value: jan2 } }],
     });
   });
 
@@ -1011,7 +1014,9 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, where, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "first_name", cond: { kind: "ilike", value: "A%" } }],
+      conditions: [
+        { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "ilike", value: "A%" } },
+      ],
     });
   });
 
@@ -1039,8 +1044,8 @@ describe("EntityManager.queries", () => {
         { alias: "p", table: "publishers", join: "inner", col1: "a.publisher_id", col2: "p.id" },
       ],
       conditions: [
-        { alias: "a", column: "first_name", cond: { kind: "eq", value: "a" } },
-        { alias: "p", column: "size_id", cond: { kind: "ne", value: 2 } },
+        { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a" } },
+        { alias: "p", column: "size_id", dbType: "int", cond: { kind: "ne", value: 2 } },
       ],
     });
   });
@@ -1196,7 +1201,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, gqlFilter, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "eq", value: 2 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "eq", value: 2 } }],
     });
   });
 
@@ -1261,7 +1266,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(am, gqlFilter, opts)).toEqual({
       selects: [`"a".*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
-      conditions: [{ alias: "a", column: "age", cond: { kind: "gt", value: 1 } }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "gt", value: 1 } }],
     });
   });
 
@@ -1351,7 +1356,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(cm, where)).toEqual({
       selects: [`"c".*`],
       tables: [{ alias: "c", table: "comments", join: "primary" }],
-      conditions: [{ alias: "c", column: "parent_book_id", cond: { kind: "eq", value: 1 } }],
+      conditions: [{ alias: "c", column: "parent_book_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
     });
   });
 
@@ -1372,7 +1377,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(cm, where)).toEqual({
       selects: [`"c".*`],
       tables: [{ alias: "c", table: "comments", join: "primary" }],
-      conditions: [{ alias: "c", column: "parent_book_id", cond: { kind: "eq", value: 1 } }],
+      conditions: [{ alias: "c", column: "parent_book_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
     });
   });
 
@@ -1450,7 +1455,7 @@ describe("EntityManager.queries", () => {
     expect(parseFindQuery(cm, where)).toEqual({
       selects: [`"c".*`],
       tables: [{ alias: "c", table: "comments", join: "primary" }],
-      conditions: [{ alias: "c", column: "parent_book_id", cond: { kind: "ne", value: 1 } }],
+      conditions: [{ alias: "c", column: "parent_book_id", dbType: "int", cond: { kind: "ne", value: 1 } }],
     });
   });
 
@@ -1498,7 +1503,7 @@ describe("EntityManager.queries", () => {
         { alias: "a", table: "authors", join: "primary" },
         { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
       ],
-      conditions: [{ alias: "att", column: "tag_id", cond: { kind: "eq", value: 1 } }],
+      conditions: [{ alias: "att", column: "tag_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
     });
   });
 
@@ -1520,7 +1525,7 @@ describe("EntityManager.queries", () => {
         { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
         { alias: "t", table: "tags", join: "outer", col1: "att.tag_id", col2: "t.id" },
       ],
-      conditions: [{ alias: "t", column: "name", cond: { kind: "eq", value: "t1" } }],
+      conditions: [{ alias: "t", column: "name", dbType: "character varying", cond: { kind: "eq", value: "t1" } }],
     });
   });
 
@@ -1576,7 +1581,7 @@ describe("EntityManager.queries", () => {
         { alias: "a", table: "authors", join: "primary" },
         { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
       ],
-      conditions: [{ alias: "b", column: "title", cond: { kind: "eq", value: "b3" } }],
+      conditions: [{ alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } }],
     });
   });
 
@@ -1596,7 +1601,7 @@ describe("EntityManager.queries", () => {
         { alias: "a", table: "authors", join: "primary" },
         { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
       ],
-      conditions: [{ alias: "b", column: "id", cond: { kind: "eq", value: 2 } }],
+      conditions: [{ alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } }],
     });
   });
 
@@ -1618,7 +1623,9 @@ describe("EntityManager.queries", () => {
         // Perhaps ideally the `col1` would be `lp_b0.id` but it doesn't matter
         { alias: "a", table: "authors", join: "outer", col1: "lp.id", col2: "a.publisher_id" },
       ],
-      conditions: [{ alias: "a", column: "first_name", cond: { kind: "eq", value: "a1" } }],
+      conditions: [
+        { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
+      ],
     });
   });
 
@@ -1804,7 +1811,12 @@ describe("EntityManager.queries", () => {
         ],
         conditions: [],
         complexConditions: [
-          { op: "and", conditions: [{ alias: "b", column: "title", cond: { kind: "eq", value: "b1" } }] },
+          {
+            op: "and",
+            conditions: [
+              { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b1" } },
+            ],
+          },
         ],
       });
     });
@@ -1901,7 +1913,12 @@ describe("EntityManager.queries", () => {
         tables: [{ alias: "a", table: "authors", join: "primary" }],
         conditions: [{ alias: "a", column: "deleted_at", cond: { kind: "is-null" }, pruneable: true }],
         complexConditions: [
-          { conditions: [{ alias: "a", column: "first_name", cond: { kind: "eq", value: "a" } }], op: "and" },
+          {
+            conditions: [
+              { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a" } },
+            ],
+            op: "and",
+          },
         ],
       });
     });
@@ -1913,6 +1930,7 @@ describe("EntityManager.queries", () => {
       expect(a.firstName.eq("a1")).toEqual({
         alias: "unset",
         column: "first_name",
+        dbType: "character varying",
         cond: { kind: "eq", value: "a1" },
       });
     });
@@ -1922,6 +1940,7 @@ describe("EntityManager.queries", () => {
       expect(a.firstName.ne("a1")).toEqual({
         alias: "unset",
         column: "first_name",
+        dbType: "character varying",
         cond: { kind: "ne", value: "a1" },
       });
     });
@@ -1931,6 +1950,7 @@ describe("EntityManager.queries", () => {
       expect(a.favoriteShape.ne(FavoriteShape.Square)).toEqual({
         alias: "unset",
         column: "favorite_shape",
+        dbType: "FavoriteShape",
         cond: { kind: "ne", value: "square" },
       });
     });
@@ -1940,6 +1960,7 @@ describe("EntityManager.queries", () => {
       expect(p.size.eq(PublisherSize.Large)).toEqual({
         alias: "unset",
         column: "size_id",
+        dbType: "int",
         cond: { kind: "eq", value: 2 },
       });
     });
@@ -1949,6 +1970,7 @@ describe("EntityManager.queries", () => {
       expect(b.author.eq("a:1")).toEqual({
         alias: "unset",
         column: "author_id",
+        dbType: "int",
         cond: { kind: "eq", value: 1 },
       });
     });
@@ -1958,6 +1980,7 @@ describe("EntityManager.queries", () => {
       expect(b.author.eq(null)).toEqual({
         alias: "unset",
         column: "author_id",
+        dbType: "int",
         cond: { kind: "is-null" },
       });
     });
@@ -1970,6 +1993,7 @@ describe("EntityManager.queries", () => {
       expect(b.author.in([a1, "a:2"])).toEqual({
         alias: "unset",
         column: "author_id",
+        dbType: "int",
         cond: { kind: "in", value: [1, 2] },
       });
     });

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -351,7 +351,7 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const publisherId: PublisherId = "1";
     const where = { publisher: { id: { in: [publisherId] } } } satisfies AuthorFilter;
-    const authors = await em.findUnsafe(Author, where);
+    const authors = await em.find(Author, where);
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
@@ -388,7 +388,7 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const publisherId: PublisherId = "1";
     const where = { publisher: { id: { nin: [publisherId] } } } satisfies AuthorFilter;
-    const authors = await em.findUnsafe(Author, where);
+    const authors = await em.find(Author, where);
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
@@ -425,7 +425,7 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const publisherId: PublisherId = "1";
     const where = { publisher: [publisherId] } satisfies AuthorFilter;
-    const authors = await em.findUnsafe(Author, where);
+    const authors = await em.find(Author, where);
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
@@ -444,7 +444,7 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const publisher = await em.load(Publisher, "p:1");
     const where = { publisher: [publisher] } satisfies AuthorFilter;
-    const authors = await em.findUnsafe(Author, where);
+    const authors = await em.find(Author, where);
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
@@ -648,7 +648,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { author: { id: ["a:4"] } } satisfies BookFilter;
-    const books = await em.findUnsafe(Book, where);
+    const books = await em.find(Book, where);
     expect(books.length).toEqual(1);
     expect(books[0].title).toEqual("b2");
 
@@ -666,7 +666,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { id: ["1", "2"] } satisfies PublisherFilter;
-    const pubs = await em.findUnsafe(Publisher, where);
+    const pubs = await em.find(Publisher, where);
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where)).toEqual({
@@ -682,7 +682,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { id: ["p:1", "p:2"] } satisfies PublisherFilter;
-    const pubs = await em.findUnsafe(Publisher, where);
+    const pubs = await em.find(Publisher, where);
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where)).toEqual({
@@ -702,7 +702,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { id: { in: ["1", "2"] } } satisfies PublisherFilter;
-    const pubs = await em.findUnsafe(Publisher, where);
+    const pubs = await em.find(Publisher, where);
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where)).toEqual({
@@ -800,7 +800,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { age: { in: [1, 2] } } satisfies AuthorFilter;
-    const authors = await em.findUnsafe(Author, where);
+    const authors = await em.find(Author, where);
     expect(authors.length).toEqual(2);
 
     expect(parseFindQuery(am, where, opts)).toEqual({
@@ -1265,7 +1265,7 @@ describe("EntityManager.queries", () => {
     await insertPublisher({ name: "p1", size_id: 1 });
     const em = newEntityManager();
     const gqlFilter: GraphQLPublisherFilter = { size: [PublisherSize.Small] };
-    const publishers = await em.findUnsafe(Publisher, gqlFilter);
+    const publishers = await em.find(Publisher, gqlFilter);
     expect(publishers.length).toEqual(1);
   });
 
@@ -1290,7 +1290,7 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ first_name: "a2", age: 2 });
     const em = newEntityManager();
     const gqlFilter: GraphQLAuthorFilter = { age: { gt: 0 } };
-    const authors = await em.findUnsafe(Author, gqlFilter, { offset: 1, limit: 1 });
+    const authors = await em.findGqlPaginated(Author, gqlFilter, { offset: 1, limit: 1 });
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
   });
@@ -1301,12 +1301,12 @@ describe("EntityManager.queries", () => {
     await insertPublisher({ id: 3, name: "p3" });
     await insertPublisher({ id: 4, name: "p4" });
     const em = newEntityManager();
-    const p23 = await em.findUnsafe(Publisher, {}, { orderBy: { name: "ASC" }, offset: 1, limit: 2 });
+    const p23 = await em.findPaginated(Publisher, {}, { orderBy: { name: "ASC" }, offset: 1, limit: 2 });
     expect(p23.length).toEqual(2);
     expect(p23[0].name).toEqual("p2");
     expect(p23[1].name).toEqual("p3");
 
-    const p43 = await em.findUnsafe(Publisher, {}, { orderBy: { name: "DESC" }, offset: 2, limit: 2 });
+    const p43 = await em.findPaginated(Publisher, {}, { orderBy: { name: "DESC" }, offset: 2, limit: 2 });
     expect(p43.length).toEqual(2);
     expect(p43[0].name).toEqual("p2");
     expect(p43[1].name).toEqual("p1");
@@ -1330,7 +1330,7 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ first_name: "a1", favorite_colors: [1, 2] });
     await insertAuthor({ first_name: "a2", favorite_colors: [] });
     const em = newEntityManager();
-    const authors = await em.findUnsafe(Author, { favoriteColors: [Color.Red] });
+    const authors = await em.find(Author, { favoriteColors: [Color.Red] });
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a1");
   });
@@ -1431,7 +1431,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { parent: ["b:1", "br:1"] } satisfies CommentFilter;
-    const comments = await em.findUnsafe(Comment, where);
+    const comments = await em.find(Comment, where);
     const [c1, c2] = comments;
     expect(comments.length).toEqual(2);
     expect(c1.text).toEqual("t1");

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -351,7 +351,7 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const publisherId: PublisherId = "1";
     const where = { publisher: { id: { in: [publisherId] } } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
+    const authors = await em.findUnsafe(Author, where);
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
@@ -388,7 +388,7 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const publisherId: PublisherId = "1";
     const where = { publisher: { id: { nin: [publisherId] } } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
+    const authors = await em.findUnsafe(Author, where);
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
@@ -425,7 +425,7 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const publisherId: PublisherId = "1";
     const where = { publisher: [publisherId] } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
+    const authors = await em.findUnsafe(Author, where);
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
@@ -444,7 +444,7 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const publisher = await em.load(Publisher, "p:1");
     const where = { publisher: [publisher] } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
+    const authors = await em.findUnsafe(Author, where);
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
@@ -648,7 +648,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { author: { id: ["a:4"] } } satisfies BookFilter;
-    const books = await em.find(Book, where);
+    const books = await em.findUnsafe(Book, where);
     expect(books.length).toEqual(1);
     expect(books[0].title).toEqual("b2");
 
@@ -666,7 +666,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { id: ["1", "2"] } satisfies PublisherFilter;
-    const pubs = await em.find(Publisher, where);
+    const pubs = await em.findUnsafe(Publisher, where);
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where)).toEqual({
@@ -682,7 +682,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { id: ["p:1", "p:2"] } satisfies PublisherFilter;
-    const pubs = await em.find(Publisher, where);
+    const pubs = await em.findUnsafe(Publisher, where);
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where)).toEqual({
@@ -702,7 +702,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { id: { in: ["1", "2"] } } satisfies PublisherFilter;
-    const pubs = await em.find(Publisher, where);
+    const pubs = await em.findUnsafe(Publisher, where);
     expect(pubs.length).toEqual(2);
 
     expect(parseFindQuery(pm, where)).toEqual({
@@ -800,7 +800,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { age: { in: [1, 2] } } satisfies AuthorFilter;
-    const authors = await em.find(Author, where);
+    const authors = await em.findUnsafe(Author, where);
     expect(authors.length).toEqual(2);
 
     expect(parseFindQuery(am, where, opts)).toEqual({
@@ -1265,7 +1265,7 @@ describe("EntityManager.queries", () => {
     await insertPublisher({ name: "p1", size_id: 1 });
     const em = newEntityManager();
     const gqlFilter: GraphQLPublisherFilter = { size: [PublisherSize.Small] };
-    const publishers = await em.findGql(Publisher, gqlFilter);
+    const publishers = await em.findUnsafe(Publisher, gqlFilter);
     expect(publishers.length).toEqual(1);
   });
 
@@ -1330,7 +1330,7 @@ describe("EntityManager.queries", () => {
     await insertAuthor({ first_name: "a1", favorite_colors: [1, 2] });
     await insertAuthor({ first_name: "a2", favorite_colors: [] });
     const em = newEntityManager();
-    const authors = await em.find(Author, { favoriteColors: [Color.Red] });
+    const authors = await em.findUnsafe(Author, { favoriteColors: [Color.Red] });
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a1");
   });
@@ -1431,7 +1431,7 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { parent: ["b:1", "br:1"] } satisfies CommentFilter;
-    const comments = await em.find(Comment, where);
+    const comments = await em.findUnsafe(Comment, where);
     const [c1, c2] = comments;
     expect(comments.length).toEqual(2);
     expect(c1.text).toEqual("t1");

--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -878,6 +878,21 @@ describe("EntityManager.queries", () => {
     });
   });
 
+  it("can find by between", async () => {
+    await insertAuthor({ first_name: "a1", age: 50 });
+
+    const em = newEntityManager();
+    const where = { age: { between: [40, 60] } } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
+    expect(authors).toHaveLength(1);
+
+    expect(parseFindQuery(am, where, opts)).toEqual({
+      selects: [`"a".*`],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
+      conditions: [{ alias: "a", column: "age", dbType: "int", cond: { kind: "between", value: [40, 60] } }],
+    });
+  });
+
   it("can find by less than", async () => {
     await insertAuthor({ first_name: "a1", age: 1 });
     await insertAuthor({ first_name: "a2", age: 2 });

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -777,7 +777,7 @@ describe("EntityManager", () => {
         ` (0::int, $1::character varying, $2::character varying), (1, $3, $4) )`,
         ` SELECT array_agg(_find.tag) as _tags, "a".*`,
         ` FROM authors as a`,
-        ` JOIN _find ON a.deleted_at IS NULL AND (a.first_name = _find.arg0 or a.last_name = _find.arg1)`,
+        ` JOIN _find ON a.deleted_at IS NULL AND (a.first_name = _find.arg0 OR a.last_name = _find.arg1)`,
         ` GROUP BY "a".id;`,
       ].join(""),
     ]);

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -12,9 +12,9 @@ import {
   select,
   update,
 } from "@src/entities/inserts";
-import { aliases, Loaded, sameEntity, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
+import { Loaded, sameEntity, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
 import { Author, Book, Color, newAuthor, newBook, newPublisher, Publisher, PublisherSize } from "./entities";
-import { knex, maybeBeginAndCommit, newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
+import { knex, maybeBeginAndCommit, newEntityManager, numberOfQueries, resetQueryCount } from "./setupDbTests";
 
 describe("EntityManager", () => {
   it("can load an entity", async () => {
@@ -705,143 +705,6 @@ describe("EntityManager", () => {
       "Cannot set 'publisher' on Author:1 during a flush outside of a entity hook or from afterCommit",
     );
     await flushPromise;
-  });
-
-  it.unlessInMemory("will dedup queries that are loaded at the same time", async () => {
-    await insertPublisher({ name: "p1" });
-    const em = newEntityManager();
-    resetQueryCount();
-    // Given two queries with exactly the same where clause
-    const q1p = em.find(Publisher, { id: "1" });
-    const q2p = em.find(Publisher, { id: "2" });
-    // When they are executed in the same event loop
-    const [q1, q2] = await Promise.all([q1p, q2p]);
-    // Then we issue a single SQL query
-    expect(numberOfQueries).toEqual(1);
-    // And it's the regular/sane query, i.e. not auto-batched
-    expect(queries).toEqual([
-      [
-        `WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )`,
-        ` SELECT array_agg(_find.tag) as _tags, "p".*, p_s0.*, p_s1.*, "p".id as id,`,
-        ` CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class`,
-        ` FROM publishers as p LEFT OUTER JOIN large_publishers p_s0 ON p.id = p_s0.id`,
-        ` LEFT OUTER JOIN small_publishers p_s1 ON p.id = p_s1.id`,
-        ` JOIN _find ON p.id = _find.arg0 GROUP BY "p".id, p_s0.id, p_s1.id`,
-        ` ORDER BY p.id ASC;`,
-      ].join(""),
-    ]);
-    expect(q1.length).toEqual(1);
-    expect(q2.length).toEqual(0);
-  });
-
-  it.unlessInMemory("will dedup queries with multiple conditions", async () => {
-    await insertAuthor({ first_name: "a1", last_name: "l1" });
-    await insertAuthor({ first_name: "a2", last_name: "l2" });
-    const em = newEntityManager();
-    resetQueryCount();
-    // Given two queries with exactly the same where clause
-    const q1p = em.find(Author, { firstName: "a1", lastName: "l1" });
-    const q2p = em.find(Author, { firstName: "a2", lastName: "l2" });
-    // When they are executed in the same event loop
-    const [q1, a2] = await Promise.all([q1p, q2p]);
-    // Then we issue a single SQL query
-    expect(numberOfQueries).toEqual(1);
-    expect(queries).toEqual([
-      [
-        `WITH _find (tag, arg0, arg1) AS (VALUES`,
-        ` ($1::int, $2::character varying, $3::character varying), ($4, $5, $6) )`,
-        ` SELECT array_agg(_find.tag) as _tags, "a".*`,
-        ` FROM authors as a`,
-        ` JOIN _find ON a.deleted_at IS NULL AND a.first_name = _find.arg0 AND a.last_name = _find.arg1`,
-        ` GROUP BY "a".id`,
-        ` ORDER BY a.id ASC;`,
-      ].join(""),
-    ]);
-  });
-
-  it.unlessInMemory("will dedup queries with complex expressions", async () => {
-    await insertAuthor({ first_name: "a1", last_name: "l1" });
-    await insertAuthor({ first_name: "a2", last_name: "l2" });
-    const em = newEntityManager();
-    resetQueryCount();
-    // Given two queries with exactly the same where clause
-    const [a1, a2] = aliases(Author, Author);
-    const q1p = em.find(Author, { as: a1 }, { conditions: { or: [a1.firstName.eq("a1"), a1.lastName.eq("l1")] } });
-    const q2p = em.find(Author, { as: a2 }, { conditions: { or: [a2.firstName.eq("a2"), a2.lastName.eq("l2")] } });
-    // When they are executed in the same event loop
-    const [q1, q2] = await Promise.all([q1p, q2p]);
-    // Then we issue a single SQL query
-    expect(numberOfQueries).toEqual(1);
-    expect(queries).toEqual([
-      [
-        `WITH _find (tag, arg0, arg1) AS (VALUES`,
-        ` ($1::int, $2::character varying, $3::character varying), ($4, $5, $6) )`,
-        ` SELECT array_agg(_find.tag) as _tags, "a".*`,
-        ` FROM authors as a`,
-        ` JOIN _find ON a.deleted_at IS NULL AND (a.first_name = _find.arg0 OR a.last_name = _find.arg1)`,
-        ` GROUP BY "a".id`,
-        ` ORDER BY a.id ASC;`,
-      ].join(""),
-    ]);
-  });
-
-  it.unlessInMemory("will dedup queries with no conditions", async () => {
-    await insertAuthor({ first_name: "a1" });
-    await insertAuthor({ first_name: "a2" });
-    const em = newEntityManager();
-    resetQueryCount();
-    // Given two queries with exactly the same where clause
-    const q1p = em.find(Author, {});
-    const q2p = em.find(Author, {});
-    // When they are executed in the same event loop
-    const [q1, q2] = await Promise.all([q1p, q2p]);
-    // Then we issue a single SQL query
-    expect(numberOfQueries).toEqual(1);
-    expect(queries).toEqual([
-      `select "a".* from "authors" as "a" where "a"."deleted_at" is null order by "a"."id" asc limit $1`,
-    ]);
-  });
-
-  it.unlessInMemory("does dedup queries with same order bys", async () => {
-    await insertPublisher({ name: "p1" });
-    await insertPublisher({ id: 2, name: "p2" });
-    const em = newEntityManager();
-    resetQueryCount();
-    // Given two queries with exactly the same where clause but different orders
-    const a1p = em.find(Author, { id: "1" }, { orderBy: { firstName: "DESC" }, softDeletes: "include" });
-    const a2p = em.find(Author, { id: "2" }, { orderBy: { firstName: "DESC" }, softDeletes: "include" });
-    // When they are executed in the same event loop
-    const [a1, a2] = await Promise.all([a1p, a2p]);
-    // Then we issue a single SQL query
-    expect(numberOfQueries).toEqual(1);
-    // And it is still auto-batched
-    expect(queries).toMatchInlineSnapshot(`
-      [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a JOIN _find ON a.id = _find.arg0 GROUP BY "a".id ORDER BY a.first_name DESC;",
-      ]
-    `);
-    // And the results are the expected reverse of each other
-    expect(a1.reverse()).toEqual(a2);
-  });
-
-  it.unlessInMemory("does dedup queries with same order bys via m2os", async () => {
-    const em = newEntityManager();
-    resetQueryCount();
-    // Given two queries with exactly the same where clause but different orders
-    const a1p = em.find(Author, { id: "1" }, { orderBy: { publisher: { id: "ASC" } }, softDeletes: "include" });
-    const a2p = em.find(Author, { id: "2" }, { orderBy: { publisher: { id: "ASC" } }, softDeletes: "include" });
-    // When they are executed in the same event loop
-    const [a1, a2] = await Promise.all([a1p, a2p]);
-    // Then we issue a single SQL query
-    expect(numberOfQueries).toEqual(1);
-    // And it is still auto-batched
-    expect(queries).toMatchInlineSnapshot(`
-      [
-        "WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) ) SELECT array_agg(_find.tag) as _tags, "a".* FROM authors as a LEFT OUTER JOIN publishers p ON a.publisher_id = p.id JOIN _find ON a.id = _find.arg0 GROUP BY "a".id, p.id ORDER BY p.id ASC;",
-      ]
-    `);
-    // And the results are the expected reverse of each other
-    expect(a1.reverse()).toEqual(a2);
   });
 
   it("can save tables with self-references", async () => {

--- a/packages/integration-tests/src/relations/CustomReference.test.ts
+++ b/packages/integration-tests/src/relations/CustomReference.test.ts
@@ -28,7 +28,7 @@ describe("CustomReference", () => {
     await insertImage({ type_id: 2, file_name: "f1", author_id: 1 });
 
     const em = newEntityManager();
-    const [a1, a2] = await em.find(Author, { id: ["1", "2"] });
+    const [a1, a2] = await em.loadAll(Author, ["1", "2"]);
     const i1 = await em.load(Image, "1", "owner");
     expect(i1.owner.get).toEqual(a1);
     i1.author.set(a2);

--- a/packages/integration-tests/src/relations/OneToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/OneToManyCollection.test.ts
@@ -202,7 +202,7 @@ describe("OneToManyCollection", () => {
     await insertAuthor({ first_name: "a2" });
     await insertBook({ title: "b1", author_id: 1 });
     const em = newEntityManager();
-    const [a1, a2] = await em.find(Author, { id: ["1", "2"] });
+    const [a1, a2] = await em.loadAll(Author, ["1", "2"]);
     const b1 = await em.load(Book, "1", "author");
 
     // When we assign a new author

--- a/packages/integration-tests/src/relations/OneToOneReference.test.ts
+++ b/packages/integration-tests/src/relations/OneToOneReference.test.ts
@@ -39,7 +39,7 @@ describe("OneToOneReference", () => {
     await insertImage({ type_id: 2, file_name: "f2", author_id: 2 });
 
     const em = newEntityManager();
-    const [a1, a2] = await em.find(Author, { id: ["1", "2"] });
+    const [a1, a2] = await em.loadAll(Author, ["1", "2"]);
     resetQueryCount();
     const [i1, i2] = await Promise.all([a1.image.load(), a2.image.load()]);
     expect(i1?.fileName).toEqual("f1");
@@ -53,7 +53,7 @@ describe("OneToOneReference", () => {
     await insertImage({ type_id: 2, file_name: "f1", author_id: 1 });
 
     const em = newEntityManager();
-    const [a1, a2] = await em.find(Author, { id: ["1", "2"] }, { populate: "image" });
+    const [a1, a2] = await em.loadAll(Author, ["1", "2"], "image");
     const i1 = await em.load(Image, "1", "author");
     i1.author.set(a2);
     expect(a1.image.get).toBeUndefined();

--- a/packages/integration-tests/src/relations/hasManyDerived.test.ts
+++ b/packages/integration-tests/src/relations/hasManyDerived.test.ts
@@ -31,7 +31,7 @@ describe("hasManyDerived", () => {
     await insertBookReview({ rating: 5, book_id: 1 });
 
     const em = newEntityManager();
-    const [b1, b2] = await em.find(Book, { id: ["1", "2"] });
+    const [b1, b2] = await em.loadAll(Book, ["1", "2"]);
     const author = await em.load(Author, "1", "reviewedBooks");
     const review = await em.load(BookReview, "1");
 
@@ -47,7 +47,7 @@ describe("hasManyDerived", () => {
     await insertBookReview({ rating: 5, book_id: 1 });
 
     const em = newEntityManager();
-    const [b1, b2] = await em.find(Book, { id: ["1", "2"] });
+    const [b1, b2] = await em.loadAll(Book, ["1", "2"]);
     const author = await em.load(Author, "1", "reviewedBooks");
 
     expect(author.reviewedBooks.get).toEqual([b1]);

--- a/packages/orm/src/Aliases.ts
+++ b/packages/orm/src/Aliases.ts
@@ -145,6 +145,7 @@ class PrimitiveAliasImpl<V> implements PrimitiveAlias<V> {
     const cond: ColumnCondition = {
       alias: "unset",
       column: this.column.columnName,
+      dbType: this.column.dbType,
       cond: mapToDb(this.column, value),
     };
     this.conditions.push(cond);
@@ -184,6 +185,7 @@ class EntityAliasImpl<T> implements EntityAlias<T> {
     const cond: ColumnCondition = {
       alias: "unset",
       column: this.column.columnName,
+      dbType: this.column.dbType,
       cond: mapToDb(this.column, value),
     };
     this.conditions.push(cond);

--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -64,7 +64,9 @@ export type ValueFilter<V, N> =
   | { lte: V | undefined }
   | { like: V | undefined }
   | { ilike: V | undefined }
-  | { gte: V | undefined; lte: V | undefined };
+  // this is between
+  | { gte: V | undefined; lte: V | undefined }
+  | { between: [V, V] | undefined };
 
 /** Filters against complex expressions of filters. */
 export type ExpressionFilter = (

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -243,7 +243,7 @@ export class EntityManager<C = unknown> {
    *
    * This method is *NOT* batch-friendly, i.e. if called in a loop, it will cause N+1s. Because
    * of this, you should prefer using `find`, unless you need something explicitly only supported
-   * by `findUnsafe`, such as `LIMIT`, `OFFSET`, or `IN` conditions.
+   * by `findUnsafe`, such as `LIMIT` and `OFFSET`.
    */
   public async findUnsafe<T extends Entity>(
     type: MaybeAbstractEntityConstructor<T>,

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -203,6 +203,7 @@ export class EntityManager<C = unknown> {
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options?: {
+      conditions?: ExpressionFilter;
       populate?: any;
       orderBy?: OrderOf<T>;
       limit?: number;
@@ -210,7 +211,9 @@ export class EntityManager<C = unknown> {
       softDeletes?: "include" | "exclude";
     },
   ): Promise<T[]> {
-    const rows = await findDataLoader(this, type).load({ where, ...options });
+    const { populate, ...rest } = options || {};
+    const settings = { where, ...rest };
+    const rows = await findDataLoader(this, type, settings).load(settings);
     const result = rows.map((row) => this.hydrate(type, row, { overwriteExisting: false }));
     if (options?.populate) {
       await this.populate(result, options.populate);
@@ -249,10 +252,12 @@ export class EntityManager<C = unknown> {
       softDeletes?: "include" | "exclude";
     },
   ): Promise<T[]> {
-    const rows = await findDataLoader(this, type).load({ where, ...options });
+    const { populate, ...rest } = options || {};
+    const settings = { where, ...rest };
+    const rows = await findDataLoader(this, type, settings).load(settings);
     const result = rows.map((row) => this.hydrate(type, row, { overwriteExisting: false }));
-    if (options?.populate) {
-      await this.populate(result, options.populate);
+    if (populate) {
+      await this.populate(result, populate);
     }
     return result;
   }

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -242,8 +242,7 @@ export class EntityManager<C = unknown> {
    * For more complex conditions, use the `find` overload that has a `conditions` option.
    *
    * This method is *NOT* batch-friendly, i.e. if called in a loop, it will cause N+1s. Because
-   * of this, you should prefer using `find`, unless you need something explicitly only supported
-   * by `findPaginated`, such as `LIMIT` and `OFFSET`.
+   * of this, you should prefer using `find`, unless you explicitly pagination support.
    */
   public async findPaginated<T extends Entity>(
     type: MaybeAbstractEntityConstructor<T>,
@@ -289,16 +288,14 @@ export class EntityManager<C = unknown> {
     where: FilterWithAlias<T>,
     options?: FindFilterOptions<T> & { populate?: any },
   ): Promise<T[]> {
-    const { populate, ...rest } = options || {};
-    const settings = { where, ...rest };
-    const rows = await findDataLoader(this, type, settings).load(settings);
-    const result = rows.map((row) => this.hydrate(type, row, { overwriteExisting: false }));
-    if (populate) {
-      await this.populate(result, populate);
-    }
-    return result;
+    return this.find(type, where, options);
   }
 
+  /**
+   * Works exactly like `findPaginated` but accepts "less than greatly typed" GraphQL filters.
+   *
+   * I.e. filtering by `null` on fields that are non-`nullable`.
+   */
   public async findGqlPaginated<T extends Entity>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -201,7 +201,8 @@ export class EntityManager<C = unknown> {
   }
 
   /**
-   * Finds entities of `type` with the `where` filter.
+   * Finds entities of `type` with the `where` filter, with auto-batching, so this method
+   * will not cause N+1s if called in a loop.
    *
    * The `where` filter is one of Joist's "join literals", which can combine both joining into
    * related entities and simple column conditions in a single literal. All conditions are ANDed.
@@ -233,7 +234,8 @@ export class EntityManager<C = unknown> {
   }
 
   /**
-   * Finds entities of `type` with the `where` filter.
+   * Finds entities of `type` with the `where` filter, without auto-batching, so this method
+   * may call N+1s if called in a loop.
    *
    * The `where` filter is one of Joist's "join literals", which can combine both joining into
    * related entities and simple column conditions in a single literal. All conditions are ANDed.

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -713,3 +713,18 @@ function parseExpression(expression: ExpressionFilter): ParsedExpressionFilter |
   }
   return { op, conditions: valid.filter(isDefined) };
 }
+
+/**
+ * Combines the simple & complex compressions of `query` into a single `ParsedExpressionFilter`.
+ *
+ * The two `query.conditions` and `query.complexConditions` separated generally for historical
+ * reasons in the `parseFindQuery` implementation, but are effectively a single expression of
+ * `AND`-ing the conditions with the complex conditions.
+ */
+export function combineConditions(query: ParsedFindQuery): ParsedExpressionFilter {
+  if (query.complexConditions) {
+    return { op: "and", conditions: [...query.conditions, ...query.complexConditions] };
+  } else {
+    return { op: "and", conditions: query.conditions };
+  }
+}

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -728,3 +728,19 @@ export function combineConditions(query: ParsedFindQuery): ParsedExpressionFilte
     return { op: "and", conditions: query.conditions };
   }
 }
+
+export function getTables(query: ParsedFindQuery): [PrimaryTable, JoinTable[], JoinTable[]] {
+  let primary: PrimaryTable;
+  const innerJoins: JoinTable[] = [];
+  const outerJoins: JoinTable[] = [];
+  for (const table of query.tables) {
+    if (table.join === "primary") {
+      primary = table;
+    } else if (table.join === "inner") {
+      innerJoins.push(table);
+    } else if (table.join === "outer") {
+      outerJoins.push(table);
+    }
+  }
+  return [primary!, innerJoins, outerJoins];
+}

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -298,7 +298,7 @@ export function parseFindQuery(
             conditions.push({
               alias: ja,
               column: field.columnNames[1],
-              dbType: "int",
+              dbType: meta.idType,
               cond: mapToDb(column, f),
             });
           }
@@ -308,7 +308,7 @@ export function parseFindQuery(
       });
     } else if (ef) {
       const column = meta.fields["id"].serde!.columns[0];
-      conditions.push({ alias, column: "id", dbType: "int", cond: mapToDb(column, ef) });
+      conditions.push({ alias, column: "id", dbType: meta.idType, cond: mapToDb(column, ef) });
     }
   }
 

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -567,6 +567,8 @@ export function parseValueFilter<V>(filter: ValueFilter<V, any>): ParsedValueFil
             case "like":
             case "ilike":
               return { kind: key, value: filter[key] };
+            case "between":
+              return { kind: key, value: filter[key] };
             default:
               throw new Error(`Unsupported value filter key ${key}`);
           }

--- a/packages/orm/src/dataloaders/findByUniqueDataLoader.ts
+++ b/packages/orm/src/dataloaders/findByUniqueDataLoader.ts
@@ -40,6 +40,7 @@ export function findByUniqueDataLoader<T extends Entity>(
         conditions.push({
           alias,
           column: column.columnName,
+          dbType: column.dbType,
           cond: { kind: "in", value: values.map((v) => column.mapToDb(v)) },
         });
         break;

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -9,7 +9,7 @@ import { getMetadata } from "../EntityMetadata";
 import {
   ColumnCondition,
   combineConditions,
-  JoinTable,
+  getTables,
   ParsedExpressionFilter,
   ParsedFindQuery,
   ParsedValueFilter,
@@ -63,9 +63,7 @@ export function findDataLoader<T extends Entity>(
       // - adding a join onto the `em_find` table
       // Biggest wrinkle is that the join condition is non-trivial; currently the AST is only c1=c2
       const columns = ["array_agg(_find.tag) as _tags", ...query.selects];
-      const primary = query.tables.find((t) => t.join === "primary")!;
-      const innerJoins = query.tables.filter((t) => t.join === "inner") as JoinTable[];
-      const outerJoins = query.tables.filter((t) => t.join === "outer") as JoinTable[];
+      const [primary, innerJoins, outerJoins] = getTables(query);
 
       const bindings: any[] = [];
       queries.forEach((query) => {

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -57,7 +57,7 @@ export function findDataLoader<T extends Entity>(
 
       // Build the list of 'arg1', 'arg2', ... strings
       const args = collectArgs(query);
-      args.unshift({ name: "tag", dbType: "int" });
+      args.unshift({ name: "tag", dbType: meta.idType });
 
       const selects = ["array_agg(_find.tag) as _tags", ...query.selects];
       const [primary, innerJoins, outerJoins] = getTables(query);

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -26,9 +26,10 @@ export function findDataLoader<T extends Entity>(
 
   const meta = getMetadata(type);
   const query = parseFindQuery(meta, where, opts);
-  // Clone b/c the complex conditions are not deep copies
+  // Clone b/c parseFindQuery does not deep copy complex conditions, i.e. `a.firstName.eq(...)`
   const clone = structuredClone(query);
   stripValues(clone);
+  // We could use `whereFilterHash` too if it's faster?
   const batchKey = JSON.stringify(clone);
 
   return em.getLoader(

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -63,8 +63,10 @@ export function findDataLoader<T extends Entity>(
       // - adding a join onto the `em_find` table
       // Biggest wrinkle is that the join condition is non-trivial; currently the AST is only c1=c2
       const columns = ["array_agg(_find.tag) as _tags", ...query.selects];
+
       const [primary, innerJoins, outerJoins] = getTables(query);
 
+      // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
       const bindings: any[] = [];
       queries.forEach((query) => {
         const { where, ...opts } = query;

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -231,18 +231,14 @@ function makeOp(cond: ParsedValueFilter<any>, argsIndex: number): [string, numbe
       return [`${fn} _find.arg${argsIndex}`, 1];
     case "is-null":
       return [`IS NULL`, 0];
-      break;
     case "not-null":
       return [`IS NOT NULL`, 0];
-      break;
     case "in":
-      return [`IN _find.arg${argsIndex}`, 1];
+      throw new Error("em.find cannot batch queries with 'IN' conditions");
     case "nin":
-      return [`NOT IN _find.arg${argsIndex}`, 1];
-      break;
+      throw new Error("em.find cannot batch queries with 'NIN' conditions");
     case "@>":
-      // FIX
-      return [`NOT IN _find.arg${argsIndex}`, 1];
+      throw new Error("em.find cannot batch queries with '@>' conditions");
     case "between":
       const [min, max] = cond.value;
       return [`BETWEEN _find.arg${argsIndex} AND _find.arg${argsIndex + 1}`, 2];

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -248,7 +248,7 @@ function makeOp(cond: ParsedValueFilter<any>, argsIndex: number): [string, numbe
     case "nin":
       return [`!= ALL(_find.arg${argsIndex})`, 1];
     case "@>":
-      throw new Error("em.find cannot batch queries with '@>' conditions");
+      return [`@> _find.arg${argsIndex}`, 1];
     case "between":
       return [`BETWEEN _find.arg${argsIndex} AND _find.arg${argsIndex + 1}`, 2];
     default:
@@ -273,7 +273,7 @@ function failIfUnsupportedCondition(query: ParsedFindQuery): void {
     visitCond(c: ColumnCondition) {
       const { kind } = c.cond;
       if (kind === "@>") {
-        throw new Error(`em.find does not support the '${kind}' operator, use 'findUnsafe' instead`);
+        // throw new Error(`em.find does not support the '${kind}' operator, use 'findPaginated' instead`);
       }
     },
   });

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -95,7 +95,8 @@ export function findDataLoader<T extends Entity>(
         ${outerJoins.map((j) => `LEFT OUTER JOIN ${j.table} ${j.alias} ON ${j.col1} = ${j.col2}`).join(" ")}
         JOIN _find ON ${conditions}
         GROUP BY ${groupBys.join(", ")}
-        ORDER BY ${orderBys.map((o) => `${o.alias}.${o.column} ${o.order}`).join(", ")};
+        ORDER BY ${orderBys.map((o) => `${o.alias}.${o.column} ${o.order}`).join(", ")}
+        LIMIT ${entityLimit};
       `;
 
       const rows = await em.driver.executeQuery(em, cleanSql(sql), bindings);

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -23,6 +23,9 @@ export function findDataLoader<T extends Entity>(
   filter: FilterAndSettings<T>,
 ): DataLoader<FilterAndSettings<T>, unknown[]> {
   const { where, ...opts } = filter;
+  if (opts.limit || opts.offset) {
+    throw new Error("Cannot use limit/offset with findDataLoader");
+  }
 
   const meta = getMetadata(type);
   const query = parseFindQuery(meta, where, opts);

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -244,9 +244,8 @@ function makeOp(cond: ParsedValueFilter<any>, argsIndex: number): [string, numbe
       // FIX
       return [`NOT IN _find.arg${argsIndex}`, 1];
     case "between":
-      // FIX
       const [min, max] = cond.value;
-      return [`NOT IN _find.arg${argsIndex}`, 1];
+      return [`BETWEEN _find.arg${argsIndex} AND _find.arg${argsIndex + 1}`, 2];
     default:
       assertNever(cond);
   }

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -3,16 +3,125 @@ import hash from "object-hash";
 import { isAlias } from "../Aliases";
 import { Entity, isEntity } from "../Entity";
 import { FilterAndSettings } from "../EntityFilter";
+import { opToFn } from "../EntityGraphQLFilter";
 import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager";
+import { getMetadata } from "../EntityMetadata";
+import {
+  ColumnCondition,
+  JoinTable,
+  ParsedExpressionFilter,
+  ParsedFindQuery,
+  ParsedValueFilter,
+  parseFindQuery,
+} from "../QueryParser";
+import { assertNever, cleanSql } from "../utils";
 
 export function findDataLoader<T extends Entity>(
   em: EntityManager,
   type: MaybeAbstractEntityConstructor<T>,
+  filter: FilterAndSettings<T>,
 ): DataLoader<FilterAndSettings<T>, unknown[]> {
+  const { where, ...opts } = filter;
+
+  const meta = getMetadata(type);
+  const query = parseFindQuery(meta, where, opts);
+  stripValues(query);
+  const batchKey = JSON.stringify(query);
+
   return em.getLoader(
     "find",
-    type.name,
-    (queries) => em.driver.find(em, type, queries),
+    batchKey,
+    async (queries) => {
+      // We're guaranteed that these queries all have the same structure
+
+      // WITH data(tag, arg1, arg2) AS (VALUES
+      //   (1, 'a', 'a'),
+      //   (2, 'b', 'b'),
+      //   (3, 'c', 'c')
+      // )
+      // SELECT array_agg(d.tag), a.*
+      // FROM authors a
+      // JOIN data d ON (d.arg1 = a.first_name OR d.arg2 = a.last_name)
+      // group by a.id;
+
+      // Build the list of arg1, arg2, ... strings
+      const args = collectArgs(query);
+
+      // Mash together a SQL query ... maybe eventually we could massage the ParsedFindQuery
+      // to support this by:
+      // - pushing the `array_agg` onto the query.selects
+      // - rewriting the value conditions to use the `em_find` CTE table
+      // - adding a join onto the `em_find` table
+      // Biggest wrinkle is that the join condition is non-trivial; currently the AST is only c1=c2
+      const columns = ["array_agg(_find.tag) as _tags", ...query.selects];
+      const primary = query.tables.find((t) => t.join === "primary")!;
+      const innerJoins = query.tables.filter((t) => t.join === "inner") as JoinTable[];
+      const outerJoins = query.tables.filter((t) => t.join === "outer") as JoinTable[];
+
+      const bindings: any[] = [];
+      queries.forEach((query) => {
+        const { where, ...opts } = query;
+        collectValues(bindings, parseFindQuery(meta, where, opts));
+      });
+
+      let argsIndex = 0;
+
+      // Create the top-level a1.firstName=data.firstName AND a2.lastName=data.lastName
+      const topConditions = [] as string[];
+      query.conditions.forEach((c) => {
+        const [op, argsTaken] = makeOp(c.cond, argsIndex);
+        topConditions.push(`${c.alias}.${c.column} ${op}`);
+        argsIndex += argsTaken;
+      });
+      // Now do any complex conditions
+      query.complexConditions?.forEach((cc) => {
+        // const conditions = [] as string[];
+        // topConditions.push(`(${conditions.join(` ${cc.op} `)})`);
+      });
+
+      // visit(query, { visitCond(c: ColumnCondition) {} });
+
+      const sql = `
+        WITH _find (tag, ${args.map((a) => a.name).join(", ")}) AS (VALUES
+          ${queries
+            .map((_, i) => {
+              // Create each row of the CTE
+              if (i === 0) {
+                // use types for the first row
+                return `(${[`${i}::int`, ...args.map((a) => `?::${a.dbType}`)].join(", ")})`;
+              } else {
+                // we don't need types for the rest of the rows
+                return `(${[i, ...args.map(() => "?")].join(", ")})`;
+              }
+            })
+            .join(", ")}
+        )
+        SELECT ${columns.join(", ")}
+        FROM ${primary.table} as ${primary.alias}
+        ${innerJoins.map((j) => `JOIN ${j.table} ${j.alias} ON ${j.col1} = ${j.col2}`).join(" ")}
+        ${outerJoins.map((j) => `LEFT OUTER JOIN ${j.table} ${j.alias} ON ${j.col1} = ${j.col2}`).join(" ")}
+        JOIN _find ON ${topConditions.join(" AND ")}
+        GROUP BY ${query.selects
+          .filter((s) => !s.includes("CASE"))
+          .filter((s) => !s.includes(" as "))
+          .map((s) => s.replace("*", "id"))
+          .join(", ")};
+      `;
+
+      const rows = await em.driver.executeQuery(em, cleanSql(sql), bindings);
+
+      // Make an empty array for each batched query
+      const results = queries.map(() => [] as any[]);
+      // Then put each row into the tagged query it matched
+      for (const row of rows) {
+        for (const tag of row._tags) {
+          results[tag].push(row);
+        }
+        delete row._tags;
+      }
+
+      return results;
+    },
     // Our filter/order tuple is a complex object, so object-hash it to ensure caching works
     { cacheKeyFn: whereFilterHash },
   );
@@ -32,4 +141,104 @@ function replacer(v: any) {
 
 export function whereFilterHash(where: FilterAndSettings<any>): any {
   return hash(where, { replacer, algorithm: "md5" });
+}
+
+/** Collects & names all the args in a query, i.e. `['arg1', 'arg2']`--not the actual values. */
+function collectArgs(query: ParsedFindQuery): { name: string; dbType: string }[] {
+  const args: { name: string; dbType: string }[] = [];
+  visit(query, {
+    visitCond(c: ColumnCondition) {
+      if ("value" in c.cond) {
+        args.push({ name: `arg${args.length}`, dbType: c.dbType });
+        // between has two values
+        if (c.cond.kind === "between") {
+          args.push({ name: `arg${args.length}`, dbType: c.dbType });
+        }
+      }
+    },
+  });
+  return args;
+}
+
+/** Pushes the arg values of a given query in the cross-query `bindings` array. */
+function collectValues(bindings: any[], query: ParsedFindQuery): void {
+  visit(query, {
+    visitCond(c: ColumnCondition) {
+      if ("value" in c.cond) {
+        // between has two values
+        if (c.cond.kind === "between") {
+          bindings.push(c.cond.value[0]);
+          bindings.push(c.cond.value[1]);
+        } else {
+          bindings.push(c.cond.value);
+        }
+      }
+    },
+  });
+}
+
+/** Replaces all values with `*` so we can see the generic structure of the query. */
+function stripValues(query: ParsedFindQuery): void {
+  visit(query, {
+    visitCond(c: ColumnCondition) {
+      if ("value" in c.cond) {
+        c.cond.value = "*";
+      }
+    },
+  });
+}
+
+/** A generic visitor over the simple & complex conditions of a query. */
+interface Visitor {
+  visitExpFilter?(c: ParsedExpressionFilter): void;
+  visitCond(c: ColumnCondition): void;
+}
+function visit(query: ParsedFindQuery, visitor: Visitor): void {
+  const { visitCond } = visitor;
+  function visitExpFilter(ef: ParsedExpressionFilter) {
+    ef.conditions.forEach((c) => {
+      if ("cond" in c) {
+        visitCond(c);
+      } else {
+        visitExpFilter(c);
+      }
+    });
+  }
+  query.conditions.forEach(visitCond);
+  query.complexConditions?.forEach(visitExpFilter);
+}
+
+function makeOp(cond: ParsedValueFilter<any>, argsIndex: number): [string, number] {
+  switch (cond.kind) {
+    case "eq":
+    case "ne":
+    case "gte":
+    case "gt":
+    case "lte":
+    case "lt":
+    case "like":
+    case "ilike":
+      const fn = opToFn[cond.kind] ?? fail(`Invalid operator ${cond.kind}`);
+      return [`${fn} _find.arg${argsIndex}`, 1];
+    case "is-null":
+      return [`IS NULL`, 0];
+      break;
+    case "not-null":
+      return [`IS NOT NULL`, 0];
+      break;
+    case "in":
+      return [`IN _find.arg${argsIndex}`, 1];
+    case "nin":
+      return [`NOT IN _find.arg${argsIndex}`, 1];
+      break;
+    case "@>":
+      // FIX
+      return [`NOT IN _find.arg${argsIndex}`, 1];
+    case "between":
+      // FIX
+      const [min, max] = cond.value;
+      return [`NOT IN _find.arg${argsIndex}`, 1];
+    default:
+      assertNever(cond);
+  }
 }

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -79,11 +79,9 @@ export function findDataLoader<T extends Entity>(
         .map((s) => s.replace("*", "id"));
 
       const orderBys = query.orderBys || [{ alias: primary.alias, column: "id", order: "ASC" }];
-      if (query.orderBys) {
-        for (const o of query.orderBys) {
-          if (o.alias !== primary.alias) {
-            groupBys.push(`${o.alias}.${o.column}`);
-          }
+      for (const o of orderBys) {
+        if (o.alias !== primary.alias) {
+          groupBys.push(`${o.alias}.${o.column}`);
         }
       }
 

--- a/packages/orm/src/dataloaders/lensDataLoader.ts
+++ b/packages/orm/src/dataloaders/lensDataLoader.ts
@@ -66,8 +66,13 @@ export function lensDataLoader<T extends Entity>(
 
     function maybeAddNotSoftDeleted(other: EntityMetadata<any>, alias: string): void {
       if (other.timestampFields.deletedAt) {
-        const column = other.allFields[other.timestampFields.deletedAt].serde?.columns[0].columnName!;
-        conditions.push({ alias, column, cond: { kind: "is-null" } });
+        const column = other.allFields[other.timestampFields.deletedAt].serde?.columns[0]!;
+        conditions.push({
+          alias,
+          column: column.columnName,
+          dbType: column.dbType,
+          cond: { kind: "is-null" },
+        });
       }
     }
 
@@ -94,6 +99,7 @@ export function lensDataLoader<T extends Entity>(
             conditions.push({
               alias,
               column: "id",
+              dbType: "int",
               cond: { kind: "in", value: deTagIds(source, sourceIds) },
             });
           }
@@ -118,6 +124,7 @@ export function lensDataLoader<T extends Entity>(
             conditions.push({
               alias: lastAlias,
               column: field.serde.columns[0].columnName,
+              dbType: field.serde.columns[0].dbType,
               cond: { kind: "in", value: deTagIds(source, sourceIds) },
             });
             // Need to add filter for soft-deleted...
@@ -148,7 +155,12 @@ export function lensDataLoader<T extends Entity>(
           maybeAddNotSoftDeleted(other, alias);
           if (isLast) {
             selects.push(`"${alias}".id as __source_id`);
-            conditions.push({ alias, column: "id", cond: { kind: "in", value: deTagIds(source, sourceIds) } });
+            conditions.push({
+              alias,
+              column: "id",
+              dbType: "int",
+              cond: { kind: "in", value: deTagIds(source, sourceIds) },
+            });
           }
           resultIsArray = true;
           lastAlias = alias;

--- a/packages/orm/src/dataloaders/lensDataLoader.ts
+++ b/packages/orm/src/dataloaders/lensDataLoader.ts
@@ -99,7 +99,7 @@ export function lensDataLoader<T extends Entity>(
             conditions.push({
               alias,
               column: "id",
-              dbType: "int",
+              dbType: other.idType,
               cond: { kind: "in", value: deTagIds(source, sourceIds) },
             });
           }
@@ -158,7 +158,7 @@ export function lensDataLoader<T extends Entity>(
             conditions.push({
               alias,
               column: "id",
-              dbType: "int",
+              dbType: other.idType,
               cond: { kind: "in", value: deTagIds(source, sourceIds) },
             });
           }

--- a/packages/orm/src/dataloaders/loadDataLoader.ts
+++ b/packages/orm/src/dataloaders/loadDataLoader.ts
@@ -21,7 +21,7 @@ export function loadDataLoader<T extends Entity>(
     const query: ParsedFindQuery = {
       selects: [`"${alias}".*`],
       tables: [{ alias, join: "primary", table: meta.tableName }],
-      conditions: [{ alias, column: "id", cond: { kind: "in", value: keys } }],
+      conditions: [{ alias, column: "id", dbType: "int", cond: { kind: "in", value: keys } }],
       orderBys: [{ alias, column: "id", order: "ASC" }],
     };
 

--- a/packages/orm/src/dataloaders/loadDataLoader.ts
+++ b/packages/orm/src/dataloaders/loadDataLoader.ts
@@ -21,7 +21,7 @@ export function loadDataLoader<T extends Entity>(
     const query: ParsedFindQuery = {
       selects: [`"${alias}".*`],
       tables: [{ alias, join: "primary", table: meta.tableName }],
-      conditions: [{ alias, column: "id", dbType: "int", cond: { kind: "in", value: keys } }],
+      conditions: [{ alias, column: "id", dbType: meta.idType, cond: { kind: "in", value: keys } }],
       orderBys: [{ alias, column: "id", order: "ASC" }],
     };
 

--- a/packages/orm/src/dataloaders/manyToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyDataLoader.ts
@@ -55,7 +55,12 @@ async function load<T extends Entity, U extends Entity>(
         conditions: Object.entries(columns).map(([columnId, values]) => {
           // Pick the right meta i.e. tag_id --> TagMeta or book_id --> BookMeta
           const meta = collection.columnName == columnId ? getMetadata(collection.entity) : collection.otherMeta;
-          return { alias, column: columnId, cond: { kind: "in", value: values.map((id) => keyToNumber(meta, id)!) } };
+          return {
+            alias,
+            column: columnId,
+            dbType: "int",
+            cond: { kind: "in", value: values.map((id) => keyToNumber(meta, id)!) },
+          };
         }),
       },
     ],

--- a/packages/orm/src/dataloaders/manyToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyDataLoader.ts
@@ -58,7 +58,7 @@ async function load<T extends Entity, U extends Entity>(
           return {
             alias,
             column: columnId,
-            dbType: "int",
+            dbType: meta.idType,
             cond: { kind: "in", value: values.map((id) => keyToNumber(meta, id)!) },
           };
         }),

--- a/packages/orm/src/dataloaders/manyToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyFindDataLoader.ts
@@ -46,8 +46,8 @@ async function load<T extends Entity, U extends Entity>(
           return {
             op: "and",
             conditions: [
-              { alias, column: columnOne, cond: { kind: "eq", value: keyToNumber(meta1, idOne) } },
-              { alias, column: columnTwo, cond: { kind: "eq", value: keyToNumber(meta2, idTwo) } },
+              { alias, column: columnOne, dbType: "int", cond: { kind: "eq", value: keyToNumber(meta1, idOne) } },
+              { alias, column: columnTwo, dbType: "int", cond: { kind: "eq", value: keyToNumber(meta2, idTwo) } },
             ],
           };
         }),

--- a/packages/orm/src/dataloaders/manyToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyFindDataLoader.ts
@@ -46,8 +46,18 @@ async function load<T extends Entity, U extends Entity>(
           return {
             op: "and",
             conditions: [
-              { alias, column: columnOne, dbType: "int", cond: { kind: "eq", value: keyToNumber(meta1, idOne) } },
-              { alias, column: columnTwo, dbType: "int", cond: { kind: "eq", value: keyToNumber(meta2, idTwo) } },
+              {
+                alias,
+                column: columnOne,
+                dbType: meta1.idType,
+                cond: { kind: "eq", value: keyToNumber(meta1, idOne) },
+              },
+              {
+                alias,
+                column: columnTwo,
+                dbType: meta2.idType,
+                cond: { kind: "eq", value: keyToNumber(meta2, idTwo) },
+              },
             ],
           };
         }),

--- a/packages/orm/src/dataloaders/oneToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyDataLoader.ts
@@ -29,7 +29,9 @@ export function oneToManyDataLoader<T extends Entity, U extends Entity>(
     const query: ParsedFindQuery = {
       selects: [`"${alias}".*`],
       tables: [{ alias, join: "primary", table: meta.tableName }],
-      conditions: [{ alias, column: collection.otherColumnName, dbType: "int", cond: { kind: "in", value: keys } }],
+      conditions: [
+        { alias, column: collection.otherColumnName, dbType: meta.idType, cond: { kind: "in", value: keys } },
+      ],
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);

--- a/packages/orm/src/dataloaders/oneToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyDataLoader.ts
@@ -29,7 +29,7 @@ export function oneToManyDataLoader<T extends Entity, U extends Entity>(
     const query: ParsedFindQuery = {
       selects: [`"${alias}".*`],
       tables: [{ alias, join: "primary", table: meta.tableName }],
-      conditions: [{ alias, column: collection.otherColumnName, cond: { kind: "in", value: keys } }],
+      conditions: [{ alias, column: collection.otherColumnName, dbType: "int", cond: { kind: "in", value: keys } }],
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);

--- a/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
@@ -40,8 +40,18 @@ export function oneToManyFindDataLoader<T extends Entity, U extends Entity>(
             return {
               op: "and",
               conditions: [
-                { alias, column: columnOne, dbType: "int", cond: { kind: "eq", value: keyToNumber(meta1, idOne) } },
-                { alias, column: columnTwo, dbType: "int", cond: { kind: "eq", value: keyToNumber(meta2, idTwo) } },
+                {
+                  alias,
+                  column: columnOne,
+                  dbType: meta1.idType,
+                  cond: { kind: "eq", value: keyToNumber(meta1, idOne) },
+                },
+                {
+                  alias,
+                  column: columnTwo,
+                  dbType: meta2.idType,
+                  cond: { kind: "eq", value: keyToNumber(meta2, idTwo) },
+                },
               ],
             };
           }),

--- a/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
@@ -40,8 +40,8 @@ export function oneToManyFindDataLoader<T extends Entity, U extends Entity>(
             return {
               op: "and",
               conditions: [
-                { alias, column: columnOne, cond: { kind: "eq", value: keyToNumber(meta1, idOne) } },
-                { alias, column: columnTwo, cond: { kind: "eq", value: keyToNumber(meta2, idTwo) } },
+                { alias, column: columnOne, dbType: "int", cond: { kind: "eq", value: keyToNumber(meta1, idOne) } },
+                { alias, column: columnTwo, dbType: "int", cond: { kind: "eq", value: keyToNumber(meta2, idTwo) } },
               ],
             };
           }),

--- a/packages/orm/src/dataloaders/oneToOneDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToOneDataLoader.ts
@@ -32,7 +32,7 @@ export function oneToOneDataLoader<T extends Entity, U extends Entity>(
     const query: ParsedFindQuery = {
       selects: [`"${alias}".*`],
       tables: [{ alias, join: "primary", table: otherMeta.tableName }],
-      conditions: [{ alias, column: reference.otherColumnName, cond: { kind: "in", value: keys } }],
+      conditions: [{ alias, column: reference.otherColumnName, dbType: "int", cond: { kind: "in", value: keys } }],
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);

--- a/packages/orm/src/dataloaders/oneToOneDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToOneDataLoader.ts
@@ -32,7 +32,9 @@ export function oneToOneDataLoader<T extends Entity, U extends Entity>(
     const query: ParsedFindQuery = {
       selects: [`"${alias}".*`],
       tables: [{ alias, join: "primary", table: otherMeta.tableName }],
-      conditions: [{ alias, column: reference.otherColumnName, dbType: "int", cond: { kind: "in", value: keys } }],
+      conditions: [
+        { alias, column: reference.otherColumnName, dbType: meta.idType, cond: { kind: "in", value: keys } },
+      ],
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);

--- a/packages/orm/src/drivers/Driver.ts
+++ b/packages/orm/src/drivers/Driver.ts
@@ -20,6 +20,9 @@ export interface Driver {
     settings: { limit?: number; offset?: number },
   ): Promise<any[]>;
 
+  /** Executes a raw SQL query with bindings. */
+  executeQuery(em: EntityManager, sql: string, bindings: any[]): Promise<any[]>;
+
   transaction<T>(
     em: EntityManager,
     fn: (txn: Knex.Transaction) => Promise<T>,

--- a/packages/orm/src/drivers/Driver.ts
+++ b/packages/orm/src/drivers/Driver.ts
@@ -1,18 +1,10 @@
 import { Knex } from "knex";
-import { Entity } from "../Entity";
-import { FilterAndSettings } from "../EntityFilter";
-import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager";
+import { EntityManager } from "../EntityManager";
 import { ParsedFindQuery } from "../QueryParser";
 import { JoinRowTodo, Todo } from "../Todo";
 
 /** Isolates all SQL calls that joist needs to make to fetch/save data. */
 export interface Driver {
-  find<T extends Entity>(
-    em: EntityManager,
-    type: MaybeAbstractEntityConstructor<T>,
-    queries: readonly FilterAndSettings<T>[],
-  ): Promise<unknown[][]>;
-
   /** Executes a low-level `ParsedFindQuery` against the database and returns the rows. */
   executeFind(
     em: EntityManager,

--- a/packages/orm/src/drivers/IdAssigner.ts
+++ b/packages/orm/src/drivers/IdAssigner.ts
@@ -17,12 +17,11 @@ export class SequenceIdAssigner implements IdAssigner {
   async assignNewIds(knex: Knex, todos: Record<string, Todo>): Promise<void> {
     const seqStatements: string[] = [];
     Object.values(todos).forEach((todo) => {
-      if (todo.inserts.length > 0) {
-        const meta = todo.metadata;
-        const sequenceName = `${meta.tableName}_id_seq`;
-        const sql = `select nextval('${sequenceName}') from generate_series(1, ${
-          todo.inserts.filter((e) => e.id === undefined).length
-        })`;
+      // Even if we have INSERTs, the user may have already assigned ids...
+      const needsIds = todo.inserts.filter((e) => e.id === undefined);
+      if (needsIds.length > 0) {
+        const sequenceName = `${todo.metadata.tableName}_id_seq`;
+        const sql = `select nextval('${sequenceName}') from generate_series(1, ${needsIds.length})`;
         seqStatements.push(sql);
       }
     });

--- a/packages/orm/src/drivers/InMemoryDriver.ts
+++ b/packages/orm/src/drivers/InMemoryDriver.ts
@@ -79,6 +79,10 @@ export class InMemoryDriver implements Driver {
     throw new Error("Not implemented");
   }
 
+  executeQuery(em: EntityManager<unknown>, sql: string, bindings: any[]): Promise<any[]> {
+    throw new Error("Method not implemented.");
+  }
+
   async assignNewIds(em: EntityManager, todos: Record<string, Todo>): Promise<void> {
     // do our version of assign ids
     Object.entries(todos).forEach(([_, todo]) => {

--- a/packages/orm/src/drivers/InMemoryDriver.ts
+++ b/packages/orm/src/drivers/InMemoryDriver.ts
@@ -1,7 +1,6 @@
 import { Knex } from "knex";
-import { Entity } from "../Entity";
-import { FilterAndSettings, ValueFilter } from "../EntityFilter";
-import { EntityConstructor, entityLimit, EntityManager } from "../EntityManager";
+import { ValueFilter } from "../EntityFilter";
+import { entityLimit, EntityManager } from "../EntityManager";
 import { EntityMetadata, getMetadata } from "../EntityMetadata";
 import { deTagId, keyToNumber, keyToString, maybeResolveReferenceToId } from "../keys";
 import { ParsedFindQuery, parseEntityFilter, parseValueFilter } from "../QueryParser";
@@ -55,21 +54,15 @@ export class InMemoryDriver implements Driver {
     this.data = {};
   }
 
-  async find<T extends Entity>(
-    em: EntityManager,
-    type: EntityConstructor<T>,
-    queries: readonly FilterAndSettings<T>[],
-  ): Promise<unknown[][]> {
-    this.onQuery();
-    return queries.map((query) => {
-      const { where, orderBy, limit, offset = 0 } = query;
-      const meta = getMetadata(type);
-      const allRows = Object.values(this.rowsOfTable(meta.tableName));
-      const matched = allRows.filter((row) => rowMatches(this, meta, row, where));
-      const sorted = !orderBy ? matched : matched.sort((a, b) => sort(this, meta, orderBy as any, a, b));
-      return ensureUnderLimit(sorted.slice(offset, offset + (limit ?? sorted.length)));
-    });
-  }
+  // This is the old Driver.find impl, maybe use for executeFind?
+  // return queries.map((query) => {
+  //   const { where, orderBy, limit, offset = 0 } = query;
+  //   const meta = getMetadata(type);
+  //   const allRows = Object.values(this.rowsOfTable(meta.tableName));
+  //   const matched = allRows.filter((row) => rowMatches(this, meta, row, where));
+  //   const sorted = !orderBy ? matched : matched.sort((a, b) => sort(this, meta, orderBy as any, a, b));
+  //   return ensureUnderLimit(sorted.slice(offset, offset + (limit ?? sorted.length)));
+  // });
 
   async executeFind(
     em: EntityManager,

--- a/packages/orm/src/utils.ts
+++ b/packages/orm/src/utils.ts
@@ -134,3 +134,8 @@ export function mergeNormalizedHints(target: any, source: any): void {
   }
   Object.assign(target, source);
 }
+
+/** Strips new lines/indentation from our `UPDATE` string; doesn't do any actual SQL param escaping/etc. */
+export function cleanSql(sql: string): string {
+  return sql.trim().replace(/\n/g, "").replace(/  +/g, " ");
+}

--- a/packages/orm/src/utils.ts
+++ b/packages/orm/src/utils.ts
@@ -135,7 +135,10 @@ export function mergeNormalizedHints(target: any, source: any): void {
   Object.assign(target, source);
 }
 
+const newLine = /\n/g;
+const doubleSpace = /  +/g;
+
 /** Strips new lines/indentation from our `UPDATE` string; doesn't do any actual SQL param escaping/etc. */
 export function cleanSql(sql: string): string {
-  return sql.trim().replace(/\n/g, "").replace(/  +/g, " ");
+  return sql.trim().replace(newLine, "").replace(doubleSpace, " ");
 }


### PR DESCRIPTION
This PR changes Joist's "auto-batch em.find/SELECT queries" from using UNION ALLs to a CTE of VALUES.

Previously Joist would batch two `em.find`s into a single SQL query that the two potentially random queries (other than being for the same entity) stitched together with a `UNION ALL`:

```sql
  (select *, -1 as __tag, -1 as __row from "authors" where "id" = $1)
  union all (select "a".*, 0 as __tag, row_number() over () as __row from "authors" as "a" where "a"."id" = $2 order by "a"."id" ASC, "a"."id" asc limit $3)
  union all (select "a".*, 1 as __tag, row_number() over () as __row from "authors" as "a" where "a"."id" = $4 order by "a"."age" DESC, "a"."id" asc limit $5) order by "__tag" asc",
```

The `__tag` syntax was used to tell which `em.find` a returned row belonged two, i.e. if we had three `em.find`s in this batch, we'd want to know the 2nd `union all`'s rows should go to the 2nd `em.find`s result set.

This `UNION ALL` approach seemed fine in theory, but resulted in pretty gnarly queries, and indeed in practice we found it didn't scale once N got to ~50 or so. It makes sense that auto-batch 1,000 queries at once is probably a bad idea, but 50 seems reasonable.

One good aspect of the `UNION ALL` approach is that it let each query have its own order by, limit, and offset, because each of those would be applied within each `UNION ALL`.

In the new approach, we don't use `UNION`s, and instead leverage the recent `parseFindQuery` infra to only batch queries by entity (as before) but also by entity + by shape of the query (new to this approach). With this constraint, that all queries in the batch have the same tables + joins + filters, we can more effectively make them "one query", but with the aggregated `WHERE` clause represented as a `JOIN`:

```sql
"WITH _find (tag, arg0) AS (VALUES ($1::int, $2::int), ($3, $4) )
SELECT array_agg(_find.tag) as _tags, "a".*
FROM authors as a
JOIN _find ON a.id = _find.arg0 GROUP BY "a".id
ORDER BY a.first_name DESC LIMIT 10000;",
```

The reason for the CTE of `VALUES` + `JOIN`, instead of just `OR`-ing all of the parameters is that, with `OR`, if a row matches multiple `em.find`s, it will only be returned once; but b/c we've added `tag` as a column to the `VALUES`, and each `em.find` caller gets its own tag, the same row will be returned multiples times (although we `array_agg` the tag to avoid actually returning the row twice), once per time it matched one of the `em.find`s.

Surprisingly enough, operators like `<=` even work in `JOIN` clauses, using a feature called "non-equi joins".

But, if callers want to use limits and offsets, they'll have to use the new `findPaginated`, which will not auto-batch and will N+1 if called in a loop. This should be fine b/c typically `findPaginated` calls would be at the top-most level of an API endpoint/graphql query.

Fixes #441 