### PR TITLE
feat: Add EntityManager-level caching for em.findCount.

### DIFF
--- a/packages/orm/src/dataloaders/findCountDataLoader.ts
+++ b/packages/orm/src/dataloaders/findCountDataLoader.ts
@@ -1,0 +1,35 @@
+import DataLoader from "dataloader";
+import { Entity } from "../Entity";
+import { FilterAndSettings } from "../EntityFilter";
+import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager";
+import { getMetadata } from "../EntityMetadata";
+import { parseFindQuery } from "../QueryParser";
+import { whereFilterHash } from "./findDataLoader";
+
+export function findCountDataLoader<T extends Entity>(
+  em: EntityManager,
+  type: MaybeAbstractEntityConstructor<T>,
+  softDeletes: "include" | "exclude",
+): DataLoader<FilterAndSettings<T>, number> {
+  const batchKey = `${type.name}-${softDeletes}`;
+  return em.getLoader(
+    "find-count",
+    batchKey,
+    async (queries) => {
+      // We don't actually de-N+1 yet, b/c how many counts are you really
+      // going to do in a loop with same-structure-but-different-params?
+      return Promise.all(
+        queries.map(async (filterAndSettings) => {
+          const { where, ...options } = filterAndSettings;
+          const query = parseFindQuery(getMetadata(type), where, options);
+          query.selects = ["count(*) as count"];
+          query.orderBys = [];
+          const rows = await em.driver.executeFind(em, query, {});
+          return Number(rows[0].count);
+        }),
+      );
+    },
+    // Our filter/order tuple is a complex object, so object-hash it to ensure caching works
+    { cacheKeyFn: whereFilterHash },
+  );
+}


### PR DESCRIPTION
Using the dataloader infra even though we're not technically batching the queries together.

Also make "count all" handling cute by adjusting the count up/down based on WIP changes.