### PR TITLE
fix: Fix gatherEntities looping on cycles.

### DIFF
--- a/packages/integration-tests/src/run.test.ts
+++ b/packages/integration-tests/src/run.test.ts
@@ -1,0 +1,13 @@
+import { Context } from "@src/context";
+import { run } from "joist-test-utils";
+
+describe("run", () => {
+  it.withCtx("does not loop with classes", async (ctx) => {
+    class Foo {
+      constructor(private ctx: Context) {}
+    }
+    await run(ctx, () => {
+      return { foo: new Foo(ctx) };
+    });
+  });
+});

--- a/packages/test-utils/src/run.ts
+++ b/packages/test-utils/src/run.ts
@@ -63,7 +63,7 @@ function gatherEntities(result: any): Entity[] {
     return [result];
   } else if (Array.isArray(result)) {
     return result.flatMap(gatherEntities);
-  } else if (result !== null && typeof result === "object") {
+  } else if (result !== null && typeof result === "object" && result?.constructor === Object) {
     return Object.values(result).flatMap(gatherEntities);
   } else {
     return [];


### PR DESCRIPTION
Granted, we're assuming POJOs won't have cycles (vs. a true already visited cache), but that seems fine for now.