### PR TITLE
fix: Support for polys in aliases.

### DIFF
--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -1831,6 +1831,43 @@ describe("EntityManager.queries", () => {
       expect(authors.length).toEqual(1);
     });
 
+    it("can use aliases for polymorphic reference with eq", async () => {
+      await insertAuthor({ first_name: "a" });
+      await insertBook({ title: "t", author_id: 1 });
+      await insertComment({ text: "t1", parent_book_id: 1 });
+      const em = newEntityManager();
+      const c = alias(Comment);
+      const comments = await em.find(
+        Comment,
+        { as: c },
+        {
+          conditions: { or: [c.parent.eq("b:1")] },
+        },
+      );
+      const [comment] = comments;
+      expect(comments.length).toEqual(1);
+      expect(comment.text).toEqual("t1");
+    });
+
+    it("can use aliases for polymorphic reference with in", async () => {
+      await insertAuthor({ first_name: "a" });
+      await insertBook({ title: "t", author_id: 1 });
+      await insertPublisher({ name: "p1" });
+      await insertComment({ text: "t1", parent_book_id: 1 });
+      await insertComment({ text: "t1", parent_publisher_id: 1 });
+      const em = newEntityManager();
+      const c = alias(Comment);
+      const comments = await em.find(
+        Comment,
+        { as: c },
+        {
+          conditions: { or: [c.parent.in(["b:1", "p:1"])] },
+        },
+      );
+      const [comment] = comments;
+      expect(comments.length).toEqual(2);
+    });
+
     it("can use aliases for or with nested and", async () => {
       await insertAuthor({ first_name: "a1" });
       await insertAuthor({ first_name: "a2", age: 30 });

--- a/packages/integration-tests/src/entities/inserts.ts
+++ b/packages/integration-tests/src/entities/inserts.ts
@@ -49,6 +49,7 @@ export function insertComment(row: {
   user_id?: number;
   parent_book_id?: number;
   parent_book_review_id?: number;
+  parent_publisher_id?: number;
 }) {
   return testDriver.insert("comments", row);
 }

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -220,8 +220,7 @@ export function parseFindQuery(
                 cond: mapToDb(column, f),
               });
             } else if (f.kind === "is-null") {
-              // Add a condition for every component
-              // TODO ...should these be anded or ored?
+              // Add a condition for every component--these can be AND-d with the rest of the simple/inline conditions
               field.components.forEach((comp) => {
                 const column = field.serde.columns.find((c) => c.columnName === comp.columnName)!;
                 conditions.push({


### PR DESCRIPTION
Only eq, ne, and in, just as in `em.find` inline conditions.