### PR TITLE
feat: Dedupe em.findOrCreates that are called in a loop.

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -773,6 +773,39 @@ describe("EntityManager", () => {
     await em.findOrCreate(Author, { age: 20 }, { lastName: "l" });
   });
 
+  it("can create with findOrCreate in a loop", async () => {
+    const em = newEntityManager();
+    const [a1, a2] = await Promise.all([
+      em.findOrCreate(Author, { firstName: "a1" }, {}),
+      em.findOrCreate(Author, { firstName: "a1" }, {}),
+    ]);
+    expect(a1).toEqual(a2);
+    expect(a1.isNewEntity).toBe(true);
+  });
+
+  it("can find with findOrCreate in a loop", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    const [a1, a2] = await Promise.all([
+      em.findOrCreate(Author, { firstName: "a1" }, {}),
+      em.findOrCreate(Author, { firstName: "a1" }, {}),
+    ]);
+    expect(a1).toEqual(a2);
+    expect(a1.isNewEntity).toBe(false);
+  });
+
+  it("can upsert with findOrCreate in a loop", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    const [a1, a2] = await Promise.all([
+      em.findOrCreate(Author, { firstName: "a1" }, {}, { lastName: "l1" }),
+      em.findOrCreate(Author, { firstName: "a1" }, {}, { lastName: "l1" }),
+    ]);
+    expect(a1).toEqual(a2);
+    expect(a1.isNewEntity).toBe(false);
+    expect(a1.lastName).toBe("l1");
+  });
+
   it("can find and populate with findOrCreate", async () => {
     await insertAuthor({ first_name: "a1" });
     await insertBook({ title: "b1", author_id: 1 });

--- a/packages/orm/src/dataloaders/findOrCreateDataLoader.ts
+++ b/packages/orm/src/dataloaders/findOrCreateDataLoader.ts
@@ -13,13 +13,13 @@ interface Key<T extends Entity> {
 export function findOrCreateDataLoader<T extends Entity>(
   em: EntityManager,
   type: EntityConstructor<T>,
-  filter: Partial<OptsOf<T>>,
+  where: Partial<OptsOf<T>>,
   softDeletes: "include" | "exclude",
 ): DataLoader<Key<T>, T> {
-  // The findOrCreateDataLoader filter is flat (only opts are allowed), so we can use Object.keys
-  // to get `{ firstName: "a1" }` and `{ firstName: "a2" }` batched to the same dataloader,
+  // The findOrCreateDataLoader `where` is flat (only top-level opts are allowed), so we can use
+  // Object.keys to get `{ firstName: "a1" }` and `{ firstName: "a2" }` batched to the same dataloader,
   // primarily so that we can dedupe `{ firstName: "a1" }` if .load-d twice.
-  const batchKey = `${type.name}-${Object.keys(filter).join("-")}-${softDeletes}`;
+  const batchKey = `${type.name}-${Object.keys(where).join("-")}-${softDeletes}`;
   return em.getLoader<Key<T>, T>(
     "find-or-create",
     batchKey,

--- a/packages/orm/src/dataloaders/findOrCreateDataLoader.ts
+++ b/packages/orm/src/dataloaders/findOrCreateDataLoader.ts
@@ -1,0 +1,51 @@
+import DataLoader from "dataloader";
+import { Entity } from "../Entity";
+import { FilterWithAlias } from "../EntityFilter";
+import { EntityConstructor, EntityManager, OptsOf, TooManyError } from "../EntityManager";
+import { whereFilterHash } from "./findDataLoader";
+
+interface Key<T extends Entity> {
+  where: Partial<OptsOf<T>>;
+  ifNew: OptsOf<T>;
+  upsert: Partial<OptsOf<T>> | undefined;
+}
+
+export function findOrCreateDataLoader<T extends Entity>(
+  em: EntityManager,
+  type: EntityConstructor<T>,
+  filter: Partial<OptsOf<T>>,
+  softDeletes: "include" | "exclude",
+): DataLoader<Key<T>, T> {
+  // The findOrCreateDataLoader filter is flat (only opts are allowed), so we can use Object.keys
+  // to get `{ firstName: "a1" }` and `{ firstName: "a2" }` batched to the same dataloader,
+  // primarily so that we can dedupe `{ firstName: "a1" }` if .load-d twice.
+  const batchKey = `${type.name}-${Object.keys(filter).join("-")}-${softDeletes}`;
+  return em.getLoader<Key<T>, T>(
+    "find-or-create",
+    batchKey,
+    async (keys) => {
+      // Ideally we would check `keys` for the same `where` clause with different
+      // ifNew+upsert combinations, and then blow up/tell the user, because they're
+      // asking for the entity to be created/updated slightly differently.
+      return Promise.all(
+        keys.map(async ({ where, ifNew, upsert }) => {
+          const entities = await em.find(type, where as FilterWithAlias<T>, { softDeletes });
+          let entity: T;
+          if (entities.length > 1) {
+            throw new TooManyError();
+          } else if (entities.length === 1) {
+            entity = entities[0];
+          } else {
+            entity = em.create(type, { ...where, ...(ifNew as object) } as OptsOf<T>);
+          }
+          if (upsert) {
+            entity.set(upsert);
+          }
+          return entity;
+        }),
+      );
+    },
+    // Our filter tuple is a complex object, so object-hash it to ensure caching works
+    { cacheKeyFn: whereFilterHash },
+  );
+}


### PR DESCRIPTION
Previously if em.findOrCreate was called in a loop, and two loop iterations asked to create the same entity, we would create it twice, leading to things like unique constraint failures.

We now use dataloader, not specifically for batching, but just for deduping, as dataloader's cache key will recognize two loop iterations asking for the same promise.

Note that we still expect the 1st `where` parameter to be the same across iterations of the loop, i.e. if one loop does findOrCreate with { firstName: "a1" } but the next loop iteration changes to do findOrCreate { lastName: "a2" } then we're currently not attempting to do anything intelligent for that.

Which should be fine; most loop iterations should use an effectively stable/hard-coded set of conditions (albeit with different values, which is fine).