### PR TITLE
feat: Add Ops AST/EntityWriter for writes

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1297,7 +1297,7 @@ describe("EntityManager", () => {
     // And before we flush, another write changes the entity
     await update("authors", { id: 1, updated_at: "2050-01-01" });
     // When we try to save our changes
-    await expect(em.flush()).rejects.toThrow("Oplock failure for a:1");
+    await expect(em.flush()).rejects.toThrow("Oplock failure for authors rows 1");
   });
 
   describe("sameEntity", () => {

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -4,14 +4,7 @@ import { aliasMgmt, isAlias } from "./Aliases";
 import { Entity, isEntity } from "./Entity";
 import { ExpressionFilter, OrderBy, ValueFilter } from "./EntityFilter";
 import { EntityMetadata } from "./EntityMetadata";
-import {
-  Column,
-  getConstructorFromTaggedId,
-  isDefined,
-  keyToNumber,
-  maybeResolveReferenceToId,
-  needsClassPerTableJoins,
-} from "./index";
+import { Column, getConstructorFromTaggedId, isDefined, keyToNumber, maybeResolveReferenceToId } from "./index";
 import { abbreviation } from "./QueryBuilder";
 import { assertNever, fail, partition } from "./utils";
 
@@ -780,4 +773,8 @@ export function getTables(query: ParsedFindQuery): [PrimaryTable, JoinTable[], J
     }
   }
   return [primary!, innerJoins, outerJoins];
+}
+
+function needsClassPerTableJoins(meta: EntityMetadata<any>): boolean {
+  return meta.subTypes.length > 0 || meta.baseTypes.length > 0;
 }

--- a/packages/orm/src/drivers/EntityWriter.ts
+++ b/packages/orm/src/drivers/EntityWriter.ts
@@ -1,0 +1,171 @@
+import { Entity } from "../Entity";
+import { EntityMetadata, getAllMetas, getBaseAndSelfMetas, getMetadata, PrimitiveField } from "../EntityMetadata";
+import { keyToNumber } from "../keys";
+import { hasSerde } from "../serde";
+import { Todo } from "../Todo";
+
+type Column = { columnName: string; dbType: string };
+export type InsertOp = { tableName: string; columns: Column[]; rows: any[][] };
+export type UpdateOp = { tableName: string; columns: Column[]; rows: any[][]; updatedAt: string | undefined };
+export type DeleteOp = { tableName: string; ids: any[] };
+
+type Ops = { inserts: InsertOp[]; updates: UpdateOp[]; deletes: DeleteOp[] };
+
+/**
+ * Builds AST-ish `Ops` for the inserts/updates/deletes in `todos`.
+ *
+ * This helps decouple the database-specific driver/library from the knowledge
+ * of turning entities into table operations, i.e. so they can be unaware of
+ * complexities like field -> column mapping, oplocks, and class table inheritance.
+ *
+ * We still assume Postgres b/c we assume all ids have been pre-assigned for INSERTs,
+ * and don't do any topological sorting of cross-row FK dependencies.
+ *
+ * But this should let us experiment with knex vs. raw client/etc.
+ */
+export function generateOps(todos: Record<string, Todo>, now: Date): Ops {
+  const ops: Ops = { inserts: [], updates: [], deletes: [] };
+  for (const todo of Object.values(todos)) {
+    const meta = todo.metadata;
+    addInserts(ops, todo);
+    addUpdates(ops, todo, now);
+    addDeletes(ops, todo);
+  }
+  return ops;
+}
+
+function addInserts(ops: Ops, todo: Todo): void {
+  if (todo.inserts.length > 0) {
+    const meta = todo.metadata;
+    if (meta.subTypes.length > 0) {
+      for (const [meta, group] of groupEntitiesByTable(todo.inserts)) {
+        ops.inserts.push(newInsertOp(meta, group));
+      }
+    } else {
+      ops.inserts.push(newInsertOp(meta, todo.inserts));
+    }
+  }
+}
+
+function newInsertOp(meta: EntityMetadata<any>, entities: Entity[]): InsertOp {
+  const columns = Object.values(meta.fields)
+    .filter(hasSerde)
+    .flatMap((f) => f.serde.columns);
+  const rows = collectBindings(entities, columns);
+  return { tableName: meta.tableName, columns, rows };
+}
+
+function addUpdates(ops: Ops, todo: Todo, now: Date): void {
+  if (todo.updates.length > 0) {
+    const meta = todo.metadata;
+    // Maybe this should be done in `em.flush`? Odd to have a side-effect here.
+    maybeBumpUpdatedAt(meta, todo, now);
+    if (meta.subTypes.length > 0) {
+      for (const [meta, group] of groupEntitiesByTable(todo.updates)) {
+        const op = newUpdateOp(meta, todo.updates);
+        if (op) ops.updates.push(op);
+      }
+    } else {
+      const op = newUpdateOp(meta, todo.updates);
+      if (op) ops.updates.push(op);
+    }
+  }
+}
+
+function maybeBumpUpdatedAt(meta: EntityMetadata<any>, todo: Todo, now: Date): void {
+  const { updatedAt } = todo.metadata.timestampFields;
+  if (updatedAt) {
+    todo.updates.forEach((e) => {
+      // Should we just go through a setter?
+      e.__orm.originalData[updatedAt] = e.__orm.data[updatedAt];
+      e.__orm.data[updatedAt] = now;
+    });
+  }
+}
+
+function newUpdateOp(meta: EntityMetadata<any>, entities: Entity[]): UpdateOp | undefined {
+  // We only include changed fields in our `UPDATE`--maybe we could change this
+  // to always use the same fields, to take advantage of Prepared Statements.
+  const changedFields = new Set<string>();
+  for (const entity of entities) {
+    Object.keys(entity.__orm.originalData).forEach((key) => changedFields.add(key));
+  }
+  // Sometimes with derived fields, an instance will be marked as an update, but if the derived field hasn't
+  // actually changed, it'll be a noop, so just short-circuit if it looks like that happened. Unless touched.
+  if (changedFields.size === 0 && !entities.some((e) => e.__orm.isTouched)) {
+    return undefined;
+  }
+
+  const { updatedAt } = meta.timestampFields;
+  const columns: Array<Column & BindingColumn> = Object.values(meta.fields)
+    .filter((f) => changedFields.has(f.fieldName) || f.fieldName === "id" || f.fieldName === updatedAt)
+    .filter(hasSerde)
+    .flatMap((f) => f.serde.columns);
+
+  // If we're using class table inheritance, base/child tables may not have any columns to update
+  if (columns.length === 1) {
+    return undefined;
+  }
+
+  // We already have the bumped updated_at column, but also include the original updated_at for the data CTE
+  if (updatedAt) {
+    columns.push({
+      columnName: "__original_updated_at",
+      dbType: "timestamptz",
+      dbValue: (data, originalData) => originalData[updatedAt],
+    });
+  }
+
+  const rows = collectBindings(entities, columns);
+  const updatedAtColumn = updatedAt
+    ? (meta.fields[updatedAt] as PrimitiveField).serde.columns[0].columnName
+    : undefined;
+  return { tableName: meta.tableName, columns, updatedAt: updatedAtColumn, rows };
+}
+
+function addDeletes(ops: Ops, todo: Todo): void {
+  if (todo.deletes.length > 0) {
+    const meta = todo.metadata;
+    const ids = todo.deletes.map((e) => keyToNumber(meta, e.idTagged!).toString());
+    if (meta.subTypes.length > 0) {
+      getAllMetas(meta).forEach((meta) => {
+        ops.deletes.push({ tableName: meta.tableName, ids });
+      });
+    } else {
+      ops.deletes.push({ tableName: meta.tableName, ids });
+    }
+  }
+}
+
+function groupEntitiesByTable(entities: Entity[]): Array<[EntityMetadata<any>, Entity[]]> {
+  const entitiesByType: Map<EntityMetadata<any>, Entity[]> = new Map();
+  for (const e of entities) {
+    for (const m of getBaseAndSelfMetas(getMetadata(e))) {
+      let list = entitiesByType.get(m);
+      if (!list) {
+        list = [];
+        entitiesByType.set(m, list);
+      }
+      list.push(e);
+    }
+  }
+  return [...entitiesByType.entries()];
+}
+
+// This structurally matches our serde column but adds an originalData
+// param so that the updatedAt psuedo-column can get its original value.
+interface BindingColumn {
+  dbValue(data: any, originalData?: any): any;
+}
+
+function collectBindings(entities: Entity[], columns: BindingColumn[]): any[][] {
+  const rows = [];
+  for (const entity of entities) {
+    const bindings = [];
+    for (const column of columns) {
+      bindings.push(column.dbValue(entity.__orm.data, entity.__orm.originalData) ?? null);
+    }
+    rows.push(bindings);
+  }
+  return rows;
+}

--- a/packages/orm/src/drivers/EntityWriter.ts
+++ b/packages/orm/src/drivers/EntityWriter.ts
@@ -62,7 +62,7 @@ function addUpdates(ops: Ops, todo: Todo, now: Date): void {
     maybeBumpUpdatedAt(meta, todo, now);
     if (meta.subTypes.length > 0) {
       for (const [meta, group] of groupEntitiesByTable(todo.updates)) {
-        const op = newUpdateOp(meta, todo.updates);
+        const op = newUpdateOp(meta, group);
         if (op) ops.updates.push(op);
       }
     } else {

--- a/packages/orm/src/drivers/PostgresDriver.ts
+++ b/packages/orm/src/drivers/PostgresDriver.ts
@@ -4,23 +4,17 @@ import {
   afterTransaction,
   beforeTransaction,
   deTagId,
-  Entity,
   EntityManager,
-  EntityMetadata,
-  getAllMetas,
-  getBaseAndSelfMetas,
   getMetadata,
-  hasSerde,
   keyToNumber,
   maybeResolveReferenceToId,
   ParsedFindQuery,
-  PrimitiveField,
-  tagIds,
 } from "../index";
 import { JoinRowTodo, Todo } from "../Todo";
 import { cleanSql, partition, zeroTo } from "../utils";
 import { buildKnexQuery } from "./buildKnexQuery";
 import { Driver } from "./Driver";
+import { DeleteOp, generateOps, InsertOp, UpdateOp } from "./EntityWriter";
 import { IdAssigner, SequenceIdAssigner } from "./IdAssigner";
 
 let lastNow = new Date();
@@ -97,50 +91,21 @@ export class PostgresDriver implements Driver {
 
   async flushEntities(em: EntityManager, todos: Record<string, Todo>): Promise<void> {
     const knex = this.getMaybeInTxnKnex(em);
-    const now = getNow();
     await this.idAssigner.assignNewIds(knex, todos);
 
-    // Do a 1st pass for INSERTs+UPDATEs so that we avoid DELETEs triggering cascade
-    // behavior that, in conjunction with our trigger-maintained `updated_at`s, causes
-    // our oplocks to fail. See https://github.com/stephenh/joist-ts/issues/591
-    for await (const todo of Object.values(todos)) {
-      const meta = todo.metadata;
-      if (todo.inserts.length > 0) {
-        if (meta.subTypes.length > 0) {
-          await batchInsertPerTable(knex, meta, todo.inserts);
-        } else {
-          await batchInsert(knex, meta, todo.inserts);
-        }
-      }
-      if (todo.updates.length > 0) {
-        const { updatedAt } = todo.metadata.timestampFields;
-        if (updatedAt) {
-          todo.updates.forEach((e) => {
-            // Should we just go through a setter?
-            e.__orm.originalData[updatedAt] = e.__orm.data[updatedAt];
-            e.__orm.data[updatedAt] = now;
-          });
-          if (meta.subTypes.length > 0) {
-            await batchUpdatePerTable(knex, meta, todo.updates);
-          } else {
-            await batchUpdate(knex, meta, todo.updates);
-          }
-        } else {
-          await batchUpdateWithoutUpdatedAt(knex, meta, todo.updates);
-        }
-      }
-    }
+    const now = getNow();
+    const ops = generateOps(todos, now);
 
-    // Now we can issue DELETEs
-    for await (const todo of Object.values(todos)) {
-      if (todo.deletes.length > 0) {
-        const meta = todo.metadata;
-        if (meta.subTypes.length > 0) {
-          await batchDeletePerTable(knex, meta, todo.deletes);
-        } else {
-          await batchDelete(knex, meta, todo.deletes);
-        }
-      }
+    // Do INSERTs+UPDATEs first so that we avoid DELETE cascades invalidating oplocks
+    // See https://github.com/stephenh/joist-ts/issues/591
+    for (const insert of ops.inserts) {
+      await batchInsert(knex, insert);
+    }
+    for (const update of ops.updates) {
+      await batchUpdate(knex, update);
+    }
+    for (const del of ops.deletes) {
+      await batchDelete(knex, del);
     }
   }
 
@@ -201,172 +166,52 @@ export class PostgresDriver implements Driver {
   }
 }
 
-async function batchInsert(knex: Knex, meta: EntityMetadata<any>, entities: Entity[]): Promise<void> {
-  const columns = Object.values(meta.fields)
-    .filter(hasSerde)
-    .flatMap((f) => f.serde.columns);
-
-  // Issue 1 UPDATE statement with N `VALUES (..., ...), (..., ...), ...` clauses
-  // and bindings is each individual value.
-  const bindings = entities.flatMap((entity) => columns.map((c) => c.dbValue(entity.__orm.data) ?? null));
+// Issue 1 INSERT statement with N `VALUES (..., ...), (..., ...), ...`
+function batchInsert(knex: Knex, op: InsertOp): Promise<void> {
+  const { tableName, columns, rows } = op;
   const sql = `
-    INSERT INTO "${meta.tableName}" (${columns.map((c) => `"${c.columnName}"`).join(", ")})
-    VALUES ${entities.map(() => `(${columns.map(() => `?`).join(", ")})`).join(",")}
+    INSERT INTO "${tableName}" (${columns.map((c) => `"${c.columnName}"`).join(", ")})
+    VALUES ${rows.map(() => `(${columns.map(() => `?`).join(", ")})`).join(",")}
   `;
-
-  await knex.raw(cleanSql(sql), bindings);
+  const bindings = rows.flat();
+  return knex.raw(cleanSql(sql), bindings);
 }
 
-/** A version of `batchInsert` that supports table-per-class inheritance. */
-async function batchInsertPerTable(knex: Knex, meta: EntityMetadata<any>, entities: Entity[]): Promise<void> {
-  // Ideally we could do this in parallel
-  for await (const [meta, group] of groupEntitiesByTable(entities)) {
-    await batchInsert(knex, meta, group);
-  }
-}
+// Issue 1 UPDATE statement with N `VALUES (..., ...), (..., ...), ...`
+async function batchUpdate(knex: Knex, op: UpdateOp): Promise<void> {
+  const { tableName, columns, rows, updatedAt } = op;
 
-async function batchUpdate(knex: Knex, meta: EntityMetadata<any>, entities: Entity[]): Promise<void> {
-  const { updatedAt } = meta.timestampFields;
-  if (!updatedAt) throw new Error("This batchUpdate expects updatedAt");
+  const cte = buildValuesCte("data", columns, rows);
 
-  // Get the unique set of fields that are changed across all the entities (of this type) we want to bulk update
-  const changedFields = new Set<string>(["id", updatedAt]);
-  entities.forEach((entity) => {
-    Object.keys(entity.__orm.originalData).forEach((key) => changedFields.add(key));
-  });
-
-  // Sometimes with derived fields, an instance will be marked as an update, but if the derived field hasn't changed,
-  // it'll be a noop, so just short-circuit if it looks like that happened, i.e. we have no changed fields.
-  // (unless one of the entities was `EntityManager.touch`-d, which seems force the save / updatedAt tick.)
-  if (changedFields.size === 2 && !entities.some((e) => e.__orm.isTouched)) {
-    return;
-  }
-
-  const columns = Object.values(meta.fields)
-    .filter((f) => changedFields.has(f.fieldName))
-    .filter(hasSerde)
-    .flatMap((f) => f.serde.columns);
-  const updatedAtField = (meta.fields[updatedAt] as PrimitiveField).serde.columns[0].columnName;
-
-  // If we're updating class table inheritance, we might not actually have any columns to update
-  if (columns.length === 1) {
-    return;
-  }
-
-  // Issue 1 UPDATE statement with N `VALUES (..., ...), (..., ...), ...` clauses
-  // and bindings is each individual value.
-  const bindings = entities.flatMap((entity) => [
-    ...columns.map((c) => c.dbValue(entity.__orm.data) ?? null),
-    entity.__orm.originalData[updatedAt],
-  ]);
-
-  const cte = buildValuesCte(
-    "data",
-    [...columns, { columnName: "original_updated_at", dbType: "timestamptz" }],
-    entities,
-  );
-
-  const sql = `
-      ${cte}
-      UPDATE "${meta.tableName}"
-      SET ${columns
-        .filter((c) => c.columnName !== "id")
-        .map((c) => `"${c.columnName}" = data."${c.columnName}"`)
-        .join(", ")}
-      FROM data
-      WHERE
-        "${meta.tableName}".id = data.id
-        AND date_trunc('milliseconds', "${meta.tableName}".${updatedAtField}) = data.original_updated_at
-      RETURNING "${meta.tableName}".id
-   `;
-
-  const result = await knex.raw(cleanSql(sql), bindings);
-  if (result.rows.length !== entities.length) {
-    const updated = new Set(result.rows.map((r: any) => r.id));
-    const missing = entities.map((e) => e.idOrFail).filter((id) => !updated.has(id));
-    throw new Error(`Oplock failure for ${tagIds(meta, missing).join(", ")}`);
-  }
-}
-
-async function batchUpdateWithoutUpdatedAt(knex: Knex, meta: EntityMetadata<any>, entities: Entity[]): Promise<void> {
-  // Get the unique set of fields that are changed across the entities (of this type) we want to bulk update
-  const changedFields = new Set<string>(["id"]);
-  entities.forEach((entity) => {
-    Object.keys(entity.__orm.originalData).forEach((key) => changedFields.add(key));
-  });
-
-  // Sometimes with derived fields, an instance will be marked as an update, but if the derived field hasn't changed,
-  // it'll be a noop, so just short-circuit if it looks like that happened, i.e. we have no changed fields.
-  // (unless one of the entities was `EntityManager.touch`-d, which seems force the save / updatedAt tick.)
-  if (changedFields.size === 1 && !entities.some((e) => e.__orm.isTouched)) {
-    return;
-  }
-
-  const columns = Object.values(meta.fields)
-    .filter((f) => changedFields.has(f.fieldName))
-    .filter(hasSerde)
-    .flatMap((f) => f.serde.columns);
-
-  // If we're updating class table inheritance, we might not actually have any columns to update
-  if (columns.length === 1) {
-    return;
-  }
-
-  // Issue 1 UPDATE statement with N `VALUES (..., ...), (..., ...), ...` clauses
-  // and bindings is each individual value.
-  const bindings = entities.flatMap((entity) => columns.map((c) => c.dbValue(entity.__orm.data) ?? null));
-
-  const cte = buildValuesCte("data", columns, entities);
+  const maybeUpdatedAt = updatedAt
+    ? ` AND date_trunc('milliseconds', "${tableName}".${updatedAt!}) = data.__original_updated_at`
+    : "";
 
   const sql = `
     ${cte}
-    UPDATE "${meta.tableName}"
+    UPDATE "${tableName}"
     SET ${columns
-      .filter((c) => c.columnName !== "id")
+      .filter((c) => c.columnName !== "id" && c.columnName !== "__original_updated_at")
       .map((c) => `"${c.columnName}" = data."${c.columnName}"`)
       .join(", ")}
     FROM data
-    WHERE
-      "${meta.tableName}".id = data.id
-    RETURNING "${meta.tableName}".id
+    WHERE "${tableName}".id = data.id ${maybeUpdatedAt}
+    RETURNING "${tableName}".id
   `;
-  await knex.raw(cleanSql(sql), bindings);
-}
 
-/** Groups table-per-class entities by table and then calls `batchUpdate` for each table. */
-async function batchUpdatePerTable(knex: Knex, meta: EntityMetadata<any>, entities: Entity[]): Promise<void> {
-  let first = true;
-  // Ideally we could do this in parallel
-  for await (const [meta, group] of groupEntitiesByTable(entities)) {
-    if (first) {
-      await batchUpdate(knex, meta, group);
-      first = false;
-    } else {
-      await batchUpdateWithoutUpdatedAt(knex, meta, group);
-    }
+  const bindings = rows.flat();
+  const result = await knex.raw(cleanSql(sql), bindings);
+
+  if (result.rows.length !== rows.length) {
+    const updated = new Set(result.rows.map((r: any) => r.id));
+    const missing = rows.map((r) => r[0]).filter((id) => !updated.has(id));
+    throw new Error(`Oplock failure for ${tableName} rows ${missing.join(", ")}`);
   }
 }
 
-async function batchDelete(knex: Knex, meta: EntityMetadata<any>, entities: Entity[]): Promise<void> {
-  await knex(meta.tableName)
-    .del()
-    .whereIn(
-      "id",
-      entities.map((e) => keyToNumber(meta, e.idTagged!).toString()),
-    );
-}
-
-async function batchDeletePerTable(knex: Knex, meta: EntityMetadata<any>, entities: Entity[]): Promise<void> {
-  await Promise.all(
-    getAllMetas(meta).map((meta) =>
-      knex(meta.tableName)
-        .del()
-        .whereIn(
-          "id",
-          entities.map((e) => keyToNumber(meta, e.idTagged!).toString()),
-        ),
-    ),
-  );
+async function batchDelete(knex: Knex, op: DeleteOp): Promise<void> {
+  const { tableName, ids } = op;
+  await knex(tableName).del().whereIn("id", ids);
 }
 
 function getNow(): Date {
@@ -381,23 +226,4 @@ function getNow(): Date {
   }
   lastNow = now;
   return now;
-}
-
-function groupEntitiesByTable(entities: Entity[]): Array<[EntityMetadata<any>, Entity[]]> {
-  const entitiesByType: Map<EntityMetadata<any>, Entity[]> = new Map();
-  for (const e of entities) {
-    for (const m of getBaseAndSelfMetas(getMetadata(e))) {
-      let list = entitiesByType.get(m);
-      if (!list) {
-        list = [];
-        entitiesByType.set(m, list);
-      }
-      list.push(e);
-    }
-  }
-  return [...entitiesByType.entries()];
-}
-
-export function needsClassPerTableJoins(meta: EntityMetadata<any>): boolean {
-  return meta.subTypes.length > 0 || meta.baseTypes.length > 0;
 }


### PR DESCRIPTION
This provides the same decoupling from Knex that the QueryParser did for finds.