### PR TITLE
fix: Add support namespaced packages within config imports

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -720,6 +720,5 @@ function superstructType(s: string): Import {
 }
 
 function userFieldTypeType(s: string): Import {
-  const [symbol, ...path] = s.split("@");
-  return Import.from(`${symbol}@${path.join('@')}`);
+  return Import.from(s);
 }

--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -715,11 +715,11 @@ function isPgEnum(c: Column): boolean {
 
 function superstructType(s: string): Import {
   // Assume it's `foo@...`, turn it into `Foo@...`
-  const [symbol, path] = s.split("@");
-  return Import.from(`${pascalCase(symbol)}@${path}`);
+  const [symbol, ...path] = s.split("@");
+  return Import.from(`${pascalCase(symbol)}@${path.join('@')}`);
 }
 
 function userFieldTypeType(s: string): Import {
-  const [symbol, path] = s.split("@");
-  return Import.from(`${symbol}@${path}`);
+  const [symbol, ...path] = s.split("@");
+  return Import.from(`${symbol}@${path.join('@')}`);
 }


### PR DESCRIPTION
~~I've noticed this isn't supported downstream in ts-poet. I'll leave this as a draft revisit this once I've had a look at that. This is assuming a double `@@` is the way to go.~~

----
As mentioned in #676, the import logic of `superstructType` and `userFieldTypeType` splits on `@` and uses the first two parts. This causes issues when importing from a namespaced package.

```json
{ "fields": { "address": { "superstruct": "address@@company/common" } } }
```

results in the reconstructed import passed to ts-poet `address@`.

This PR rests all of the following parts and joins them back up with an `@`.

