### PR TITLE
fix: Allow m2os to be used in filters. Fixes #680.

### DIFF
--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -492,6 +492,18 @@ describe("EntityManager.queries", () => {
     });
   });
 
+  it("can find by foreign key with a m2o reference", async () => {
+    await insertPublisher({ id: 1, name: "p1" });
+    await insertAuthor({ id: 1, first_name: "a1", publisher_id: 1 });
+    await insertAuthor({ id: 2, first_name: "a2", publisher_id: 1 });
+
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "a:1");
+    const where = { publisher: a1.publisher } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
+    expect(authors.length).toEqual(2);
+  });
+
   it("can find by foreign key is tagged flavor", async () => {
     await insertPublisher({ id: 1, name: "p1" });
     await insertAuthor({ id: 2, first_name: "a1" });

--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -31,9 +31,12 @@ export type EntityFilter<T extends Entity, I = IdOf<T>, F = FilterOf<T>, N = nev
   | T[]
   | I
   | I[]
+  // Note that this is a weak type (all optional keys) but TS still enforces at least one overlap
   | ({ as?: Alias<T> } & F)
-  | N
+  // Always allow `undefined` for condition pruning
   | undefined
+  // But only allow `null` for `nullable` relations
+  | N
   | { ne: T | I | N | undefined }
   | Alias<T>;
 
@@ -45,7 +48,12 @@ export type UniqueFilter<T extends Entity> = {
   [K in keyof FieldsOf<T> & keyof FilterOf<T> as FieldsOf<T>[K] extends { unique: true } ? K : never]?: FilterOf<T>[K];
 };
 
-/** Filters against a specific field's values within `em.find` inline conditions. */
+/**
+ * Filters against a specific field's values within `em.find` inline conditions.
+ *
+ * We always allow `undefined` to support condition pruning, but only conditionally
+ * allow `null` if the column is actually nullable.
+ */
 export type ValueFilter<V, N> =
   | V
   | V[]


### PR DESCRIPTION
I think personally I would prefer not allowing relations to be used in find filters, however b/c ManyToOneReference.id makes it structurally match the EntityFilter, it seems hard/not worth the complexity to prevent the ManyToOneReference in the EntityFilter mapped type as a compile error (which would be ideal imo).

So instead just suppose m2os by calling `.id`.