### PR TITLE
fix: jsonb top level array

### DIFF
--- a/packages/codegen/src/generateMetadataFile.ts
+++ b/packages/codegen/src/generateMetadataFile.ts
@@ -11,6 +11,7 @@ import {
   PolymorphicKeySerde,
   PrimitiveSerde,
   SuperstructSerde,
+  JsonSerde
 } from "./symbols";
 import { q } from "./utils";
 
@@ -70,6 +71,7 @@ function generateFields(config: Config, dbMetadata: EntityDbMetadata): Record<st
       ? code`new ${SuperstructSerde}("${fieldName}", "${columnName}", ${superstruct})`
       : columnType === "numeric"
       ? code`new ${DecimalToNumberSerde}("${fieldName}", "${columnName}")`
+      : columnType === 'jsonb' ? code`new ${JsonSerde}("${fieldName}", "${columnName}", ${superstruct})`
       : code`new ${PrimitiveSerde}("${fieldName}", "${columnName}", "${columnType}")`;
     fields[fieldName] = code`
       {

--- a/packages/codegen/src/symbols.ts
+++ b/packages/codegen/src/symbols.ts
@@ -23,6 +23,7 @@ export const EnumFieldSerde = imp("EnumFieldSerde@joist-orm");
 export const EnumArrayFieldSerde = imp("EnumArrayFieldSerde@joist-orm");
 export const PolymorphicKeySerde = imp("PolymorphicKeySerde@joist-orm");
 export const PrimitiveSerde = imp("PrimitiveSerde@joist-orm");
+export const JsonSerde = imp("JsonSerde@joist-orm");
 export const SuperstructSerde = imp("SuperstructSerde@joist-orm");
 export const DecimalToNumberSerde = imp("DecimalToNumberSerde@joist-orm");
 export const fail = imp("fail@joist-orm");

--- a/packages/integration-tests/joist-config.json
+++ b/packages/integration-tests/joist-config.json
@@ -14,6 +14,7 @@
         "initials": { "derived": "sync" },
         "numberOfBooks": { "derived": "async" },
         "numberOfPublicReviews": { "derived": "async" },
+        "quotes": { "superstruct": "quotes@src/entities/types" },
         "wasEverPopular": { "protected": true }
       },
       "relations": { "books": { "orderBy": "order" } },

--- a/packages/integration-tests/migrations/1580658856631_author.ts
+++ b/packages/integration-tests/migrations/1580658856631_author.ts
@@ -99,6 +99,7 @@ export function up(b: MigrationBuilder): void {
     mentor_id: foreignKey("authors", { notNull: false }),
     // for testing jsbon columns
     address: { type: "jsonb", notNull: false },
+    quotes: { type: "jsonb", notNull: false },
     deleted_at: { type: "timestamptz", notNull: false },
     // for testing derived fields using other derived fields
     number_of_public_reviews: { type: "int", notNull: false },

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1289,6 +1289,22 @@ describe("EntityManager", () => {
       expect(a.address).toEqual({ street: "123 Main" });
     });
 
+    it("can save array values", async () => {
+      const em = newEntityManager();
+      new Author(em, { firstName: "a1", quotes: ['incredible', 'funny', 'seminal'] });
+      await em.flush();
+      const rows = await select("authors");
+      expect(rows.length).toEqual(1);
+      expect(rows[0].quotes).toEqual(['incredible', 'funny', 'seminal']);
+    });
+
+    it("can read array values", async () => {
+      await insertAuthor({ first_name: "f", quotes: JSON.stringify(['incredible', 'funny', 'seminal']) });
+      const em = newEntityManager();
+      const a = await em.load(Author, "a:1");
+      expect(a.quotes).toEqual(['incredible', 'funny', 'seminal']);
+    });
+
     it("rejects saving invalid values", async () => {
       const em = newEntityManager();
       expect(() => {

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1027,6 +1027,7 @@ describe("EntityManager", () => {
       numberOfBooks: null,
       numberOfPublicReviews: null,
       publisher: "p:1",
+      quotes: null,
       ssn: null,
       updatedAt: expect.anything(),
       wasEverPopular: null,

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -37,7 +37,7 @@ import {
   ValueGraphQLFilter,
 } from "joist-orm";
 import { Context } from "src/context";
-import { Address, address } from "src/entities/types";
+import { Address, address, Quotes, quotes } from "src/entities/types";
 import { assert } from "superstruct";
 import {
   Author,
@@ -85,6 +85,7 @@ export interface AuthorFields {
   graduated: { kind: "primitive"; type: Date; unique: false; nullable: undefined };
   wasEverPopular: { kind: "primitive"; type: boolean; unique: false; nullable: undefined };
   address: { kind: "primitive"; type: Address; unique: false; nullable: undefined };
+  quotes: { kind: "primitive"; type: Quotes; unique: false; nullable: undefined };
   deletedAt: { kind: "primitive"; type: Date; unique: false; nullable: undefined };
   numberOfPublicReviews: { kind: "primitive"; type: number; unique: false; nullable: undefined };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never };
@@ -106,6 +107,7 @@ export interface AuthorOpts {
   graduated?: Date | null;
   wasEverPopular?: boolean | null;
   address?: Address | null;
+  quotes?: Quotes | null;
   deletedAt?: Date | null;
   favoriteColors?: Color[];
   favoriteShape?: FavoriteShape | null;
@@ -145,6 +147,7 @@ export interface AuthorFilter {
   graduated?: ValueFilter<Date, null>;
   wasEverPopular?: BooleanFilter<null>;
   address?: ValueFilter<Address, null>;
+  quotes?: ValueFilter<Quotes, null>;
   deletedAt?: ValueFilter<Date, null>;
   numberOfPublicReviews?: ValueFilter<number, null>;
   createdAt?: ValueFilter<Date, never>;
@@ -176,6 +179,7 @@ export interface AuthorGraphQLFilter {
   graduated?: ValueGraphQLFilter<Date>;
   wasEverPopular?: BooleanGraphQLFilter;
   address?: ValueGraphQLFilter<Address>;
+  quotes?: ValueGraphQLFilter<Quotes>;
   deletedAt?: ValueGraphQLFilter<Date>;
   numberOfPublicReviews?: ValueGraphQLFilter<number>;
   createdAt?: ValueGraphQLFilter<Date>;
@@ -207,6 +211,7 @@ export interface AuthorOrder {
   graduated?: OrderBy;
   wasEverPopular?: OrderBy;
   address?: OrderBy;
+  quotes?: OrderBy;
   deletedAt?: OrderBy;
   numberOfPublicReviews?: OrderBy;
   createdAt?: OrderBy;
@@ -379,6 +384,17 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
       assert(_address, address);
     }
     setField(this, "address", _address);
+  }
+
+  get quotes(): Quotes | undefined {
+    return this.__orm.data["quotes"];
+  }
+
+  set quotes(_quotes: Quotes | undefined) {
+    if (_quotes) {
+      assert(_quotes, quotes);
+    }
+    setField(this, "quotes", _quotes);
   }
 
   get deletedAt(): Date | undefined {

--- a/packages/integration-tests/src/entities/inserts.ts
+++ b/packages/integration-tests/src/entities/inserts.ts
@@ -32,6 +32,7 @@ export function insertAuthor(row: {
   favorite_colors?: number[];
   favorite_shape?: string;
   address?: object;
+  quotes?: string;
   graduated?: any;
   updated_at?: any;
   deleted_at?: any;

--- a/packages/integration-tests/src/entities/metadata.ts
+++ b/packages/integration-tests/src/entities/metadata.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, configureMetadata, DecimalToNumberSerde, EntityManager as EntityManager1, EntityMetadata, EnumArrayFieldSerde, EnumFieldSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde } from "joist-orm";
 import { Context } from "src/context";
-import { address } from "src/entities/types";
+import { address, quotes } from "src/entities/types";
 import {
   AdvanceStatuses,
   Author,
@@ -81,6 +81,7 @@ export const authorMeta: EntityMetadata<Author> = {
     "graduated": { kind: "primitive", fieldName: "graduated", fieldIdName: undefined, derived: false, required: false, protected: false, type: "Date", serde: new PrimitiveSerde("graduated", "graduated", "date"), immutable: false },
     "wasEverPopular": { kind: "primitive", fieldName: "wasEverPopular", fieldIdName: undefined, derived: false, required: false, protected: true, type: "boolean", serde: new PrimitiveSerde("wasEverPopular", "was_ever_popular", "boolean"), immutable: false },
     "address": { kind: "primitive", fieldName: "address", fieldIdName: undefined, derived: false, required: false, protected: false, type: "Object", serde: new SuperstructSerde("address", "address", address), immutable: false },
+    "quotes": { kind: "primitive", fieldName: "quotes", fieldIdName: undefined, derived: false, required: false, protected: false, type: "Object", serde: new SuperstructSerde("quotes", "quotes", quotes), immutable: false },
     "deletedAt": { kind: "primitive", fieldName: "deletedAt", fieldIdName: undefined, derived: false, required: false, protected: false, type: "Date", serde: new PrimitiveSerde("deletedAt", "deleted_at", "timestamp with time zone"), immutable: false },
     "numberOfPublicReviews": { kind: "primitive", fieldName: "numberOfPublicReviews", fieldIdName: undefined, derived: "async", required: false, protected: false, type: "number", serde: new PrimitiveSerde("numberOfPublicReviews", "number_of_public_reviews", "int"), immutable: false },
     "createdAt": { kind: "primitive", fieldName: "createdAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("createdAt", "created_at", "timestamp with time zone"), immutable: false },

--- a/packages/integration-tests/src/entities/types.ts
+++ b/packages/integration-tests/src/entities/types.ts
@@ -1,9 +1,12 @@
-import { Infer, object, string } from "superstruct";
+import {array, Infer, object, string} from "superstruct";
 
 export type Address = Infer<typeof address>;
+export type Quotes = Infer<typeof quotes>;
 
 export const address = object({
   street: string(),
 });
+
+export const quotes = array(string());
 
 export type IpAddress = string & { __type: "IpAddress" };

--- a/packages/orm/src/serde.ts
+++ b/packages/orm/src/serde.ts
@@ -216,8 +216,27 @@ export class SuperstructSerde implements FieldSerde {
   }
 
   dbValue(data: any) {
-    // assume the data is already valid b/c it came from the entity
-    return Array.isArray(data[this.fieldName]) ? JSON.stringify(data[this.fieldName]) : data[this.fieldName];
+    return JSON.stringify(data[this.fieldName])
+  }
+
+  mapToDb(value: any) {
+    return JSON.stringify(value);
+  }
+}
+
+export class JsonSerde implements FieldSerde {
+  dbType = "jsonb";
+  isArray = false;
+  columns = [this];
+
+  constructor(private fieldName: string, public columnName: string) {}
+
+  setOnEntity(data: any, row: any): void {
+    data[this.fieldName] = maybeNullToUndefined(row[this.columnName]);;
+  }
+
+  dbValue(data: any) {
+    return JSON.stringify(data[this.fieldName])
   }
 
   mapToDb(value: any) {

--- a/packages/orm/src/serde.ts
+++ b/packages/orm/src/serde.ts
@@ -217,10 +217,10 @@ export class SuperstructSerde implements FieldSerde {
 
   dbValue(data: any) {
     // assume the data is already valid b/c it came from the entity
-    return data[this.fieldName];
+    return Array.isArray(data[this.fieldName]) ? JSON.stringify(data[this.fieldName]) : data[this.fieldName];
   }
 
   mapToDb(value: any) {
-    return value;
+    return JSON.stringify(value);
   }
 }


### PR DESCRIPTION
As discussed in #684, stringifies within SuperstructSerde and a newly introduced JsonSerde.

Will see how this behaves in ~~GHA~~ circleci, but locally I'm getting

```
● EntityManager › findOrCreate resolves dups with different where clauses in a loop

     expect(received).toBe(expected) // Object.is equality

     Expected: "C"
     Received: "B"

       891 |     expect(a1).toEqual(a2);
       892 |     // And the last upsert wins
     > 893 |     expect(a1.lastName).toBe("C");
           |                         ^
       894 |   });
       895 |
       896 |   it("can find and populate with findOrCreate", async () => {

       at Object.toBe (src/EntityManager.test.ts:893:25)
```

which is curious because I'm not sure where my changes are coming in to play here.