### PR TITLE
fix: JsonSerde args within codegen

### DIFF
--- a/packages/codegen/src/generateMetadataFile.ts
+++ b/packages/codegen/src/generateMetadataFile.ts
@@ -71,7 +71,7 @@ function generateFields(config: Config, dbMetadata: EntityDbMetadata): Record<st
       ? code`new ${SuperstructSerde}("${fieldName}", "${columnName}", ${superstruct})`
       : columnType === "numeric"
       ? code`new ${DecimalToNumberSerde}("${fieldName}", "${columnName}")`
-      : columnType === 'jsonb' ? code`new ${JsonSerde}("${fieldName}", "${columnName}", ${superstruct})`
+      : columnType === 'jsonb' ? code`new ${JsonSerde}("${fieldName}", "${columnName}")`
       : code`new ${PrimitiveSerde}("${fieldName}", "${columnName}", "${columnType}")`;
     fields[fieldName] = code`
       {

--- a/packages/integration-tests/migrations/1580658856631_author.ts
+++ b/packages/integration-tests/migrations/1580658856631_author.ts
@@ -225,6 +225,7 @@ export function up(b: MigrationBuilder): void {
     bigserial: { type: "bigserial", notNull: true },
     doublePrecision: { type: "double precision", notNull: true },
     nullable_text: { type: "text", notNull: false },
+    json: { type: "jsonb", notNull: false },
   });
 
   // for testing ignore of m2m

--- a/packages/integration-tests/src/entities/AuthorStatCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorStatCodegen.ts
@@ -40,6 +40,7 @@ export interface AuthorStatFields {
   bigserial: { kind: "primitive"; type: number; unique: false; nullable: never };
   doublePrecision: { kind: "primitive"; type: number; unique: false; nullable: never };
   nullableText: { kind: "primitive"; type: string; unique: false; nullable: undefined };
+  json: { kind: "primitive"; type: Object; unique: false; nullable: undefined };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never };
 }
@@ -56,6 +57,7 @@ export interface AuthorStatOpts {
   bigserial: number;
   doublePrecision: number;
   nullableText?: string | null;
+  json?: Object | null;
 }
 
 export interface AuthorStatIdsOpts {
@@ -74,6 +76,7 @@ export interface AuthorStatFilter {
   bigserial?: ValueFilter<number, never>;
   doublePrecision?: ValueFilter<number, never>;
   nullableText?: ValueFilter<string, null>;
+  json?: ValueFilter<Object, null>;
   createdAt?: ValueFilter<Date, never>;
   updatedAt?: ValueFilter<Date, never>;
 }
@@ -91,6 +94,7 @@ export interface AuthorStatGraphQLFilter {
   bigserial?: ValueGraphQLFilter<number>;
   doublePrecision?: ValueGraphQLFilter<number>;
   nullableText?: ValueGraphQLFilter<string>;
+  json?: ValueGraphQLFilter<Object>;
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
 }
@@ -108,6 +112,7 @@ export interface AuthorStatOrder {
   bigserial?: OrderBy;
   doublePrecision?: OrderBy;
   nullableText?: OrderBy;
+  json?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
 }
@@ -248,6 +253,14 @@ export abstract class AuthorStatCodegen extends BaseEntity<EntityManager> {
 
   set nullableText(nullableText: string | undefined) {
     setField(this, "nullableText", nullableText);
+  }
+
+  get json(): Object | undefined {
+    return this.__orm.data["json"];
+  }
+
+  set json(json: Object | undefined) {
+    setField(this, "json", json);
   }
 
   get createdAt(): Date {

--- a/packages/integration-tests/src/entities/metadata.ts
+++ b/packages/integration-tests/src/entities/metadata.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, configureMetadata, DecimalToNumberSerde, EntityManager as EntityManager1, EntityMetadata, EnumArrayFieldSerde, EnumFieldSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde } from "joist-orm";
+import { BaseEntity, configureMetadata, DecimalToNumberSerde, EntityManager as EntityManager1, EntityMetadata, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde } from "joist-orm";
 import { Context } from "src/context";
 import { address, quotes } from "src/entities/types";
 import {
@@ -131,6 +131,7 @@ export const authorStatMeta: EntityMetadata<AuthorStat> = {
     "bigserial": { kind: "primitive", fieldName: "bigserial", fieldIdName: undefined, derived: false, required: true, protected: false, type: "number", serde: new PrimitiveSerde("bigserial", "bigserial", "bigint"), immutable: false },
     "doublePrecision": { kind: "primitive", fieldName: "doublePrecision", fieldIdName: undefined, derived: false, required: true, protected: false, type: "number", serde: new PrimitiveSerde("doublePrecision", "double_precision", "double precision"), immutable: false },
     "nullableText": { kind: "primitive", fieldName: "nullableText", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PrimitiveSerde("nullableText", "nullable_text", "text"), immutable: false },
+    "json": { kind: "primitive", fieldName: "json", fieldIdName: undefined, derived: false, required: false, protected: false, type: "Object", serde: new JsonSerde("json", "json"), immutable: false },
     "createdAt": { kind: "primitive", fieldName: "createdAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("createdAt", "created_at", "timestamp with time zone"), immutable: false },
     "updatedAt": { kind: "primitive", fieldName: "updatedAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("updatedAt", "updated_at", "timestamp with time zone"), immutable: false },
   },


### PR DESCRIPTION
I introduced an issue within #685 passing the wrong amount of args in to JsonSerde in the codegen, resulting in ts issues in any generated `metadata.ts` for any jsonb columns with no `superstruct` config.

There are no usages of non-superstruct'd json within the integration tests as far as I could tell, which would have caught this, so I've added in a json column to `author_stats` which looked like a good place for this, but let me know!

Sorry about that!