### PR TITLE
fix: add toJSON to ValidationErrors

### DIFF
--- a/packages/integration-tests/src/rules.test.ts
+++ b/packages/integration-tests/src/rules.test.ts
@@ -2,6 +2,6 @@ import { ValidationErrors } from "joist-orm";
 
 describe("ValidationErrors", () => {
   it("serialises even with prototype lost", () => {
-    expect(JSON.stringify({ ...new ValidationErrors("example") })).toEqual(`"<ValidationErrors> example"`);
+    expect(JSON.stringify({ ...new ValidationErrors("example") })).toEqual(`"ValidationErrors: example"`);
   });
 });

--- a/packages/integration-tests/src/rules.test.ts
+++ b/packages/integration-tests/src/rules.test.ts
@@ -1,0 +1,7 @@
+import { ValidationErrors } from "joist-orm";
+
+describe("ValidationErrors", () => {
+  it("serialises even with prototype lost", () => {
+    expect(JSON.stringify({ ...new ValidationErrors("example") })).toEqual(`"<ValidationErrors> example"`);
+  });
+});

--- a/packages/orm/src/rules.ts
+++ b/packages/orm/src/rules.ts
@@ -35,11 +35,13 @@ export type ValidationError = { entity: Entity } & GenericError;
 
 export class ValidationErrors extends Error {
   public errors: ValidationError[];
+  public readonly toJSON: () => string;
   constructor(errors: ValidationError[]);
   constructor(message: string);
   constructor(messageOrErrors: ValidationError[] | string) {
     super(typeof messageOrErrors === "string" ? messageOrErrors : errorMessage(messageOrErrors));
     this.errors = typeof messageOrErrors === "string" ? [] : messageOrErrors;
+    this.toJSON = () => `<ValidationErrors> ${this.message}`;
   }
 }
 

--- a/packages/orm/src/rules.ts
+++ b/packages/orm/src/rules.ts
@@ -41,6 +41,8 @@ export class ValidationErrors extends Error {
   constructor(messageOrErrors: ValidationError[] | string) {
     super(typeof messageOrErrors === "string" ? messageOrErrors : errorMessage(messageOrErrors));
     this.errors = typeof messageOrErrors === "string" ? [] : messageOrErrors;
+    // Jest clones without prototype, so explictly setting this as a property rather than a class method
+    // https://github.com/jestjs/jest/issues/11958
     this.toJSON = () => `<ValidationErrors> ${this.message}`;
   }
 }

--- a/packages/orm/src/rules.ts
+++ b/packages/orm/src/rules.ts
@@ -43,7 +43,7 @@ export class ValidationErrors extends Error {
     this.errors = typeof messageOrErrors === "string" ? [] : messageOrErrors;
     // Jest clones without prototype, so explictly setting this as a property rather than a class method
     // https://github.com/jestjs/jest/issues/11958
-    this.toJSON = () => `<ValidationErrors> ${this.message}`;
+    this.toJSON = () => `ValidationErrors: ${this.message}`;
   }
 }
 


### PR DESCRIPTION
Following on from https://github.com/stephenh/joist-ts/discussions/692.

- ValidationErrors holds a property of entities which have circular references.
- Jest returns the failure error of a test back to its root process by stringifying
- Jest also clones the returned object before stringifying, destroying the prototype where a toJSON method would live

This (from my testing, Jest 29.5.0 w/ Circus) _should_ stop issues around circular references by introducing toJSON as a property of ValidationErrors which survives the clone. 

I've added in a test to attempt to represent this issue, wasn't sure the best place for it - happy to move/change.