### PR TITLE
fix: ensure exclusive `or` or `and` in ExpressionFilter

### DIFF
--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -1899,6 +1899,13 @@ describe("EntityManager.queries", () => {
       expect(authors.length).toEqual(2);
     });
 
+    it("can use exclusively allows or or and", async () => {
+      const em = newEntityManager();
+      const a = alias(Author);
+      // @ts-expect-error
+      await em.find(Author, { as: a }, { conditions: { and: [a.isPopular.eq(true)], or: [a.lastName.eq(null)] } });
+    });
+
     it("can use primitive aliases for null", async () => {
       await insertAuthor({ first_name: "a1" });
       await insertAuthor({ first_name: "a2", last_name: "l2" });

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -86,7 +86,7 @@ export interface AuthorFields {
   graduated: { kind: "primitive"; type: Date; unique: false; nullable: undefined };
   wasEverPopular: { kind: "primitive"; type: boolean; unique: false; nullable: undefined };
   address: { kind: "primitive"; type: Address; unique: false; nullable: undefined };
-  businessAddress: { kind: "primitive"; type: z.infer<typeof AddressSchema>; unique: false; nullable: undefined };
+  businessAddress: { kind: "primitive"; type: z.input<typeof AddressSchema>; unique: false; nullable: undefined };
   quotes: { kind: "primitive"; type: Quotes; unique: false; nullable: undefined };
   deletedAt: { kind: "primitive"; type: Date; unique: false; nullable: undefined };
   numberOfPublicReviews: { kind: "primitive"; type: number; unique: false; nullable: undefined };
@@ -109,7 +109,7 @@ export interface AuthorOpts {
   graduated?: Date | null;
   wasEverPopular?: boolean | null;
   address?: Address | null;
-  businessAddress?: z.infer<typeof AddressSchema> | null;
+  businessAddress?: z.input<typeof AddressSchema> | null;
   quotes?: Quotes | null;
   deletedAt?: Date | null;
   favoriteColors?: Color[];
@@ -150,7 +150,7 @@ export interface AuthorFilter {
   graduated?: ValueFilter<Date, null>;
   wasEverPopular?: BooleanFilter<null>;
   address?: ValueFilter<Address, null>;
-  businessAddress?: ValueFilter<z.infer<typeof AddressSchema>, null>;
+  businessAddress?: ValueFilter<z.input<typeof AddressSchema>, null>;
   quotes?: ValueFilter<Quotes, null>;
   deletedAt?: ValueFilter<Date, null>;
   numberOfPublicReviews?: ValueFilter<number, null>;
@@ -183,7 +183,7 @@ export interface AuthorGraphQLFilter {
   graduated?: ValueGraphQLFilter<Date>;
   wasEverPopular?: BooleanGraphQLFilter;
   address?: ValueGraphQLFilter<Address>;
-  businessAddress?: ValueGraphQLFilter<z.infer<typeof AddressSchema>>;
+  businessAddress?: ValueGraphQLFilter<z.input<typeof AddressSchema>>;
   quotes?: ValueGraphQLFilter<Quotes>;
   deletedAt?: ValueGraphQLFilter<Date>;
   numberOfPublicReviews?: ValueGraphQLFilter<number>;

--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -80,6 +80,6 @@ export type ValueFilter<V, N> =
 
 /** Filters against complex expressions of filters. */
 export type ExpressionFilter = (
-  | { and: Array<ExpressionFilter | ColumnCondition | undefined> }
-  | { or: Array<ExpressionFilter | ColumnCondition | undefined> }
+  | { and: Array<ExpressionFilter | ColumnCondition | undefined>; or?: never }
+  | { or: Array<ExpressionFilter | ColumnCondition | undefined>; and?: never }
 ) & { pruneIfUndefined?: "any" | "all" };

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -739,9 +739,9 @@ export function maybeAddNotSoftDeleted(
 
 function parseExpression(expression: ExpressionFilter): ParsedExpressionFilter | undefined {
   const [op, expressions] =
-    "and" in expression
+    "and" in expression && expression.and
       ? ["and" as const, expression.and]
-      : "or" in expression
+      : "or" in expression && expression.or
       ? ["or" as const, expression.or]
       : fail(`Invalid expression ${expression}`);
   const conditions = expressions.map((exp) => (exp && ("and" in exp || "or" in exp) ? parseExpression(exp) : exp));


### PR DESCRIPTION
One of the things I hit early on was not realising each ExpressionFilter needs an `and` or an `or` but not both. TypeScript doesn't catch this with it's union/object handling.

I've added in never to the other side of expressions to ensure TS does catch this:

```ts
/** Filters against complex expressions of filters. */
export type ExpressionFilter = (
  | { and: Array<ExpressionFilter | ColumnCondition | undefined>; or?: never }
  | { or: Array<ExpressionFilter | ColumnCondition | undefined>; and?: never }
) & { pruneIfUndefined?: "any" | "all" };
```

It doesn't result in the best error, but it at least helps point to the fact joist isn't going to support this:
<img width="832" alt="image" src="https://github.com/stephenh/joist-ts/assets/382352/0e625904-3be8-4806-b978-cab73f23c680">
