### PR TITLE
docs: zod + type + em method semantics

### DIFF
--- a/docs/docs/features/entity-manager.md
+++ b/docs/docs/features/entity-manager.md
@@ -88,6 +88,11 @@ const em = newEntityManager();
 const a = await em.load(Author, "a:1");
 ```
 
+- Returns
+    - Entity if found
+    - throws `Error` if not
+
+
 ### `#loadAll`
 
 Load multiple instances of a given entity and ids, and fails if any id does not exist.
@@ -96,6 +101,11 @@ Load multiple instances of a given entity and ids, and fails if any id does not 
 const em = newEntityManager();
 const a = await em.loadAll(Author, ["a:1", "a:2"]);
 ```
+
+- Returns
+    - Array of entities if found
+    - throws `Error` if not
+
 
 ### `#loadAllIfExists`
 

--- a/docs/docs/features/queries-find.md
+++ b/docs/docs/features/queries-find.md
@@ -109,15 +109,22 @@ Inline conditions can be any of the following formats/operators:
   * `{ eq: null }` becomes `IS NULL`
   * `{ ne: null }` becomes `IS NOT NULL`
   * `{ in: ["a1", "b2", null] }`
+  * `{ nin: ["a1", "b2"] }` becomes `NOT IN`
   * `{ lt: 1 }`
   * `{ gt: 1 }`
   * `{ gte: 1 }`
   * `{ lte: 1 }`
+  * `{ like: "str" }`
+  * `{ ilike: "str" }`
 * An operator literal can also include multiple keys, i.e.:
   * `{ gt: 1, lt: 10 }` becomes `> 1 AND < 10`
 * An operator literal can also use an explicit `op` key, i.e.:
   * `{ op: "eq", value: "a1" }` 
   * `{ op: "in", value: ["a1", "a2"] }`
+* An array field can also use these additional operators, i.e.:
+  * `{ contains: ["book"] }`
+  * `{ overlaps: ["book"] }`
+  * `{ containedBy: ["book"] }`
 
 :::tip
 
@@ -222,6 +229,10 @@ You can also query based on an association
 const books = await em.find(Book, { author: { firstName: "a2" } });
 ```
 
+- Batch friendly
+- Returns
+  - Array of zero or more entities
+
 ### `#findOne`
 
 ```ts
@@ -229,12 +240,25 @@ const em = newEntityManager();
 const author = await em.findOne(Author, { email: 'foo@bar.com" });
 ```
 
+- Batch friendly
+- Returns
+  - Entity if one found
+  - `undefined` if nothing found
+  - throws `TooManyError` if more than 1 found
+
 ### `#findOneOrFail`
 
 ```ts
 const em = newEntityManager();
 const author = await em.findOneOrFail(Author, { email: "foo@bar.com" });
 ```
+
+- Batch friendly
+- Returns
+  - Entity if one found
+  - throws `NotFoundError` if nothing found
+  - throws `TooManyError` if more than 1 found
+
 
 ### `#findOrCreate`
 

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -266,6 +266,8 @@ export interface FieldConfig {
   protected?: boolean;
   ignore?: true;
   superstruct?: string;
+  zodSchema?: string;
+  type?: string;
 }
 ```
 
@@ -274,7 +276,9 @@ Where:
 * `derived` controls whether this field is derived from business logic (...link to docs...)
 * `protected` controls whether this is field is `protected` and so can only be accessed internally by the domain model code
 * `ignore` controls whether to ignore the field
-* `superstruct` links to the superstruct type to use for `jsonb` columns, i.e. `commentStreamReads@src/entities/superstruct` (...link to docs...)
+* `superstruct` links to the superstruct type to use for [`jsonb` columns](../modeling/jsonb-fields.md), i.e. `commentStreamReads@src/entities/superstruct`
+* `zodSchema` links to the Zod schema to use for [`jsonb` columns](../modeling/jsonb-fields.md), i.e. `CommentStreamReads@src/entities/schemas` 
+* `type` links to an TypeScript type to use instead of the schema derived one
 
 ### `entities.relations`
 

--- a/docs/docs/modeling/jsonb-fields.md
+++ b/docs/docs/modeling/jsonb-fields.md
@@ -9,14 +9,46 @@ Postgres has rich support for [storing JSON](https://www.postgresql.org/docs/cur
 
 While Postgres does not apply a schema to `jsonb` columns, this can often be useful when you do actually have/know a schema for a `jsonb` column, but are using the `jsonb` column as a more succinct/pragmatic way to store nested/hierarchical data than as strictly relational tables and columns.
 
-To support this, Joist uses the [superstruct](https://docs.superstructjs.org/) library, which can describe both the TypeScript type for a value (i.e. `Address` has both as a `street` and a `city`), as well as do runtime validation and parsing of address values.
+To support this, Joist supports both the [superstruct](https://docs.superstructjs.org/) library and [Zod](https://zod.dev/), which can describe both the TypeScript type for a value (i.e. `Address` has both as a `street` and a `city`), as well as do runtime validation and parsing of address values.
 
-That said, if you do want to use the `jsonb` column effectively as an `any` object, the superstruct typing is optional, and you'll just work with `Object`s instead.
+That said, if you do want to use the `jsonb` column effectively as an `any` object, the additional typing is optional, and you'll just work with `Object`s instead.
 
 ### Approach
 
 We'll use an example of storing an `Address` with `street` and `city` fields within a single `jsonb` column.
 
+#### Zod
+First, define a [Zod](https://zod.dev/) schema for the data you're going to store in `src/entities/types.ts`:
+
+```typescript
+import { z } from "zod";
+
+export const Address = z.object({
+  street: z.string(),
+  city: z.string(),
+});
+```
+
+Then tell Joist to use this `Address` schema for the `Author.address` field in `joist-config.json`:
+
+```json
+{
+  "entities": {
+    "Author": {
+      "fields": {
+        "address": {
+          "zodSchema": "Address@src/entities/types"
+        }
+      },
+      "tag": "a"
+    }
+  }
+}
+```
+
+Now just run `joist-codegen` and the `AuthorCodegen`'s `address` field use the `Address` schema using Zod's `z.input` and `z.output` inference in setter and getter respectively.
+
+#### Superstruct
 First, define a [superstruct](https://docs.superstructjs.org/) type for the data you're going to store in `src/entities/types.ts`:
 
 ```typescript


### PR DESCRIPTION
We've been working with Joist for the last couple of weeks now and speaking to my team wanted to see what they thought is missing or could be improved with the docs while it's all still fresh and new.

- Add `zodSchema` & `type` to FieldConfig under Configuration
- Add `Zod` to the JSONB Fields page alongside Superstruct
- Mention missing operators "Find Queries"
- Add some explain some addtional semantics around find/findOne/load etc; if they throw, what they throw etc
  - Not entirely happy with the formatting of this, so open to ideas

Bit of a sidenote, but I was suprised to see that `load` just throws a generic base Error and not something from Joist, NotFoundError or otherwise.