### PR TITLE
feat: add basic custom serde support

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -12,6 +12,7 @@ import {
   isLargeCollection,
   isProtected,
   ormMaintainedFields,
+  serdeConfig,
   superstructConfig,
   zodSchemaConfig,
 } from "./config";
@@ -103,6 +104,7 @@ export type PrimitiveField = Field & {
   unique: boolean;
   superstruct: Import | undefined;
   zodSchema: Import | undefined;
+  customSerde: Import | undefined;
 };
 
 export type EnumField = Field & {
@@ -374,6 +376,7 @@ function newPrimitive(config: Config, entity: Entity, column: Column, table: Tab
   const columnName = column.name;
   const columnType = (column.type.shortName || column.type.name) as DatabaseColumnType;
   const fieldType = mapType(table.name, columnName, columnType);
+  const customSerde = serdeConfig(config, entity, fieldName);
   const superstruct = superstructConfig(config, entity, fieldName);
   const zodSchema = zodSchemaConfig(config, entity, fieldName);
   const userFieldType = fieldTypeConfig(config, entity, fieldName);
@@ -394,6 +397,7 @@ function newPrimitive(config: Config, entity: Entity, column: Column, table: Tab
     ignore: isFieldIgnored(config, entity, fieldName, column.notNull, column.default !== null),
     superstruct: fieldType === "Object" && superstruct ? Import.from(superstruct) : undefined,
     zodSchema: fieldType === "Object" && zodSchema ? Import.from(zodSchema) : undefined,
+    customSerde: customSerde ? serdeType(customSerde) : undefined,
   };
 }
 
@@ -747,5 +751,9 @@ function zodSchemaType(s: string): Code {
 }
 
 function userFieldTypeType(s: string): Import {
+  return Import.from(s);
+}
+
+function serdeType(s: string): Import {
   return Import.from(s);
 }

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -13,6 +13,7 @@ export interface FieldConfig {
   superstruct?: string;
   zodSchema?: string;
   type?: string;
+  serde?: string;
 }
 
 export interface RelationConfig {
@@ -97,6 +98,10 @@ export function isAsyncDerived(config: Config, entity: Entity, fieldName: string
 
 export function isProtected(config: Config, entity: Entity, fieldName: string): boolean {
   return config.entities[entity.name]?.fields?.[fieldName]?.protected === true;
+}
+
+export function serdeConfig(config: Config, entity: Entity, fieldName: string): string | undefined {
+  return config.entities[entity.name]?.fields?.[fieldName]?.serde;
 }
 
 export function superstructConfig(config: Config, entity: Entity, fieldName: string): string | undefined {

--- a/packages/codegen/src/generateMetadataFile.ts
+++ b/packages/codegen/src/generateMetadataFile.ts
@@ -67,7 +67,7 @@ function generateFields(config: Config, dbMetadata: EntityDbMetadata): Record<st
   `;
 
   dbMetadata.primitives.forEach((p) => {
-    const { fieldName, derived, columnName, columnType, superstruct, zodSchema } = p;
+    const { fieldName, derived, columnName, columnType, superstruct, zodSchema, customSerde } = p;
     const serdeType = superstruct
       ? code`new ${SuperstructSerde}("${fieldName}", "${columnName}", ${superstruct})`
       : zodSchema
@@ -76,7 +76,7 @@ function generateFields(config: Config, dbMetadata: EntityDbMetadata): Record<st
       ? code`new ${DecimalToNumberSerde}("${fieldName}", "${columnName}")`
       : columnType === "jsonb"
       ? code`new ${JsonSerde}("${fieldName}", "${columnName}")`
-      : code`new ${PrimitiveSerde}("${fieldName}", "${columnName}", "${columnType}")`;
+      : code`new ${customSerde ?? PrimitiveSerde}("${fieldName}", "${columnName}", "${columnType}")`;
     fields[fieldName] = code`
       {
         kind: "primitive",

--- a/packages/codegen/src/generateMetadataFile.ts
+++ b/packages/codegen/src/generateMetadataFile.ts
@@ -68,7 +68,9 @@ function generateFields(config: Config, dbMetadata: EntityDbMetadata): Record<st
 
   dbMetadata.primitives.forEach((p) => {
     const { fieldName, derived, columnName, columnType, superstruct, zodSchema, customSerde } = p;
-    const serdeType = superstruct
+    const serdeType = customSerde
+      ? code`new ${customSerde}("${fieldName}", "${columnName}", ${superstruct})`
+      : superstruct
       ? code`new ${SuperstructSerde}("${fieldName}", "${columnName}", ${superstruct})`
       : zodSchema
       ? code`new ${ZodSerde}("${fieldName}", "${columnName}", ${zodSchema})`
@@ -76,7 +78,7 @@ function generateFields(config: Config, dbMetadata: EntityDbMetadata): Record<st
       ? code`new ${DecimalToNumberSerde}("${fieldName}", "${columnName}")`
       : columnType === "jsonb"
       ? code`new ${JsonSerde}("${fieldName}", "${columnName}")`
-      : code`new ${customSerde ?? PrimitiveSerde}("${fieldName}", "${columnName}", "${columnType}")`;
+      : code`new ${PrimitiveSerde}("${fieldName}", "${columnName}", "${columnType}")`;
     fields[fieldName] = code`
       {
         kind: "primitive",

--- a/packages/graphql-codegen/src/testUtils.ts
+++ b/packages/graphql-codegen/src/testUtils.ts
@@ -29,6 +29,7 @@ export function newPrimitiveField(fieldName: string, opts: Partial<PrimitiveFiel
     columnDefault: null,
     superstruct: undefined,
     zodSchema: undefined,
+    customSerde: undefined,
     ...opts,
   };
 }

--- a/packages/integration-tests/joist-config.json
+++ b/packages/integration-tests/joist-config.json
@@ -41,7 +41,13 @@
     "PublisherGroup": { "relations": { "critics": { "large": true } }, "tag": "pg" },
     "SmallPublisher": { "fields": { "allAuthorNames": { "derived": "async" } }, "tag": "p" },
     "Tag": { "relations": { "authors": { "large": true } }, "tag": "t" },
-    "User": { "fields": { "ipAddress": { "type": "IpAddress@src/entities/types" } }, "tag": "u" }
+    "User": {
+      "fields": {
+        "ipAddress": { "type": "IpAddress@src/entities/types" },
+        "password": { "serde": "PasswordValueSerde@src/entities/types", "type": "PasswordValue@src/entities/types" }
+      },
+      "tag": "u"
+    }
   },
   "entitiesDirectory": "./src/entities"
 }

--- a/packages/integration-tests/migrations/1580658856631_author.ts
+++ b/packages/integration-tests/migrations/1580658856631_author.ts
@@ -199,6 +199,7 @@ export function up(b: MigrationBuilder): void {
       otherFieldName: "userOneToOne",
     }),
     ip_address: { type: "varchar(255)", notNull: false },
+    password: { type: "varchar(255)", notNull: false },
   });
 
   // for testing polymorphic references

--- a/packages/integration-tests/src/entities/User.test.ts
+++ b/packages/integration-tests/src/entities/User.test.ts
@@ -1,5 +1,10 @@
 import { User } from "@src/entities";
+import { insertUser } from "@src/entities/inserts";
+import { PasswordValue } from "@src/entities/types";
 import { newEntityManager } from "@src/setupDbTests";
+
+const PASSWORD = "correct.horse.battery.staple";
+const PASSWORD_ENCODED = "Y29ycmVjdC5ob3JzZS5iYXR0ZXJ5LnN0YXBsZQ==";
 
 describe("User", () => {
   it("custom type is exposed", async () => {
@@ -7,5 +12,44 @@ describe("User", () => {
     // @ts-expect-error
     const a1 = em.create(User, { name: "a1", email: "test@test.com", ipAddress: "127.0.0.1" });
     await expect(em.flush()).resolves.toEqual([a1]);
+  });
+
+  it("can interact with serde value", async () => {
+    const em = newEntityManager();
+    const a1 = em.create(User, {
+      name: "a1",
+      email: "test@test.com",
+      password: PasswordValue.fromPlainText(PASSWORD),
+    });
+    await expect(em.flush()).resolves.toEqual([a1]);
+    await expect(a1.password?.encoded).toEqual(PASSWORD_ENCODED);
+  });
+
+  it("loads serde values correctly", async () => {
+    insertUser({
+      id: 1,
+      name: "a1",
+      email: "test@test.com",
+      password: PASSWORD_ENCODED,
+    });
+
+    const em = newEntityManager();
+    const a1 = await em.load(User, "u:1");
+    await expect(a1.password?.encoded).toEqual(PASSWORD_ENCODED);
+  });
+
+  it("can interact with serde value", async () => {
+    insertUser({
+      id: 1,
+      name: "a1",
+      email: "test@test.com",
+      password: PASSWORD_ENCODED,
+    });
+
+    const em = newEntityManager();
+    const a1 = await em.load(User, "u:1");
+    a1.password = PasswordValue.fromPlainText("another");
+    await expect(em.flush()).resolves.toEqual([a1]);
+    expect(a1.password.matches(PASSWORD)).toBe(false);
   });
 });

--- a/packages/integration-tests/src/entities/UserCodegen.ts
+++ b/packages/integration-tests/src/entities/UserCodegen.ts
@@ -31,7 +31,7 @@ import {
   ValueGraphQLFilter,
 } from "joist-orm";
 import { Context } from "src/context";
-import { IpAddress } from "src/entities/types";
+import { IpAddress, PasswordValue } from "src/entities/types";
 import {
   Author,
   AuthorId,
@@ -53,6 +53,7 @@ export interface UserFields {
   name: { kind: "primitive"; type: string; unique: false; nullable: never };
   email: { kind: "primitive"; type: string; unique: false; nullable: never };
   ipAddress: { kind: "primitive"; type: IpAddress; unique: false; nullable: undefined };
+  password: { kind: "primitive"; type: PasswordValue; unique: false; nullable: undefined };
   createdAt: { kind: "primitive"; type: Date; unique: false; nullable: never };
   updatedAt: { kind: "primitive"; type: Date; unique: false; nullable: never };
   authorManyToOne: { kind: "m2o"; type: Author; nullable: undefined };
@@ -62,6 +63,7 @@ export interface UserOpts {
   name: string;
   email: string;
   ipAddress?: IpAddress | null;
+  password?: PasswordValue | null;
   authorManyToOne?: Author | AuthorId | null;
   createdComments?: Comment[];
   likedComments?: Comment[];
@@ -78,6 +80,7 @@ export interface UserFilter {
   name?: ValueFilter<string, never>;
   email?: ValueFilter<string, never>;
   ipAddress?: ValueFilter<IpAddress, null>;
+  password?: ValueFilter<PasswordValue, null>;
   createdAt?: ValueFilter<Date, never>;
   updatedAt?: ValueFilter<Date, never>;
   authorManyToOne?: EntityFilter<Author, AuthorId, FilterOf<Author>, null>;
@@ -90,6 +93,7 @@ export interface UserGraphQLFilter {
   name?: ValueGraphQLFilter<string>;
   email?: ValueGraphQLFilter<string>;
   ipAddress?: ValueGraphQLFilter<IpAddress>;
+  password?: ValueGraphQLFilter<PasswordValue>;
   createdAt?: ValueGraphQLFilter<Date>;
   updatedAt?: ValueGraphQLFilter<Date>;
   authorManyToOne?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, null>;
@@ -102,6 +106,7 @@ export interface UserOrder {
   name?: OrderBy;
   email?: OrderBy;
   ipAddress?: OrderBy;
+  password?: OrderBy;
   createdAt?: OrderBy;
   updatedAt?: OrderBy;
   authorManyToOne?: AuthorOrder;
@@ -195,6 +200,14 @@ export abstract class UserCodegen extends BaseEntity<EntityManager> {
 
   set ipAddress(ipAddress: IpAddress | undefined) {
     setField(this, "ipAddress", ipAddress);
+  }
+
+  get password(): PasswordValue | undefined {
+    return this.__orm.data["password"];
+  }
+
+  set password(password: PasswordValue | undefined) {
+    setField(this, "password", password);
   }
 
   get createdAt(): Date {

--- a/packages/integration-tests/src/entities/inserts.ts
+++ b/packages/integration-tests/src/entities/inserts.ts
@@ -56,7 +56,7 @@ export function insertComment(row: {
   return testDriver.insert("comments", row);
 }
 
-export function insertUser(row: { id?: number; name: string; email: string }) {
+export function insertUser(row: { id?: number; name: string; email: string; password: string }) {
   return testDriver.insert("users", row);
 }
 

--- a/packages/integration-tests/src/entities/metadata.ts
+++ b/packages/integration-tests/src/entities/metadata.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, configureMetadata, DecimalToNumberSerde, EntityManager as EntityManager1, EntityMetadata, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde, ZodSerde } from "joist-orm";
 import { Context } from "src/context";
-import { address, AddressSchema, quotes } from "src/entities/types";
+import { address, AddressSchema, PasswordValueSerde, quotes } from "src/entities/types";
 import {
   AdvanceStatuses,
   Author,
@@ -510,6 +510,7 @@ export const userMeta: EntityMetadata<User> = {
     "name": { kind: "primitive", fieldName: "name", fieldIdName: undefined, derived: false, required: true, protected: false, type: "string", serde: new PrimitiveSerde("name", "name", "character varying"), immutable: false },
     "email": { kind: "primitive", fieldName: "email", fieldIdName: undefined, derived: false, required: true, protected: false, type: "string", serde: new PrimitiveSerde("email", "email", "character varying"), immutable: false },
     "ipAddress": { kind: "primitive", fieldName: "ipAddress", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PrimitiveSerde("ipAddress", "ip_address", "character varying"), immutable: false },
+    "password": { kind: "primitive", fieldName: "password", fieldIdName: undefined, derived: false, required: false, protected: false, type: "string", serde: new PasswordValueSerde("password", "password", "character varying"), immutable: false },
     "createdAt": { kind: "primitive", fieldName: "createdAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("createdAt", "created_at", "timestamp with time zone"), immutable: false },
     "updatedAt": { kind: "primitive", fieldName: "updatedAt", fieldIdName: undefined, derived: "orm", required: false, protected: false, type: "Date", serde: new PrimitiveSerde("updatedAt", "updated_at", "timestamp with time zone"), immutable: false },
     "authorManyToOne": { kind: "m2o", fieldName: "authorManyToOne", fieldIdName: "authorManyToOneId", derived: false, required: false, otherMetadata: () => authorMeta, otherFieldName: "userOneToOne", serde: new KeySerde("a", "authorManyToOne", "author_id", "int"), immutable: false },

--- a/packages/integration-tests/src/entities/types.ts
+++ b/packages/integration-tests/src/entities/types.ts
@@ -1,3 +1,4 @@
+import { Serde } from "joist-orm";
 import { Infer, array, object, string } from "superstruct";
 import { z } from "zod";
 
@@ -15,3 +16,34 @@ export const AddressSchema = z.object({
 export const quotes = array(string());
 
 export type IpAddress = string & { __type: "IpAddress" };
+
+export class PasswordValue {
+  static fromEncoded(str: string) {
+    return new PasswordValue(str);
+  }
+
+  static fromPlainText(str: string) {
+    return new PasswordValue(Buffer.from(str, "utf8").toString("base64"));
+  }
+
+  constructor(public readonly encoded: string) {}
+
+  matches(str: string) {
+    return Buffer.from(str, "utf8").toString("base64") === this.encoded;
+  }
+}
+
+export class PasswordValueSerde extends Serde {
+  dbValue(data: any): any {
+    return PasswordValue.fromEncoded(data[this.columnName]);
+  }
+
+  mapToDb(value: any): any {
+    if (value instanceof PasswordValue) return value.encoded;
+    return value;
+  }
+
+  setOnEntity(data: any, row: any): void {
+    data[this.fieldName] = PasswordValue.fromEncoded(row[this.columnName]);
+  }
+}

--- a/packages/orm/src/serde.ts
+++ b/packages/orm/src/serde.ts
@@ -39,6 +39,18 @@ export interface Column {
   isArray: boolean;
 }
 
+export abstract class Serde implements FieldSerde {
+  columns = [this];
+
+  isArray: boolean = false;
+
+  public constructor(protected fieldName: string, public columnName: string, public dbType: string) {}
+
+  abstract dbValue(data: any): any;
+  abstract setOnEntity(data: any, row: any): void;
+  abstract mapToDb(data: any): any;
+}
+
 export class PrimitiveSerde implements FieldSerde {
   isArray = false;
   columns = [this];


### PR DESCRIPTION
Following on from the previous attempt and discussions in #678.

This implements a new FieldConfig option `serde`. This overrides the class used within metadata.ts. I've left this as only taking precedence over all others if set. (One thing to suggest in the future for dx is the idea of friendly validation of joist-config.json when running codegen).

I've implemented Serde as an abstract class to reduce boilerplate for consumers and the finer nuance (which fields from the constructor need to be public, `column = [this]`.

Tests added around a Users password "hashed" with base64 (perfect security :)) also combining with `type` for the value objects use case.
