### PR TITLE
feat: Updated EntityId codegen to use actual type instead of a string

### DIFF
--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -1,45 +1,27 @@
 import { camelCase, pascalCase } from "change-case";
 import { Code, code, imp, joinCode } from "ts-poet";
-import { DbMetadata, EntityDbMetadata, EnumField, PrimitiveField, PrimitiveTypescriptType } from "./EntityDbMetadata";
 import { Config } from "./config";
+import { DbMetadata, EntityDbMetadata, EnumField, PrimitiveField, PrimitiveTypescriptType } from "./EntityDbMetadata";
 import { keywords } from "./keywords";
 import {
   BaseEntity,
   BooleanFilter,
   BooleanGraphQLFilter,
   Changes,
+  cleanStringValue,
   Collection,
   ConfigApi,
+  deTagId,
   Entity,
   EntityFilter,
   EntityGraphQLFilter,
   EntityMetadata,
   EntityOrmField,
+  fail as failSymbol,
   FieldsOf,
   FilterOf,
   Flavor,
   GraphQLFilterOf,
-  IdOf,
-  LargeCollection,
-  Lens,
-  LoadHint,
-  Loaded,
-  ManyToOneReference,
-  MaybeAbstractEntityConstructor,
-  OneToOneReference,
-  OptsOf,
-  OrderBy,
-  PartialOrNull,
-  PersistedAsyncProperty,
-  PersistedAsyncReference,
-  PolymorphicReference,
-  SSAssert,
-  ValueFilter,
-  ValueGraphQLFilter,
-  Zod,
-  cleanStringValue,
-  deTagId,
-  fail as failSymbol,
   hasLargeMany,
   hasLargeManyToMany,
   hasMany,
@@ -47,12 +29,30 @@ import {
   hasOne,
   hasOnePolymorphic,
   hasOneToOne,
+  IdOf,
   isLoaded,
+  LargeCollection,
+  Lens,
+  Loaded,
+  LoadHint,
   loadLens,
+  ManyToOneReference,
+  MaybeAbstractEntityConstructor,
   newChangesProxy,
   newRequiredRule,
+  OneToOneReference,
+  OptsOf,
+  OrderBy,
+  PartialOrNull,
+  PersistedAsyncProperty,
+  PersistedAsyncReference,
+  PolymorphicReference,
   setField,
   setOpts,
+  SSAssert,
+  ValueFilter,
+  ValueGraphQLFilter,
+  Zod,
 } from "./symbols";
 import { fail, uncapitalize } from "./utils";
 
@@ -454,7 +454,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   }
 
   return code`
-    export type ${entityName}Id = ${Flavor}<string, "${entityName}"> ${maybeBaseId};
+    export type ${entityName}Id = ${Flavor}<string, ${entityName}> ${maybeBaseId};
 
     ${generatePolymorphicTypes(meta)}
     

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -72,7 +72,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type AuthorId = Flavor<string, "Author">;
+export type AuthorId = Flavor<string, Author>;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/AuthorStatCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorStatCodegen.ts
@@ -26,7 +26,7 @@ import { Context } from "src/context";
 import { AuthorStat, authorStatMeta, newAuthorStat } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type AuthorStatId = Flavor<string, "AuthorStat">;
+export type AuthorStatId = Flavor<string, AuthorStat>;
 
 export interface AuthorStatFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -46,7 +46,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type BookAdvanceId = Flavor<string, "BookAdvance">;
+export type BookAdvanceId = Flavor<string, BookAdvance>;
 
 export interface BookAdvanceFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -60,7 +60,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type BookId = Flavor<string, "Book">;
+export type BookId = Flavor<string, Book>;
 
 export interface BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -47,7 +47,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type BookReviewId = Flavor<string, "BookReview">;
+export type BookReviewId = Flavor<string, BookReview>;
 
 export interface BookReviewFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -51,7 +51,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type CommentId = Flavor<string, "Comment">;
+export type CommentId = Flavor<string, Comment>;
 
 export type CommentParent = Author | Book | BookReview | Publisher;
 export function getCommentParentConstructors(): MaybeAbstractEntityConstructor<CommentParent>[] {

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -49,7 +49,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type CriticId = Flavor<string, "Critic">;
+export type CriticId = Flavor<string, Critic>;
 
 export interface CriticFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -32,7 +32,7 @@ import { Context } from "src/context";
 import { Critic, CriticColumn, criticColumnMeta, CriticId, criticMeta, CriticOrder, newCriticColumn } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type CriticColumnId = Flavor<string, "CriticColumn">;
+export type CriticColumnId = Flavor<string, CriticColumn>;
 
 export interface CriticColumnFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -51,7 +51,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type ImageId = Flavor<string, "Image">;
+export type ImageId = Flavor<string, Image>;
 
 export interface ImageFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/LargePublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/LargePublisherCodegen.ts
@@ -44,7 +44,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type LargePublisherId = Flavor<string, "LargePublisher"> & Flavor<string, "Publisher">;
+export type LargePublisherId = Flavor<string, LargePublisher> & Flavor<string, "Publisher">;
 
 export interface LargePublisherFields extends PublisherFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -67,7 +67,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type PublisherId = Flavor<string, "Publisher">;
+export type PublisherId = Flavor<string, Publisher>;
 
 export interface PublisherFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
@@ -43,7 +43,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type PublisherGroupId = Flavor<string, "PublisherGroup">;
+export type PublisherGroupId = Flavor<string, PublisherGroup>;
 
 export interface PublisherGroupFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
@@ -37,7 +37,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type SmallPublisherId = Flavor<string, "SmallPublisher"> & Flavor<string, "Publisher">;
+export type SmallPublisherId = Flavor<string, SmallPublisher> & Flavor<string, "Publisher">;
 
 export interface SmallPublisherFields extends PublisherFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -46,7 +46,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type TagId = Flavor<string, "Tag">;
+export type TagId = Flavor<string, Tag>;
 
 export interface TagFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/integration-tests/src/entities/UserCodegen.ts
+++ b/packages/integration-tests/src/entities/UserCodegen.ts
@@ -47,7 +47,7 @@ import {
 } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type UserId = Flavor<string, "User">;
+export type UserId = Flavor<string, User>;
 
 export interface UserFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -32,7 +32,7 @@ import { Context } from "src/context";
 import { Artist, artistMeta, newArtist, Painting, PaintingId, paintingMeta } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type ArtistId = Flavor<string, "Artist">;
+export type ArtistId = Flavor<string, Artist>;
 
 export interface ArtistFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: false };

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -32,7 +32,7 @@ import { Context } from "src/context";
 import { Author, authorMeta, Book, BookId, bookMeta, newAuthor } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type AuthorId = Flavor<string, "Author">;
+export type AuthorId = Flavor<string, Author>;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -32,7 +32,7 @@ import { Context } from "src/context";
 import { Author, AuthorId, authorMeta, AuthorOrder, Book, bookMeta, newBook } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type BookId = Flavor<string, "Book">;
+export type BookId = Flavor<string, Book>;
 
 export interface BookFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/tests/schema-misc/src/entities/DatabaseOwnerCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/DatabaseOwnerCodegen.ts
@@ -26,7 +26,7 @@ import { Context } from "src/context";
 import { DatabaseOwner, databaseOwnerMeta, newDatabaseOwner } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type DatabaseOwnerId = Flavor<string, "DatabaseOwner">;
+export type DatabaseOwnerId = Flavor<string, DatabaseOwner>;
 
 export interface DatabaseOwnerFields {
   id: { kind: "primitive"; type: number; unique: true; nullable: false };

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -32,7 +32,7 @@ import { Context } from "src/context";
 import { Artist, ArtistId, artistMeta, ArtistOrder, newPainting, Painting, paintingMeta } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type PaintingId = Flavor<string, "Painting">;
+export type PaintingId = Flavor<string, Painting>;
 
 export interface PaintingFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: false };

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -33,7 +33,7 @@ import { Context } from "src/context";
 import { Author, authorMeta, Book, BookId, bookMeta, newAuthor } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type AuthorId = Flavor<string, "Author">;
+export type AuthorId = Flavor<string, Author>;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: false };

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -33,7 +33,7 @@ import { Context } from "src/context";
 import { Author, AuthorId, authorMeta, AuthorOrder, Book, bookMeta, newBook } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type BookId = Flavor<string, "Book">;
+export type BookId = Flavor<string, Book>;
 
 export interface BookFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: false };

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -32,7 +32,7 @@ import { Context } from "src/context";
 import { Author, authorMeta, Book, BookId, bookMeta, newAuthor } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type AuthorId = Flavor<string, "Author">;
+export type AuthorId = Flavor<string, Author>;
 
 export interface AuthorFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: false };

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -32,7 +32,7 @@ import { Context } from "src/context";
 import { Author, AuthorId, authorMeta, AuthorOrder, Book, bookMeta, newBook } from "./entities";
 import type { EntityManager } from "./entities";
 
-export type BookId = Flavor<string, "Book">;
+export type BookId = Flavor<string, Book>;
 
 export interface BookFields {
   id: { kind: "primitive"; type: string; unique: true; nullable: false };


### PR DESCRIPTION
Allows using code generated ID types generically.  eg,

```typescript
type Foo<T> = T extends { _type?: infer U } ? U : never;
const a: Foo<AuthorId> = em.create(Author, ...); // works
const b: Foo<AuthorId> = em.create(Book, ...); // error: Type 'Book' is not assignable to type 'Author'
```