### PR TITLE
fix: Run beforeDelete hooks before entities are disconnected.

### DIFF
--- a/packages/integration-tests/src/entities/Book.test.ts
+++ b/packages/integration-tests/src/entities/Book.test.ts
@@ -1,4 +1,4 @@
-import { Author, Book, newBook } from "../entities";
+import { Author, Book, newAuthor, newBook } from "../entities";
 import { newEntityManager } from "../setupDbTests";
 
 describe("Book", () => {
@@ -23,5 +23,15 @@ describe("Book", () => {
     await em.flush();
     b.order++;
     await em.flush();
+  });
+
+  it("can observe reference from beforeDelete", async () => {
+    const em = newEntityManager();
+    const a = newAuthor(em);
+    const b = newBook(em, { author: a });
+    await em.flush();
+    em.delete(a);
+    await em.flush();
+    expect(b.authorSetWhenDeleteRuns).toBe(true);
   });
 });

--- a/packages/integration-tests/src/entities/Book.ts
+++ b/packages/integration-tests/src/entities/Book.ts
@@ -6,6 +6,7 @@ export class Book extends BookCodegen {
   favoriteColorsRuleInvoked = 0;
   reviewsRuleInvoked = 0;
   numberOfBooks2RuleInvoked = 0;
+  authorSetWhenDeleteRuns: boolean | undefined = undefined;
 }
 
 config.addRule((book) => {
@@ -36,3 +37,9 @@ config.addRule({ author: "numberOfBooks2" }, (b) => {
 });
 
 config.cascadeDelete("reviews");
+
+// Verify that beforeDelete hooks see their pre-unhooked-state, because if they run
+// after the entity is unhooked, they won't be able to access their relationships.
+config.beforeDelete("author", (b) => {
+  b.authorSetWhenDeleteRuns = b.author.getWithDeleted !== undefined;
+});

--- a/packages/integration-tests/src/getProperties.test.ts
+++ b/packages/integration-tests/src/getProperties.test.ts
@@ -16,6 +16,7 @@ describe("getProperties", () => {
       reviews: expect.any(OneToManyCollection),
       comments: expect.any(OneToManyCollection),
       author: expect.any(ManyToOneReferenceImpl),
+      authorSetWhenDeleteRuns: undefined,
       currentDraftAuthor: expect.any(OneToOneReferenceImpl),
       image: expect.any(OneToOneReferenceImpl),
       tags: expect.any(ManyToManyCollection),


### PR DESCRIPTION
We disconnect deleted entities from the rest of the object graph, to ensure the most accurate/consistent view of the graph.

However, if we disconnect deleted entities too soon, i.e. before their own hooks run, then their beforeDeletes cannot really do meaningful logic like custom cascade deletes.

I'd considered just not disconnecting the entities at all, because our o2m/m2o get's now "filter deleted entities" logic, but turns out the disconnection also has the purposeful (at least documented by tests) side-effect by un-setting optional FKs that were pointing to the deleted entity.

And so if we just stop doing the disconnect, this side effect never happens (i.e. unsetting the optional `Author.publisher` field when a Publisher is deleted).

So this PR moves where we invoke `beforeDelete`, to happen right before we disconnect entities from the graph.

This should strike the right balance of giving them a chance to have custom beforeDelete logic, but still doing the disconnection for side-effects + making their rest of the graph reflect the delete.