### PR TITLE
fix: orderBy on cti base fields 

### DIFF
--- a/packages/integration-tests/src/Inheritance.test.ts
+++ b/packages/integration-tests/src/Inheritance.test.ts
@@ -242,6 +242,17 @@ describe("Inheritance", () => {
     expect(lp as LargePublisher).toMatchEntity({ name: "lp1", country: "country" });
   });
 
+  it.only("can order by properties from the base type", async () => {
+    await insertPublisher({ id: 1, name: "a" });
+    await insertPublisher({ id: 2, name: "b" });
+
+    const em = newEntityManager();
+    const [b, a] = await em.find(SmallPublisher, { }, { orderBy: { name: 'DESC'}});
+
+    expect(a as SmallPublisher).toMatchEntity({ name: "a" });
+    expect(b as SmallPublisher).toMatchEntity({ name: "b" });
+  });
+
   it("can find entities from the base type", async () => {
     await insertPublisher({ name: "sp1" });
     await insertLargePublisher({ id: 2, name: "lp1" });

--- a/packages/integration-tests/src/Inheritance.test.ts
+++ b/packages/integration-tests/src/Inheritance.test.ts
@@ -242,7 +242,7 @@ describe("Inheritance", () => {
     expect(lp as LargePublisher).toMatchEntity({ name: "lp1", country: "country" });
   });
 
-  it.only("can order by properties from the base type", async () => {
+  it("can order by properties from the base type", async () => {
     await insertPublisher({ id: 1, name: "a" });
     await insertPublisher({ id: 2, name: "b" });
 

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -315,7 +315,7 @@ export function parseFindQuery(
       const field = meta.allFields[key] ?? fail(`${key} not found on ${meta.tableName}`);
       if (field.kind === "primitive" || field.kind === "primaryKey" || field.kind === "enum") {
         const column = field.serde.columns[0];
-        orderBys.push({ alias, column: column.columnName, order: value as OrderBy });
+        orderBys.push({ alias: `${alias}${field.aliasSuffix ?? ''}`, column: column.columnName, order: value as OrderBy });
       } else if (field.kind === "m2o") {
         // Do we already this table joined in?
         let table = tables.find((t) => t.table === field.otherMetadata().tableName);


### PR DESCRIPTION
All order by properties which existed in `meta.allFields` were built against the root alias, rather than the base type table the field belonged to.

- Added repro
- Looks like aliasPrefix is the cleanest way to do this, but haven't been around QueryParser too much yet!