### PR TITLE
chore: Clean up EntityManager's private fields.

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -691,7 +691,7 @@ describe("EntityManager", () => {
     const flushPromise = em.flush();
     await delay(0);
     expect(() => (author.firstName = "different name")).toThrow(
-      "Cannot set 'firstName' on Author:1 during a flush outside of a entity hook or from afterCommit",
+      "Cannot mutate an entity during an em.flush outside of a entity hook or from afterCommit",
     );
     await flushPromise;
   });
@@ -705,7 +705,7 @@ describe("EntityManager", () => {
     const flushPromise = em.flush();
     await delay(0);
     expect(() => p1.authors.add(a1)).toThrow(
-      /Cannot set 'publisher' on Author[:#]1 during a flush outside of a entity hook or from afterCommit/,
+      "Cannot mutate an entity during an em.flush outside of a entity hook or from afterCommit",
     );
     await flushPromise;
   });
@@ -719,7 +719,7 @@ describe("EntityManager", () => {
     const flushPromise = em.flush();
     await delay(0);
     expect(() => a1.publisher.set(p1)).toThrow(
-      "Cannot set 'publisher' on Author:1 during a flush outside of a entity hook or from afterCommit",
+      "Cannot mutate an entity during an em.flush outside of a entity hook or from afterCommit",
     );
     await flushPromise;
   });

--- a/packages/integration-tests/src/relations/ManyToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/ManyToManyCollection.test.ts
@@ -31,7 +31,7 @@ describe("ManyToManyCollection", () => {
     expect(tag.books.get.length).toEqual(1);
     expect(book.tags.get[0]).toStrictEqual(tag);
     expect(tag.books.get[0]).toStrictEqual(book);
-    expect(em.__data.joinRows["books_to_tags"].length).toEqual(1);
+    expect((em as any).__api.joinRows["books_to_tags"].length).toEqual(1);
   });
 
   it("can load a many-to-many with constant queries", async () => {

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -179,15 +179,14 @@ export class EntityManager<C = unknown> {
   public readonly ctx: C;
   public driver: Driver;
   public currentTxnKnex: Knex | undefined;
-  private _entities: Entity[] = [];
+  #entities: Entity[] = [];
   // Indexes the currently loaded entities by their tagged ids. This fixes a real-world
   // performance issue where `findExistingInstance` scanning `_entities` was an `O(n^2)`.
-  private _entityIndex: Map<string, Entity> = new Map();
-  private flushSecret: number = 0;
-  private _isFlushing: boolean = false;
-  private _isValidating: boolean = false;
-  // TODO Make these private
-  public pendingChildren: Map<string, Map<string, Entity[]>> = new Map();
+  #entityIndex: Map<string, Entity> = new Map();
+  #flushSecret: number = 0;
+  #isFlushing: boolean = false;
+  #isValidating: boolean = false;
+  #pendingChildren: Map<string, Map<string, Entity[]>> = new Map();
   /**
    * Tracks cascade deletes.
    *
@@ -196,17 +195,17 @@ export class EntityManager<C = unknown> {
    * of our `flush` loop, and b) cascade deletions before we recalc fields & run user hooks,
    * so that both see the most accurate state.
    */
-  private pendingCascadeDeletes: Entity[] = [];
-  public dataloaders: Record<string, LoaderCache> = {};
-  // This is attempting to be internal/module private
-  __data = {
-    joinRows: {} as Record<string, JoinRow[]>,
-    /** Stores any `source -> downstream` reactions to recalc during `em.flush`. */
-    rm: new ReactionsManager(),
-  };
-  private hooks: Record<EntityManagerHook, HookFn[]> = {
-    beforeTransaction: [],
-    afterTransaction: [],
+  #pendingCascadeDeletes: Entity[] = [];
+  #dataloaders: Record<string, LoaderCache> = {};
+  #joinRows: Record<string, JoinRow[]> = {};
+  /** Stores any `source -> downstream` reactions to recalc during `em.flush`. */
+  #rm = new ReactionsManager();
+  #hooks: Record<EntityManagerHook, HookFn[]> = { beforeTransaction: [], afterTransaction: [] };
+  private __api: EntityManagerInternalApi = {
+    joinRows: this.#joinRows,
+    pendingChildren: this.#pendingChildren,
+    hooks: this.#hooks,
+    rm: this.#rm,
   };
 
   constructor(em: EntityManager<C>);
@@ -215,9 +214,9 @@ export class EntityManager<C = unknown> {
     if (emOrCtx instanceof EntityManager) {
       const em = emOrCtx;
       this.driver = em.driver;
-      this.hooks = {
-        beforeTransaction: [...em.hooks.beforeTransaction],
-        afterTransaction: [...em.hooks.afterTransaction],
+      this.#hooks = {
+        beforeTransaction: [...em.#hooks.beforeTransaction],
+        afterTransaction: [...em.#hooks.afterTransaction],
       };
       this.ctx = em.ctx!;
     } else {
@@ -228,13 +227,13 @@ export class EntityManager<C = unknown> {
 
   /** Returns a read-only shallow copy of the currently-loaded entities. */
   get entities(): ReadonlyArray<Entity> {
-    return [...this._entities];
+    return [...this.#entities];
   }
 
   /** Looks up `id` in the list of already-loaded entities. */
   getEntity<T extends Entity>(id: IdOf<T>): T | undefined {
     assertIdIsTagged(id);
-    return this._entityIndex.get(id) as T | undefined;
+    return this.#entityIndex.get(id) as T | undefined;
   }
 
   /**
@@ -467,7 +466,7 @@ export class EntityManager<C = unknown> {
     // clause before knowing if it should adjust teh amount.
     const isSelectAll = Object.keys(where).length === 0;
     if (isSelectAll) {
-      for (const entity of this._entities) {
+      for (const entity of this.#entities) {
         if (entity instanceof type) {
           if (entity.isNewEntity) {
             count++;
@@ -1006,11 +1005,11 @@ export class EntityManager<C = unknown> {
       if (this.findExistingInstance(entity.idTagged) !== undefined) {
         throw new Error(`Entity ${entity} has a duplicate instance already loaded`);
       }
-      this._entityIndex.set(entity.idTagged, entity);
+      this.#entityIndex.set(entity.idTagged, entity);
     }
 
-    this._entities.push(entity);
-    if (this._entities.length >= entityLimit) {
+    this.#entities.push(entity);
+    if (this.#entities.length >= entityLimit) {
       throw new Error(`More than ${entityLimit} entities have been instantiated`);
     }
 
@@ -1023,7 +1022,7 @@ export class EntityManager<C = unknown> {
       if (updatedAt) {
         entity.__orm.data[updatedAt] = new Date();
       }
-      this.__data.rm.queueAllDownstreamFields(entity);
+      this.#rm.queueAllDownstreamFields(entity);
     }
 
     currentlyInstantiatingEntity = entity;
@@ -1047,11 +1046,11 @@ export class EntityManager<C = unknown> {
     }
     entity.__orm.deleted = "pending";
     // Any derived fields that read this entity will need recalc-d
-    this.__data.rm.queueAllDownstreamFields(entity);
+    this.#rm.queueAllDownstreamFields(entity);
     // Synchronously unhook the entity if the relations are loaded
     getCascadeDeleteRelations(entity).forEach((r) => r.maybeCascadeDelete());
     // And queue the cascade deletes
-    this.pendingCascadeDeletes.push(entity);
+    this.#pendingCascadeDeletes.push(entity);
   }
 
   async assignNewIds() {
@@ -1080,9 +1079,9 @@ export class EntityManager<C = unknown> {
       throw new Error("Cannot flush while another flush is already in progress");
     }
 
-    this._isFlushing = true;
+    this.#isFlushing = true;
 
-    await currentFlushSecret.run({ flushSecret: this.flushSecret }, async () => {
+    await currentFlushSecret.run({ flushSecret: this.#flushSecret }, async () => {
       // Recalc any touched entities
       const touched = this.entities.filter((e) => e.__orm.isTouched);
       if (touched.length > 0) {
@@ -1094,7 +1093,7 @@ export class EntityManager<C = unknown> {
       // that would NPE their logic anyway).
       await this.cascadeDeletes();
       // Recalc before we run hooks, so the hooks will see the latest calculated values.
-      await this.__data.rm.recalcPendingDerivedValues();
+      await this.#rm.recalcPendingDerivedValues();
     });
 
     const hooksInvoked: Set<Entity> = new Set();
@@ -1103,7 +1102,7 @@ export class EntityManager<C = unknown> {
     try {
       while (pendingEntities.length > 0) {
         // Run hooks in a series of loops until things "settle down"
-        await currentFlushSecret.run({ flushSecret: this.flushSecret }, async () => {
+        await currentFlushSecret.run({ flushSecret: this.#flushSecret }, async () => {
           // Run our hooks
           let todos = createTodos(pendingEntities);
           await beforeCreate(this.ctx, todos);
@@ -1118,11 +1117,11 @@ export class EntityManager<C = unknown> {
           // The hooks could have deleted this-loop or prior-loop entities, so re-cascade again.
           await this.cascadeDeletes();
           // The hooks could have changed fields, so recalc again.
-          await this.__data.rm.recalcPendingDerivedValues();
+          await this.#rm.recalcPendingDerivedValues();
 
           for (const e of pendingEntities) hooksInvoked.add(e);
           pendingEntities = this.entities.filter((e) => e.isPendingFlush && !hooksInvoked.has(e));
-          this.flushSecret += 1;
+          this.#flushSecret += 1;
         });
       }
 
@@ -1133,18 +1132,18 @@ export class EntityManager<C = unknown> {
 
       if (!skipValidation) {
         try {
-          this._isValidating = true;
+          this.#isValidating = true;
           // Run simple rules first b/c it includes not-null/required rules, so that then when we run
           // `validateReactiveRules` next, the lambdas won't see invalid entities.
           await validateSimpleRules(entityTodos);
           await validateReactiveRules(entityTodos);
         } finally {
-          this._isValidating = false;
+          this.#isValidating = false;
         }
         await afterValidation(this.ctx, entityTodos);
       }
 
-      const joinRowTodos = combineJoinRows(this.__data.joinRows);
+      const joinRowTodos = combineJoinRows(this.#joinRows);
 
       if (Object.keys(entityTodos).length > 0 || Object.keys(joinRowTodos).length > 0) {
         // The driver will handle the right thing if we're already in an existing transaction.
@@ -1163,7 +1162,7 @@ export class EntityManager<C = unknown> {
 
         Object.values(entityTodos).forEach((todo) => {
           todo.inserts.forEach((e) => {
-            this._entityIndex.set(e.idTagged!, e);
+            this.#entityIndex.set(e.idTagged!, e);
             e.__orm.isNew = false;
           });
           todo.deletes.forEach((e) => {
@@ -1176,8 +1175,8 @@ export class EntityManager<C = unknown> {
         });
 
         // Reset the find caches b/c data will have changed in the db
-        this.dataloaders = {};
-        this.__data.rm.clear();
+        this.#dataloaders = {};
+        this.#rm.clear();
       }
 
       return entitiesToFlush;
@@ -1190,12 +1189,23 @@ export class EntityManager<C = unknown> {
       }
       throw e;
     } finally {
-      this._isFlushing = false;
+      this.#isFlushing = false;
     }
   }
 
   get isFlushing(): boolean {
-    return this._isFlushing;
+    return this.#isFlushing;
+  }
+
+  checkWritesAllowed(): void {
+    if (this.#isFlushing) {
+      const { flushSecret } = currentFlushSecret.getStore() || {};
+      if (flushSecret === undefined) {
+        throw new Error(`Cannot mutate an entity during an em.flush outside of a entity hook or from afterCommit`);
+      } else if (flushSecret !== this.#flushSecret) {
+        throw new Error(`Attempting to reuse a hook context outside its flush loop`);
+      }
+    }
   }
 
   /**
@@ -1225,10 +1235,10 @@ export class EntityManager<C = unknown> {
   async refresh(entity: Entity): Promise<void>;
   async refresh(entities: ReadonlyArray<Entity>): Promise<void>;
   async refresh(param?: Entity | ReadonlyArray<Entity> | { deepLoad?: boolean }): Promise<void> {
-    this.dataloaders = {};
+    this.#dataloaders = {};
     const deepLoad = param && "deepLoad" in param && param.deepLoad;
     let todo =
-      param === undefined ? this._entities : Array.isArray(param) ? param : isEntity(param) ? [param] : this._entities;
+      param === undefined ? this.#entities : Array.isArray(param) ? param : isEntity(param) ? [param] : this.#entities;
     const done = new Set<Entity>();
     while (todo.length > 0) {
       const copy = [...todo];
@@ -1283,7 +1293,7 @@ export class EntityManager<C = unknown> {
   // Currently only public for the driver impls
   public findExistingInstance<T>(id: string): T | undefined {
     assertIdIsTagged(id);
-    return this._entityIndex.get(id) as T | undefined;
+    return this.#entityIndex.get(id) as T | undefined;
   }
 
   /**
@@ -1331,11 +1341,11 @@ export class EntityManager<C = unknown> {
   }
 
   public beforeTransaction(fn: HookFn) {
-    this.hooks.beforeTransaction.push(fn);
+    this.#hooks.beforeTransaction.push(fn);
   }
 
   public afterTransaction(fn: HookFn) {
-    this.hooks.afterTransaction.push(fn);
+    this.#hooks.afterTransaction.push(fn);
   }
 
   /**
@@ -1357,7 +1367,7 @@ export class EntityManager<C = unknown> {
     // If we wanted to, if not in a transaction, we could potentially do lookups against a global cache,
     // to achieve cross-request batching. Granted we'd need all DataLoaders to have caching disabled, see:
     // https://github.com/stephenh/joist-ts/issues/629
-    const loadersForKind = (this.dataloaders[operation] ??= {});
+    const loadersForKind = (this.#dataloaders[operation] ??= {});
     return getOrSet(loadersForKind, batchKey, () => new DataLoader(fn, opts));
   }
 
@@ -1367,8 +1377,8 @@ export class EntityManager<C = unknown> {
 
   /** Recursively cascades any pending deletions. */
   private async cascadeDeletes(): Promise<void> {
-    let entities = this.pendingCascadeDeletes;
-    this.pendingCascadeDeletes = [];
+    let entities = this.#pendingCascadeDeletes;
+    this.#pendingCascadeDeletes = [];
     // Loop if our deletes cascade to other deletes
     while (entities.length > 0) {
       // For cascade delete relations, cascade the delete...
@@ -1380,10 +1390,21 @@ export class EntityManager<C = unknown> {
       await beforeDelete(this.ctx, todos);
       // For all relations, unhook the entity from the other side
       await Promise.all(entities.flatMap(getRelations).map((r) => r.cleanupOnEntityDeleted()));
-      entities = this.pendingCascadeDeletes;
-      this.pendingCascadeDeletes = [];
+      entities = this.#pendingCascadeDeletes;
+      this.#pendingCascadeDeletes = [];
     }
   }
+}
+
+export interface EntityManagerInternalApi {
+  joinRows: Record<string, JoinRow[]>;
+  pendingChildren: Map<string, Map<string, Entity[]>>;
+  hooks: Record<EntityManagerHook, HookFn[]>;
+  rm: ReactionsManager;
+}
+
+export function getEmInternalApi(em: EntityManager): EntityManagerInternalApi {
+  return (em as any)["__api"];
 }
 
 export let entityLimit = 10_000;
@@ -1503,11 +1524,11 @@ async function validateSimpleRules(todos: Record<string, Todo>): Promise<void> {
 }
 
 export function beforeTransaction(em: EntityManager, knex: Knex.Transaction): Promise<unknown> {
-  return Promise.all(em["hooks"].beforeTransaction.map((fn) => fn(em, knex)));
+  return Promise.all(getEmInternalApi(em)["hooks"].beforeTransaction.map((fn) => fn(em, knex)));
 }
 
 export function afterTransaction(em: EntityManager, knex: Knex.Transaction): Promise<unknown> {
-  return Promise.all(em["hooks"].afterTransaction.map((fn) => fn(em, knex)));
+  return Promise.all(getEmInternalApi(em)["hooks"].afterTransaction.map((fn) => fn(em, knex)));
 }
 
 async function runHook(

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1526,11 +1526,11 @@ async function validateSimpleRules(todos: Record<string, Todo>): Promise<void> {
 }
 
 export function beforeTransaction(em: EntityManager, knex: Knex.Transaction): Promise<unknown> {
-  return Promise.all(getEmInternalApi(em)["hooks"].beforeTransaction.map((fn) => fn(em, knex)));
+  return Promise.all(getEmInternalApi(em).hooks.beforeTransaction.map((fn) => fn(em, knex)));
 }
 
 export function afterTransaction(em: EntityManager, knex: Knex.Transaction): Promise<unknown> {
-  return Promise.all(getEmInternalApi(em)["hooks"].afterTransaction.map((fn) => fn(em, knex)));
+  return Promise.all(getEmInternalApi(em).hooks.afterTransaction.map((fn) => fn(em, knex)));
 }
 
 async function runHook(

--- a/packages/orm/src/dataloaders/findCountDataLoader.ts
+++ b/packages/orm/src/dataloaders/findCountDataLoader.ts
@@ -10,7 +10,7 @@ import {
   buildValuesCte,
   collectArgs,
   createBindings,
-  getKeyFromGenericStructure,
+  getBatchKeyFromGenericStructure,
   whereFilterHash,
 } from "./findDataLoader";
 
@@ -26,7 +26,7 @@ export function findCountDataLoader<T extends Entity>(
 
   const meta = getMetadata(type);
   const query = parseFindQuery(meta, where, opts);
-  const batchKey = getKeyFromGenericStructure(query);
+  const batchKey = getBatchKeyFromGenericStructure(query);
 
   return em.getLoader(
     "find-count",

--- a/packages/orm/src/dataloaders/findDataLoader.ts
+++ b/packages/orm/src/dataloaders/findDataLoader.ts
@@ -30,7 +30,7 @@ export function findDataLoader<T extends Entity>(
 
   const meta = getMetadata(type);
   const query = parseFindQuery(meta, where, opts);
-  const batchKey = getKeyFromGenericStructure(query);
+  const batchKey = getBatchKeyFromGenericStructure(query);
 
   return em.getLoader(
     "find",
@@ -282,7 +282,7 @@ function ensureUnderLimit(rows: unknown[]): void {
   }
 }
 
-export function getKeyFromGenericStructure(query: ParsedFindQuery): string {
+export function getBatchKeyFromGenericStructure(query: ParsedFindQuery): string {
   // Clone b/c parseFindQuery does not deep copy complex conditions, i.e. `a.firstName.eq(...)`
   const clone = structuredClone(query);
   stripValues(clone);

--- a/packages/orm/src/dataloaders/manyToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyDataLoader.ts
@@ -1,7 +1,7 @@
 import DataLoader from "dataloader";
 import { Entity } from "../Entity";
-import { EntityManager } from "../EntityManager";
-import { abbreviation, getMetadata, keyToNumber, keyToString, ManyToManyCollection, ParsedFindQuery } from "../index";
+import { EntityManager, getEmInternalApi } from "../EntityManager";
+import { ManyToManyCollection, ParsedFindQuery, abbreviation, getMetadata, keyToNumber, keyToString } from "../index";
 import { JoinRow } from "../relations/ManyToManyCollection";
 import { getOrSet } from "../utils";
 
@@ -34,7 +34,7 @@ async function load<T extends Entity, U extends Entity>(
   const rowsByKey: Record<string, JoinRow[]> = {};
 
   // Keep a reference to our row to track updates/deletes
-  const emJoinRows = getOrSet(em.__data.joinRows, joinTableName, []);
+  const emJoinRows = getOrSet(getEmInternalApi(em).joinRows, joinTableName, []);
 
   // Break out `column_id=string` keys out
   const columns: Record<string, string[]> = {};

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -80,7 +80,7 @@ export function setField<T extends Entity>(entity: T, fieldName: keyof T & strin
   ensureNotDeleted(entity, "pending");
   const { em } = entity;
 
-  em.checkWritesAllowed();
+  getEmInternalApi(em).checkWritesAllowed();
 
   const { data, originalData } = entity.__orm;
 

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -1,8 +1,8 @@
 import { Entity, EntityOrmField, isEntity } from "./Entity";
 import {
-  currentFlushSecret,
   EntityConstructor,
   EntityManager,
+  getEmInternalApi,
   MaybeAbstractEntityConstructor,
   OptsOf,
 } from "./EntityManager";
@@ -80,17 +80,7 @@ export function setField<T extends Entity>(entity: T, fieldName: keyof T & strin
   ensureNotDeleted(entity, "pending");
   const { em } = entity;
 
-  if (em.isFlushing) {
-    const { flushSecret } = currentFlushSecret.getStore() || {};
-    if (flushSecret === undefined) {
-      throw new Error(
-        `Cannot set '${fieldName}' on ${entity} during a flush outside of a entity hook or from afterCommit`,
-      );
-    }
-    if (flushSecret !== em["flushSecret"]) {
-      throw new Error(`Attempting to reuse a hook context outside its flush loop`);
-    }
-  }
+  em.checkWritesAllowed();
 
   const { data, originalData } = entity.__orm;
 
@@ -99,7 +89,7 @@ export function setField<T extends Entity>(entity: T, fieldName: keyof T & strin
     if (equalOrSameEntity(originalData[fieldName], newValue)) {
       data[fieldName] = newValue;
       delete originalData[fieldName];
-      em.__data.rm.dequeueDownstreamReactiveFields(entity, fieldName);
+      getEmInternalApi(em).rm.dequeueDownstreamReactiveFields(entity, fieldName);
       return true;
     }
   }
@@ -114,7 +104,7 @@ export function setField<T extends Entity>(entity: T, fieldName: keyof T & strin
   if (!(fieldName in originalData)) {
     originalData[fieldName] = currentValue;
   }
-  em.__data.rm.queueDownstreamReactiveFields(entity, fieldName);
+  getEmInternalApi(em).rm.queueDownstreamReactiveFields(entity, fieldName);
   data[fieldName] = newValue;
   return true;
 }

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -4,6 +4,7 @@ import {
   ensureNotDeleted,
   Entity,
   EntityMetadata,
+  getEmInternalApi,
   getMetadata,
   IdOf,
   ManyToManyField,
@@ -137,7 +138,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
         [this.columnName]: this.#entity,
         [this.otherColumnName]: other,
       };
-      getOrSet(this.#entity.em.__data.joinRows, this.joinTableName, []).push(joinRow);
+      getOrSet(getEmInternalApi(this.#entity.em).joinRows, this.joinTableName, []).push(joinRow);
       (other[this.otherFieldName] as any as ManyToManyCollection<U, T>).add(this.#entity, true);
     }
   }
@@ -146,7 +147,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     ensureNotDeleted(this.#entity, "pending");
 
     if (!percolated) {
-      const joinRows = getOrSet(this.#entity.em.__data.joinRows, this.joinTableName, []);
+      const joinRows = getOrSet(getEmInternalApi(this.#entity.em).joinRows, this.joinTableName, []);
       const row = joinRows.find((r) => r[this.columnName] === this.#entity && r[this.otherColumnName] === other);
       if (row) {
         row.deleted = true;
@@ -159,7 +160,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
           [this.otherColumnName]: other,
           deleted: true,
         };
-        getOrSet(this.#entity.em.__data.joinRows, this.joinTableName, []).push(joinRow);
+        getOrSet(getEmInternalApi(this.#entity.em).joinRows, this.joinTableName, []).push(joinRow);
       }
       (other[this.otherFieldName] as any as ManyToManyCollection<U, T>).remove(this.#entity, true);
     }
@@ -263,7 +264,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
       this.removedBeforeLoaded?.forEach((e) => {
         remove(this.loaded!, e);
         const { em } = this.#entity;
-        const row = em.__data.joinRows[this.joinTableName].find(
+        const row = getEmInternalApi(em).joinRows[this.joinTableName].find(
           (r) => r[this.columnName] === this.#entity && r[this.otherColumnName] === e,
         );
         if (row) {

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -1,5 +1,5 @@
 import { Entity, isEntity } from "../Entity";
-import { IdOf, currentlyInstantiatingEntity, sameEntity } from "../EntityManager";
+import { IdOf, currentlyInstantiatingEntity, getEmInternalApi, sameEntity } from "../EntityManager";
 import { EntityMetadata, ManyToOneField, getMetadata } from "../EntityMetadata";
 import {
   OneToManyLargeCollection,
@@ -280,10 +280,10 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     } else if (typeof id === "string") {
       // Other is not loaded in memory, but cache it in case our other side is later loaded
       const { em } = this.#entity;
-      let map = em.pendingChildren.get(id);
+      let map = getEmInternalApi(em).pendingChildren.get(id);
       if (!map) {
         map = new Map();
-        em.pendingChildren.set(id, map);
+        getEmInternalApi(em).pendingChildren.set(id, map);
       }
       let list = map.get(this.otherFieldName);
       if (!list) {

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -6,6 +6,7 @@ import {
   ensureNotDeleted,
   Entity,
   EntityMetadata,
+  getEmInternalApi,
   getMetadata,
   IdOf,
   maybeResolveReferenceToId,
@@ -228,7 +229,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     // be handled here?)
     if (!this.#entity.isNewEntity) {
       const { em } = this.#entity;
-      const newChildren = em.pendingChildren.get(this.#entity.idTagged!)?.get(this.fieldName);
+      const newChildren = getEmInternalApi(em).pendingChildren.get(this.#entity.idTagged!)?.get(this.fieldName);
       if (newChildren) {
         (this.#addedBeforeLoaded ??= []).push(...(newChildren as U[]));
         newChildren.splice(0, newChildren.length);

--- a/packages/orm/src/relations/hasPersistedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasPersistedAsyncProperty.ts
@@ -1,5 +1,5 @@
 import { Entity } from "../Entity";
-import { Const, currentlyInstantiatingEntity } from "../EntityManager";
+import { Const, currentlyInstantiatingEntity, getEmInternalApi } from "../EntityManager";
 import { getMetadata } from "../EntityMetadata";
 import { isLoaded, setField } from "../index";
 import { Reacted, ReactiveHint } from "../reactiveHints";
@@ -96,7 +96,7 @@ export class PersistedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint
       // official "being called during em.flush" update (...unless we're accessing it
       // during the validate phase of `em.flush`, then skip it to avoid tripping up
       // the "cannot change entities during flush" logic.)
-      if (!(this.#entity.em as any)._isValidating) {
+      if (!getEmInternalApi(this.#entity.em).isValidating) {
         setField(this.#entity, this.fieldName, newValue);
       }
       return newValue;

--- a/packages/orm/src/relations/hasPersistedAsyncReference.ts
+++ b/packages/orm/src/relations/hasPersistedAsyncReference.ts
@@ -5,6 +5,7 @@ import {
   ensureTagged,
   EntityMetadata,
   fail,
+  getEmInternalApi,
   getMetadata,
   isEntity,
   isLoaded,
@@ -115,7 +116,7 @@ export class PersistedAsyncReferenceImpl<
       // official "being called during em.flush" update (...unless we're accessing it
       // during the validate phase of `em.flush`, then skip it to avoid tripping up
       // the "cannot change entities during flush" logic.)
-      if (!(this.#entity.em as any)._isValidating) {
+      if (!getEmInternalApi(this.#entity.em).isValidating) {
         this.setImpl(newValue);
       }
       return this.maybeFindEntity();


### PR DESCRIPTION
Potential alternatives:

1. Current version, which is `#` private fields, exposed via a separate `__api` object
2. Stay with TS private fields, and have `getEmInternalApi` just return `em` directly casted, b/c the field names line up and callable, i.e.:

```
interface InternalApi {
  someField: string;
}

class Foo {
  private someField: string;
}

function getInternalApi(foo: Foo) {
  return foo as InternalApi;
}
```