### PR TITLE
Trying bun.

### DIFF
--- a/packages/integration-tests/benchmark.ts
+++ b/packages/integration-tests/benchmark.ts
@@ -1,7 +1,8 @@
-import * as console from "console";
 import { Benchmark } from "kelonio";
 import { knex as createKnex } from "knex";
 import postgres from "postgres";
+
+// Run with `yarn tsx ./benchmark.ts` or `bun ./benchmark.ts`
 
 const knex = createKnex({
   client: "pg",
@@ -17,7 +18,7 @@ async function main() {
   await knex.raw("select flush_database()");
 
   const benchmark = new Benchmark();
-  const numberOfEntities = 20;
+  const numberOfEntities = 2000;
   const iterations = 100;
 
   // Running with serial=false gives particularly bad results for the "individual" tests b/c each

--- a/packages/integration-tests/bunfig.toml
+++ b/packages/integration-tests/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/setupDbTests.ts"]

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -24,6 +24,7 @@
     "@swc/jest": "^0.2.26",
     "@types/jest": "^29.5.2",
     "@types/node": "^18.16.16",
+    "bun-types": "^0.7.0",
     "env-cmd": "^10.1.0",
     "jest": "^29.5.0",
     "jest-junit": "^16.0.0",

--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -1,4 +1,5 @@
 import { insertAuthor, insertBook, insertPublisher, select } from "@src/entities/inserts";
+import { describe, expect, it } from "bun:test";
 import { defaultValue, getMetadata, jan1, jan2 } from "joist-orm";
 import { newPgConnectionConfig } from "joist-utils";
 import pgStructure from "pg-structure";

--- a/packages/integration-tests/src/setupDbTests.ts
+++ b/packages/integration-tests/src/setupDbTests.ts
@@ -1,7 +1,7 @@
 import { EntityManager } from "@src/entities";
 import { InMemoryTestDriver, PostgresTestDriver, TestDriver } from "@src/testDrivers";
+import { afterAll, beforeAll, beforeEach } from "bun:test";
 import { Driver } from "joist-orm";
-import { toMatchEntity } from "joist-test-utils";
 import { Knex } from "knex";
 
 // Eventually set this via an env flag for dual CI builds, but for now just hard-coding
@@ -11,7 +11,7 @@ export const inMemory = false;
 export let testDriver: TestDriver;
 export let driver: Driver;
 export let knex: Knex;
-export const makeApiCall = jest.fn();
+export const makeApiCall = () => {}; // jest.fn();
 export let numberOfQueries = 0;
 export let queries: string[] = [];
 
@@ -22,7 +22,7 @@ export function newEntityManager() {
   return em;
 }
 
-expect.extend({ toMatchEntity });
+// expect.extend({ toMatchEntity });
 
 beforeAll(async () => {
   testDriver = inMemory ? new InMemoryTestDriver() : new PostgresTestDriver();

--- a/packages/integration-tests/src/testDrivers.ts
+++ b/packages/integration-tests/src/testDrivers.ts
@@ -34,7 +34,7 @@ export class PostgresTestDriver implements TestDriver {
     this.knex = createKnex({
       client: "pg",
       connection: newPgConnectionConfig(),
-      debug: false,
+      debug: true,
       asyncStackTraces: true,
     }).on("query", (e: any) => {
       recordQuery(e.sql);

--- a/packages/integration-tests/src/testDrivers.ts
+++ b/packages/integration-tests/src/testDrivers.ts
@@ -34,7 +34,7 @@ export class PostgresTestDriver implements TestDriver {
     this.knex = createKnex({
       client: "pg",
       connection: newPgConnectionConfig(),
-      debug: true,
+      debug: false,
       asyncStackTraces: true,
     }).on("query", (e: any) => {
       recordQuery(e.sql);

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "Node16",
     "strict": true,
-    "types": ["jest", "node"],
+    "types": ["jest", "node", "bun-types"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "composite": true,

--- a/packages/orm/src/config.ts
+++ b/packages/orm/src/config.ts
@@ -192,12 +192,15 @@ export class ConfigData<T extends Entity, C> {
   cachedReactiveLoadHints: Record<string, any> = {};
 }
 
+// i.e. `Foo.ts:123:4`
+const lineNumber = /s:\d+:\d+/;
+
 function getCallerName(): string {
   const err = getErrorObject();
   // E.g. at Object.<anonymous> (/home/stephen/homebound/graphql-service/src/entities/Activity.ts:86:8)
-  // (Make sure to drop lines that don't start with 'at' b/c the stack format can differ
+  // (Make sure to drop lines that don't end with '...Foo.ts:123:3' b/c the stack format can differ
   // slightly i.e. if running via tsx/using a node loader (probably?)
-  const line = err.stack!.split("\n").filter((line) => line.includes(" at "))[3];
+  const line = err.stack!.split("\n").filter((line) => line.match(lineNumber))[3];
   const parts = line.split("/");
   // Get the last part, which will be the file name, i.e. Activity.ts:86:8
   return parts[parts.length - 1].replace(/:\d+\)?$/, "");

--- a/yarn.lock
+++ b/yarn.lock
@@ -7927,6 +7927,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bun-types@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "bun-types@npm:0.7.0"
+  checksum: 1b6fb1ec5b8665a254cc95778121371b6ec2dac365b5aed95f8cdd2f6e2fa343fbf7e197796c10e0b97e713f0cb1aa83029f4f63cc9f81fec0073113181d4a74
+  languageName: node
+  linkType: hard
+
 "bytes@npm:3.0.0":
   version: 3.0.0
   resolution: "bytes@npm:3.0.0"
@@ -13016,6 +13023,7 @@ __metadata:
     "@swc/jest": ^0.2.26
     "@types/jest": ^29.5.2
     "@types/node": ^18.16.16
+    bun-types: ^0.7.0
     env-cmd: ^10.1.0
     jest: ^29.5.0
     jest-junit: ^16.0.0


### PR DESCRIPTION


```
$ yarn tsx ./benchmark.ts 
{ numberOfEntities: 20, iterations: 100, serial: false }
- - - - - - - - - - - - - - - - - Performance - - - - - - - - - - - - - - - - -
Knex 20 Authors individually:
  54.98002 ms (+/- 4.47285 ms) from 100 iterations (90.60917 total)
Knex 20 Authors with VALUES:
  9.60382 ms (+/- 0.8705 ms) from 100 iterations (17.31402 total)
Postgres.js 20 Authors individually:
  35.03314 ms (+/- 2.55702 ms) from 100 iterations (57.7876 total)
Postgres.js 20 Authors individual but pipelined:
  12.15234 ms (+/- 1.20982 ms) from 100 iterations (22.53366 total)
Postgres.js 20 Authors with VALUES:
  10.79837 ms (+/- 0.78941 ms) from 100 iterations (17.55825 total)
Knex 20 Authors & 20 Books with VALUES in txn:
  14.09879 ms (+/- 1.23703 ms) from 100 iterations (24.69181 total)
Knex 20 Authors & 20 Books with VALUES no txn:
  9.82445 ms (+/- 0.72382 ms) from 100 iterations (17.82231 total)
Postgres.js 20 Authors & 20 Books with VALUES in txn:
  10.15367 ms (+/- 0.97758 ms) from 100 iterations (18.19925 total)
Postgres.js 20 Authors & 20 Books with VALUES no txn:
  8.36935 ms (+/- 0.53088 ms) from 100 iterations (14.42399 total)
Postgres.js 20 Authors & Books 20 individual but pipelined in txn:
  22.27308 ms (+/- 1.88734 ms) from 100 iterations (37.0828 total)
Postgres.js 20 Authors & Books 20 individual but pipelined in order in txn:
  14.66987 ms (+/- 1.51559 ms) from 100 iterations (27.89266 total)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```

```
$ bun ./benchmark.ts
[0.00ms] ".env"
{
  numberOfEntities: 20,
  iterations: 100,
  serial: false
}
- - - - - - - - - - - - - - - - - Performance - - - - - - - - - - - - - - - - -
Knex 20 Authors individually:
  107.99749 ms (+/- 4.70359 ms) from 100 iterations (142.78433 total)
Knex 20 Authors with VALUES:
  10.22446 ms (+/- 0.97155 ms) from 100 iterations (18.94254 total)
Postgres.js 20 Authors individually:
  94.83945 ms (+/- 2.0869 ms) from 100 iterations (112.80325 total)
Postgres.js 20 Authors individual but pipelined:
  12.02272 ms (+/- 1.11337 ms) from 100 iterations (22.11956 total)
Postgres.js 20 Authors with VALUES:
  8.55829 ms (+/- 0.74603 ms) from 100 iterations (15.12889 total)
Knex 20 Authors & 20 Books with VALUES in txn:
  47.43201 ms (+/- 1.35576 ms) from 100 iterations (59.21472 total)
Knex 20 Authors & 20 Books with VALUES no txn:
  15.91467 ms (+/- 1.39611 ms) from 100 iterations (27.21155 total)
Postgres.js 20 Authors & 20 Books with VALUES in txn:
  9.66795 ms (+/- 0.91306 ms) from 100 iterations (17.40216 total)
Postgres.js 20 Authors & 20 Books with VALUES no txn:
  7.82525 ms (+/- 0.63469 ms) from 100 iterations (14.38368 total)
Postgres.js 20 Authors & Books 20 individual but pipelined in txn:
  16.00505 ms (+/- 1.48175 ms) from 100 iterations (29.23786 total)
Postgres.js 20 Authors & Books 20 individual but pipelined in order in txn:
  15.22288 ms (+/- 1.57789 ms) from 100 iterations (28.77216 total)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```