### PR TITLE
feat: Add transientFields convention to Reacted.

### DIFF
--- a/packages/integration-tests/src/Entity.test.ts
+++ b/packages/integration-tests/src/Entity.test.ts
@@ -10,12 +10,6 @@ describe("Entity", () => {
     const copy = deepCopyAndNormalize(author);
     expect(copy).toMatchInlineSnapshot(`
       {
-        "afterCommitIdIsSet": false,
-        "afterCommitIsDeletedEntity": false,
-        "afterCommitIsNewEntity": false,
-        "afterCommitRan": false,
-        "afterValidationRan": false,
-        "ageRuleInvoked": 0,
         "allPublisherAuthorNames": {
           "fn": {},
           "loadPromise": undefined,
@@ -31,10 +25,6 @@ describe("Entity", () => {
           "otherFieldName": "mentor",
           "undefined": null,
         },
-        "beforeCreateRan": false,
-        "beforeDeleteRan": false,
-        "beforeFlushRan": false,
-        "beforeUpdateRan": false,
         "bookComments": {
           "fieldName": "bookComments",
           "fn": {},
@@ -46,7 +36,6 @@ describe("Entity", () => {
             },
           },
         },
-        "bookCommentsCalcInvoked": 0,
         "books": {
           "fieldName": "books",
           "loaded": undefined,
@@ -68,7 +57,6 @@ describe("Entity", () => {
           "otherFieldName": "currentDraftAuthor",
           "undefined": null,
         },
-        "deleteDuringFlush": false,
         "favoriteBook": {
           "_isLoaded": false,
           "fieldName": "favoriteBook",
@@ -82,7 +70,6 @@ describe("Entity", () => {
           },
           "undefined": null,
         },
-        "graduatedRuleInvoked": 0,
         "image": {
           "_isLoaded": false,
           "fieldName": "image",
@@ -123,7 +110,6 @@ describe("Entity", () => {
           "otherFieldName": "authors",
           "undefined": null,
         },
-        "mentorRuleInvoked": 0,
         "numberOfBooks": {
           "fieldName": "numberOfBooks",
           "fn": {},
@@ -142,7 +128,6 @@ describe("Entity", () => {
             "isReactive": true,
           },
         },
-        "numberOfBooksCalcInvoked": 0,
         "numberOfPublicReviews": {
           "fieldName": "numberOfPublicReviews",
           "fn": {},
@@ -201,7 +186,6 @@ describe("Entity", () => {
             "load": {},
           },
         },
-        "setGraduatedInFlush": undefined,
         "tags": {
           "addedBeforeLoaded": undefined,
           "columnName": "author_id",
@@ -211,6 +195,24 @@ describe("Entity", () => {
           "otherColumnName": "tag_id",
           "otherFieldName": "authors",
           "removedBeforeLoaded": undefined,
+        },
+        "transientFields": {
+          "afterCommitIdIsSet": false,
+          "afterCommitIsDeletedEntity": false,
+          "afterCommitIsNewEntity": false,
+          "afterCommitRan": false,
+          "afterValidationRan": false,
+          "ageRuleInvoked": 0,
+          "beforeCreateRan": false,
+          "beforeDeleteRan": false,
+          "beforeFlushRan": false,
+          "beforeUpdateRan": false,
+          "bookCommentsCalcInvoked": 0,
+          "deleteDuringFlush": false,
+          "graduatedRuleInvoked": 0,
+          "mentorRuleInvoked": 0,
+          "numberOfBooksCalcInvoked": 0,
+          "setGraduatedInFlush": false,
         },
         "userOneToOne": {
           "_isLoaded": false,

--- a/packages/integration-tests/src/EntityManager.reactiveRules.test.tsx
+++ b/packages/integration-tests/src/EntityManager.reactiveRules.test.tsx
@@ -66,12 +66,12 @@ describe("EntityManager.reactiveRules", () => {
     const a = newAuthor(em);
     await em.flush();
     // Then we run the mentor rule
-    expect(a.mentorRuleInvoked).toBe(1);
+    expect(a.transientFields.mentorRuleInvoked).toBe(1);
     // And when we do set the mentor
     a.mentor.set(newAuthor(em));
     await em.flush();
     // Then it runs again
-    expect(a.mentorRuleInvoked).toBe(2);
+    expect(a.transientFields.mentorRuleInvoked).toBe(2);
   });
 
   it.withCtx("runs rule triggered by a hook", async ({ em }) => {
@@ -79,15 +79,15 @@ describe("EntityManager.reactiveRules", () => {
     const a = newAuthor(em);
     await em.flush();
     // And the rule runs b/c all rules run on create
-    expect(a.graduatedRuleInvoked).toBe(1);
+    expect(a.transientFields.graduatedRuleInvoked).toBe(1);
     // When we change something about the author
     a.mentor.set(newAuthor(em));
     // And also tell the hook to change graduated
-    a.setGraduatedInFlush = true;
+    a.transientFields.setGraduatedInFlush = true;
     await em.flush();
     // Then the validation rule (or async derived field) that depends on
     // `Author.graduated` runs again
-    expect(a.graduatedRuleInvoked).toBe(2);
+    expect(a.transientFields.graduatedRuleInvoked).toBe(2);
   });
 
   it.withCtx("runs rule on parent of an immutable field", async ({ em }) => {
@@ -232,25 +232,25 @@ describe("EntityManager.reactiveRules", () => {
     // When I flush
     await em.flush();
     // Then I expect that the bookComments has been calc'd
-    expect(a.bookCommentsCalcInvoked).toEqual(1);
+    expect(a.transientFields.bookCommentsCalcInvoked).toEqual(1);
     expect(a.bookComments.fieldValue).toEqual("B1C1, B1C2, B2C1, B2C2");
     // And when a publisher with a comment is created
     const p = newPublisher(em, { authors: [a], comments: [{}, {}] });
     await em.flush();
     // Then bookComments is not recalc'd
-    expect(a.bookCommentsCalcInvoked).toEqual(1);
+    expect(a.transientFields.bookCommentsCalcInvoked).toEqual(1);
     // And when one of the authors book comments is touched
     const [commentB1C1] = a.books.get[0].comments.get;
     commentB1C1.text = "B1C1 - Updated";
     await em.flush();
     // Then I expect that bookComments was recalc'd
-    expect(a.bookCommentsCalcInvoked).toEqual(2);
+    expect(a.transientFields.bookCommentsCalcInvoked).toEqual(2);
     expect(a.bookComments.fieldValue).toEqual("B1C1 - Updated, B1C2, B2C1, B2C2");
     // And when I move the comment to be on a publisher instead
     commentB1C1.parent.set(p);
     await em.flush();
     // Then I expect that the bookComments is recalc'd
-    expect(a.bookCommentsCalcInvoked).toEqual(3);
+    expect(a.transientFields.bookCommentsCalcInvoked).toEqual(3);
     expect(a.bookComments.fieldValue).toEqual("B1C2, B2C1, B2C2");
   });
 

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -690,7 +690,7 @@ describe("EntityManager", () => {
     const em = newEntityManager();
     const author = await em.load(Author, "1");
     author.firstName = "new name";
-    author.setGraduatedInFlush = true;
+    author.transientFields.setGraduatedInFlush = true;
     expect(author.graduated).toBeUndefined();
     await em.flush();
     expect(author.graduated).toBeDefined();
@@ -1476,7 +1476,7 @@ describe("EntityManager", () => {
     // When we delete the author from a beforeFlush hook
     const em2 = newEntityManager();
     const a2 = await em2.load(Author, a1.idOrFail);
-    a2.deleteDuringFlush = true;
+    a2.transientFields.deleteDuringFlush = true;
     em2.touch(a2);
     await em2.flush();
     // Then the entities were deleted
@@ -1490,7 +1490,7 @@ describe("EntityManager", () => {
     const em = newEntityManager();
     const a1 = newAuthor(em, { books: [{ reviews: [{}] }] });
     // When we delete the author before its even been saved
-    a1.deleteDuringFlush = true;
+    a1.transientFields.deleteDuringFlush = true;
     await em.flush();
     // Then the entities were not saved
     expect(await countOfAuthors()).toBe(0);

--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -180,44 +180,44 @@ describe("Author", () => {
     // Given that a validation exists preventing the firstName and lastName from being the same values
     const em = newEntityManager();
     const a1 = new Author(em, { firstName: "a1", lastName: "a1" });
-    expect(a1.afterValidationRan).toBeFalsy();
+    expect(a1.transientFields.afterValidationRan).toBeFalsy();
 
     // When a flush occurs with the skipValidation option set to true
     await em.flush({ skipValidation: true });
 
     // Then it does not run afterValidation hooks
-    expect(a1.afterValidationRan).toBeFalsy();
+    expect(a1.transientFields.afterValidationRan).toBeFalsy();
   });
 
   it("can have lifecycle hooks", async () => {
     const em = newEntityManager();
     const a1 = new Author(em, { firstName: "a1" });
-    expect(a1.beforeFlushRan).toBeFalsy();
-    expect(a1.beforeCreateRan).toBeFalsy();
-    expect(a1.beforeUpdateRan).toBeFalsy();
-    expect(a1.afterCommitRan).toBeFalsy();
-    expect(a1.afterCommitIdIsSet).toBeFalsy();
-    expect(a1.afterCommitIsNewEntity).toBeFalsy();
-    expect(a1.afterValidationRan).toBeFalsy();
-    expect(a1.beforeDeleteRan).toBeFalsy();
+    expect(a1.transientFields.beforeFlushRan).toBeFalsy();
+    expect(a1.transientFields.beforeCreateRan).toBeFalsy();
+    expect(a1.transientFields.beforeUpdateRan).toBeFalsy();
+    expect(a1.transientFields.afterCommitRan).toBeFalsy();
+    expect(a1.transientFields.afterCommitIdIsSet).toBeFalsy();
+    expect(a1.transientFields.afterCommitIsNewEntity).toBeFalsy();
+    expect(a1.transientFields.afterValidationRan).toBeFalsy();
+    expect(a1.transientFields.beforeDeleteRan).toBeFalsy();
     await em.flush();
-    expect(a1.beforeFlushRan).toBeTruthy();
-    expect(a1.beforeCreateRan).toBeTruthy();
-    expect(a1.beforeUpdateRan).toBeFalsy();
-    expect(a1.beforeDeleteRan).toBeFalsy();
-    expect(a1.afterValidationRan).toBeTruthy();
-    expect(a1.afterCommitRan).toBeTruthy();
-    expect(a1.afterCommitIdIsSet).toBeTruthy();
-    expect(a1.afterCommitIsNewEntity).toBeTruthy();
+    expect(a1.transientFields.beforeFlushRan).toBeTruthy();
+    expect(a1.transientFields.beforeCreateRan).toBeTruthy();
+    expect(a1.transientFields.beforeUpdateRan).toBeFalsy();
+    expect(a1.transientFields.beforeDeleteRan).toBeFalsy();
+    expect(a1.transientFields.afterValidationRan).toBeTruthy();
+    expect(a1.transientFields.afterCommitRan).toBeTruthy();
+    expect(a1.transientFields.afterCommitIdIsSet).toBeTruthy();
+    expect(a1.transientFields.afterCommitIsNewEntity).toBeTruthy();
     a1.firstName = "new name";
-    a1.beforeCreateRan = false;
+    a1.transientFields.beforeCreateRan = false;
     await em.flush();
-    expect(a1.beforeCreateRan).toBeFalsy();
-    expect(a1.beforeUpdateRan).toBeTruthy();
+    expect(a1.transientFields.beforeCreateRan).toBeFalsy();
+    expect(a1.transientFields.beforeUpdateRan).toBeTruthy();
     em.delete(a1);
     await em.flush();
-    expect(a1.beforeDeleteRan).toBeTruthy();
-    expect(a1.afterCommitIsDeletedEntity).toBeTruthy();
+    expect(a1.transientFields.beforeDeleteRan).toBeTruthy();
+    expect(a1.transientFields.afterCommitIsDeletedEntity).toBeTruthy();
   });
 
   it("can access the context in hooks", async () => {
@@ -249,13 +249,13 @@ describe("Author", () => {
     const a1 = new Author(em, { firstName: "a1" });
     await em.flush();
     expect(a1.numberOfBooks.get).toEqual(0);
-    expect(a1.numberOfBooksCalcInvoked).toBe(2);
+    expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(2);
     // When we add a book
     new Book(em, { title: "b1", author: a1 });
     // Then the author derived value is re-derived
     await em.flush();
     expect(a1.numberOfBooks.get).toEqual(1);
-    expect(a1.numberOfBooksCalcInvoked).toBe(4);
+    expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(4);
     const rows = await select("authors");
     expect(rows[0].number_of_books).toEqual(1);
   });
@@ -300,13 +300,13 @@ describe("Author", () => {
     await em.flush();
     expect(a1.numberOfBooks.get).toEqual(1);
     // And we calc'd it once during flush, and again in the ^ get
-    expect(a1.numberOfBooksCalcInvoked).toBe(2);
+    expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(2);
     // When we change the book
     b1.title = "b12";
     await em.flush();
     // Then the author derived value didn't change
     expect(a1.numberOfBooks.get).toEqual(1);
-    expect(a1.numberOfBooksCalcInvoked).toBe(3);
+    expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(3);
   });
 
   it("can force async derived values to recalc on touch", async () => {
@@ -315,14 +315,14 @@ describe("Author", () => {
     const a1 = newAuthor(em, { firstName: "a1" });
     await em.flush();
     expect(a1.numberOfBooks.get).toEqual(0);
-    expect(a1.numberOfBooksCalcInvoked).toBe(2);
+    expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(2);
     // When we touch the author
     em.touch(a1);
     await em.flush();
     // Then the author derived value didn't change
     expect(a1.numberOfBooks.get).toEqual(0);
     // But it was called again
-    expect(a1.numberOfBooksCalcInvoked).toBe(4);
+    expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(4);
   });
 
   it("has async derived values triggered on both old and new value", async () => {

--- a/packages/integration-tests/src/getProperties.test.ts
+++ b/packages/integration-tests/src/getProperties.test.ts
@@ -75,10 +75,17 @@ describe("getProperties", () => {
         "mentor",
         "publisher",
         "image",
-        "beforeFlushRan",
-        "beforeDeleteRan",
-        "afterCommitRan",
       ]),
     );
+  });
+
+  it("does not include fullNonReactiveAccess", () => {
+    const p = Object.keys(getProperties(authorMeta));
+    expect(p).not.toEqual(expect.arrayContaining(["fullNonReactiveAccess"]));
+  });
+
+  it("does not include transientFields", () => {
+    const p = Object.keys(getProperties(authorMeta));
+    expect(p).not.toEqual(expect.arrayContaining(["transientFields"]));
   });
 });

--- a/packages/orm/src/getProperties.ts
+++ b/packages/orm/src/getProperties.ts
@@ -30,7 +30,7 @@ export function getProperties<T extends Entity>(meta: EntityMetadata<T>): Record
         }
       })
       // Purposefully return methods, primitives, etc. so that `entityResolver` can add them to the resolver
-      .filter(([key]) => key !== "entity"),
+      .filter(([key]) => key !== "fullNonReactiveAccess" && key !== "transientFields"),
   );
   return propertiesCache[meta.tagName];
 }

--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -66,7 +66,13 @@ export type Reacted<T extends Entity, H> = Entity & {
    * will then allow accessing the field via the `Reacted<Author, ...>` type.
    */
   fullNonReactiveAccess: Loaded<T, H>;
-};
+} & MaybeTransientFields<T>;
+
+export type MaybeTransientFields<T> = "transientFields" extends keyof T
+  ? {
+      transientFields: T["transientFields"];
+    }
+  : {};
 
 export function reverseReactiveHint<T extends Entity>(
   rootType: MaybeAbstractEntityConstructor<T>,


### PR DESCRIPTION
This conventionalizes having `transientFields` that Reacted logic is allowed to access.

This is generally similar to going through `fullNonReactiveAccess`, but:

1. Is less scary that `fullNonReactiveAccess`
2. Provides an alternative to `fullNonReactiveAccess` to avoid normalizing usage of `fNRA`
3. Highlights that transient fields are not columns/fields in the db