### PR TITLE
fix: Transitively load derived values when the entities are new.

### DIFF
--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -292,6 +292,28 @@ describe("Author", () => {
     expect(a2.numberOfPublicReviews2.get).toEqual(0);
   });
 
+  it("can load derived fields that depend on derived fields", async () => {
+    const em = newEntityManager();
+    // Given an author with a derived field that uses a derived field
+    const a1 = new Author(em, { firstName: "a1", age: 22, graduated: new Date() });
+    const b1 = newBook(em, { author: a1 });
+    const br = newBookReview(em, { rating: 1, book: b1 });
+    const comment = newComment(em, { text: "", parent: br });
+    await em.flush();
+    // When we want to recalc numberOfPublicReviews2
+    const em2 = newEntityManager();
+    const a2 = await em2.load(Author, a1.idOrFail, "books");
+    // And we've also made a new BookReview that doesn't have an existing value calculated yet
+    const br2 = em.create(BookReview, { book: a2.books.get[0], rating: 2 });
+    // Then the numberOfPublicReviews2.load will ensure isPublic is loaded first
+    expect(await a2.numberOfPublicReviews2.load()).toBe(2);
+    // And we calc'd the br2.isPublic b/c it's new
+    expect(br2.transientFields.isPublicCalc).toBe(2);
+    // But we did not calc the br2.isPublic b/c it was already unavailable
+    const [br1] = await a2.books.get[0].reviews.load();
+    expect(br1.transientFields.isPublicCalc).toBe(0);
+  });
+
   it("can save when async derived values don't change", async () => {
     const em = newEntityManager();
     // Given an author with a book

--- a/packages/integration-tests/src/entities/Author.test.ts
+++ b/packages/integration-tests/src/entities/Author.test.ts
@@ -303,13 +303,13 @@ describe("Author", () => {
     // When we want to recalc numberOfPublicReviews2
     const em2 = newEntityManager();
     const a2 = await em2.load(Author, a1.idOrFail, "books");
-    // And we've also made a new BookReview that doesn't have an existing value calculated yet
+    // And we make a new BookReview that doesn't have isPublic calculated yet
     const br2 = em.create(BookReview, { book: a2.books.get[0], rating: 2 });
-    // Then the numberOfPublicReviews2.load will ensure isPublic is loaded first
+    // Then the numberOfPublicReviews2.load will ensure br2.isPublic is loaded first
     expect(await a2.numberOfPublicReviews2.load()).toBe(2);
     // And we calc'd the br2.isPublic b/c it's new
     expect(br2.transientFields.isPublicCalc).toBe(2);
-    // But we did not calc the br2.isPublic b/c it was already unavailable
+    // But we did not calc the br2.isPublic b/c it was already available
     const [br1] = await a2.books.get[0].reviews.load();
     expect(br1.transientFields.isPublicCalc).toBe(0);
   });

--- a/packages/integration-tests/src/entities/BookReview.ts
+++ b/packages/integration-tests/src/entities/BookReview.ts
@@ -13,6 +13,7 @@ import { Author, BookReviewCodegen, bookReviewConfig as config, Publisher } from
 export class BookReview extends BookReviewCodegen {
   // Currently this infers as Reference<BookReview, Author, undefined> --> it should be never...
   readonly author: Reference<BookReview, Author, never> = hasOneThrough((review) => review.book.author);
+  transientFields = { isPublicCalc: 0 };
 
   // This is kind of silly domain wise, but used as an example of hasOneDerived with a load hint. We don't
   // technically have any conditional logic in `get` so could use a lens, but we want to test hasOneDerived.
@@ -26,6 +27,7 @@ export class BookReview extends BookReviewCodegen {
     "isPublic",
     { book: { author: ["age", "graduated"] } },
     (review) => {
+      review.transientFields.isPublicCalc++;
       const author = review.book.get.author.get;
       // Currently our multi-hop reactivity recalc is more aggressive (runs before) our multi-hop
       // cascade deletion (which requires multiple 'pending loops' within `em.flush`), so we might

--- a/packages/integration-tests/src/relations/PersistedAsyncProperty.test.ts
+++ b/packages/integration-tests/src/relations/PersistedAsyncProperty.test.ts
@@ -12,8 +12,8 @@ describe("PersistedAsyncProperty", () => {
     await insertBookReview({ rating: 1, book_id: 1 });
     const em = newEntityManager();
     // And we can load the numberOfPublicReviews tree
-    const a = await em.load(Author, "a:1", "numberOfPublicReviews");
-    expect(a.numberOfPublicReviews.get).toBe(1);
+    const a = await em.load(Author, "a:1");
+    expect(await a.numberOfPublicReviews.load()).toBe(1);
     // When we move Book b2 into a1 (instead of creating a new one, to ensure its review collection is not loaded)
     const b2 = await em.load(Book, "b:2");
     b2.author.set(a);

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -942,9 +942,11 @@ export class EntityManager<C = unknown> {
             // property that we ourselves depend on, don't bother loading it if it's
             // already been calculated (i.e. we have no reason to believe its value
             // is stale, so we should avoid pulling all of its data into memory).
-            if (relation instanceof PersistedAsyncPropertyImpl && relation.isSet) {
-              return;
-            }
+            //
+            // But if it's _not_ previously set, i.e. b/c the entity itself is a new entity,
+            // then go ahead and call `.load()` so that the downstream reactive calc can
+            // call `.get` to evaluate its derived value.
+            if (relation instanceof PersistedAsyncPropertyImpl && relation.isSet) return;
             return relation.isLoaded && !opts.forceReload ? undefined : (relation.load(opts) as Promise<any>);
           });
         });

--- a/packages/orm/src/loadHints.ts
+++ b/packages/orm/src/loadHints.ts
@@ -180,6 +180,7 @@ export function isLoaded<T extends Entity, H extends LoadHint<T>>(entity: T, hin
   } else if (typeof hint === "object") {
     return Object.entries(hint as object).every(([key, nestedHint]) => {
       const relation = (entity as any)[key];
+      if (typeof relation.load !== "function") return true;
       if (relation.isLoaded) {
         const result = relation.get;
         return Array.isArray(result)

--- a/packages/orm/src/relations/hasPersistedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasPersistedAsyncProperty.ts
@@ -78,12 +78,16 @@ export class PersistedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint
   load(opts?: { forceReload?: boolean }): Promise<V> {
     const { loadHint } = this;
     if (!this.loaded || opts?.forceReload) {
-      return (this.loadPromise ??= this.#entity.em.populate(this.#entity, loadHint).then(() => {
-        this.loadPromise = undefined;
-        this.loaded = true;
-        // Go through `this.get` so that `setField` is called to set our latest value
-        return this.get;
-      }));
+      return (this.loadPromise ??= this.#entity.em
+        // Usually populate takes a loadHint, but cheat and give it our reactive hint
+        // to make sure any downstream reactive derived fields are themselves populated.
+        .populate(this.#entity, { hint: this.reactiveHint, allowFields: true } as any)
+        .then(() => {
+          this.loadPromise = undefined;
+          this.loaded = true;
+          // Go through `this.get` so that `setField` is called to set our latest value
+          return this.get;
+        }));
     }
     return Promise.resolve(this.get);
   }

--- a/packages/orm/src/relations/hasPersistedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasPersistedAsyncProperty.ts
@@ -23,7 +23,19 @@ export interface PersistedAsyncProperty<T extends Entity, V> {
   isLoaded: boolean;
   isSet: boolean;
 
-  /** Calculates the latest derived value. */
+  /**
+   * Calculates the latest derived value.
+   *
+   * Users are not required to call this method explicitly, as Joist will keep the
+   * persisted value automatically in-sync, but if for some reason (code changes,
+   * bug fixes, etc.) you need to trigger an explicit recalc, you can call `.load()`,
+   * any dependent data will be loaded from the database, and the latest value
+   * returned, and then later stored to the database on `em.flush`.
+   *
+   * Note that persisted properties used in load hints, i.e. `em.populate`s that
+   * accidentally list reactive fields (instead of just relations) will not have
+   * `.load()` invoked, and will instead use the previously-calculated value.
+   */
   load(opts?: { forceReload?: boolean }): Promise<V>;
 
   /** If loaded, returns the latest derived value, or if unload returns the previously-calculated value. */


### PR DESCRIPTION
This prevents 'scopeUpdated has not been derived yet' errors, when we've created a new entity, and some dependent field depends on a field within the new entity.

Note that we're careful to only call `.load()` on derived fields that are explicitly new/not set yet, as otherwise we'd defeat the purpose of "derived fields can depend on other derived fields to cheaply calculate their values".