### PR TITLE
fix: Fix derived field populate

### DIFF
--- a/packages/integration-tests/src/EntityManager.populate.test.ts
+++ b/packages/integration-tests/src/EntityManager.populate.test.ts
@@ -223,11 +223,4 @@ describe("EntityManager.populate", () => {
     const p = em.load(Author, "a:1", { publisher: "size" });
     await expect(p).rejects.toThrow("Invalid load hint 'size' on SmallPublisher:1");
   });
-
-  it("doesn't blow up on reactive hint tags", async () => {
-    const em = newEntityManager();
-    const a = newAuthor(em);
-    await em.populate(a, { hint: "numberOfPublicReviews2:ro", allowFields: true } as any);
-    await em.populate(a, { hint: "numberOfPublicReviews2_ro", allowFields: true } as any);
-  });
 });

--- a/packages/integration-tests/src/reactiveHints.test.ts
+++ b/packages/integration-tests/src/reactiveHints.test.ts
@@ -131,6 +131,11 @@ describe("reactiveHints", () => {
       });
     });
 
+    it("works with persisted derived fields", () => {
+      expect(convertToLoadHint(getMetadata(BookReview), { isPublic: {} })).toStrictEqual({ isPublic: {} });
+      expect(convertToLoadHint(getMetadata(BookReview), { isPublic_ro: {} })).toStrictEqual({ isPublic: {} });
+    });
+
     it("does not squash multiple expanded hints", () => {
       // Given one Author hasReactiveAsyncProperty that goes through publisher -> comments
       expect(convertToLoadHint(am, ["latestComment2"])).toEqual({

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -949,7 +949,7 @@ export class EntityManager<C = unknown> {
             // But if it's _not_ previously set, i.e. b/c the entity itself is a new entity,
             // then go ahead and call `.load()` so that the downstream reactive calc can
             // call `.get` to evaluate its derived value.
-            if (relation instanceof PersistedAsyncPropertyImpl && relation.isSet) return;
+            if (allowFields && relation instanceof PersistedAsyncPropertyImpl && relation.isSet) return;
             return relation.isLoaded && !opts.forceReload ? undefined : (relation.load(opts) as Promise<any>);
           });
         });

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -50,7 +50,7 @@ import {
   tagId,
 } from "./index";
 import { LoadHint, Loaded, NestedLoadHint, New, RelationsIn } from "./loadHints";
-import { normalizeHint, suffixRe } from "./normalizeHints";
+import { normalizeHint } from "./normalizeHints";
 import { followReverseHint } from "./reactiveHints";
 import { ManyToOneReferenceImpl, OneToOneReferenceImpl, PersistedAsyncReferenceImpl } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
@@ -925,20 +925,14 @@ export class EntityManager<C = unknown> {
       (batch) => {
         // Because we're using `{ cache: false }`, we could have dups in the list, so unique
         const list = [...new Set(batch)];
-        const { allowFields } = opts as any;
 
         const hints = Object.entries(normalizeHint(hintOpt as any));
 
         // One breadth-width pass to ensure each relation is loaded
         const loadPromises = list.flatMap((entity) => {
           return hints.map(([key]) => {
-            // Watch for hasPersistedAsyncProperty passing us a reactive hint...
-            if (allowFields) key = key.replace(suffixRe, "");
             const relation = (entity as any)[key];
             if (!relation || typeof relation.load !== "function") {
-              // We let hasPersistedAsyncProperty ask us to populate field-level reactive
-              // hints, but only as an internal implementation detail.
-              if (allowFields && getMetadata(entity as any).allFields[key]) return;
               throw new Error(`Invalid load hint '${key}' on ${entity}`);
             }
             // If we're populating a hasPersistedAsyncProperty, and find an upstream
@@ -949,7 +943,12 @@ export class EntityManager<C = unknown> {
             // But if it's _not_ previously set, i.e. b/c the entity itself is a new entity,
             // then go ahead and call `.load()` so that the downstream reactive calc can
             // call `.get` to evaluate its derived value.
-            if (allowFields && relation instanceof PersistedAsyncPropertyImpl && relation.isSet) return;
+            if (
+              (opts as any).isPersistedAsyncPropertyLoad &&
+              relation instanceof PersistedAsyncPropertyImpl &&
+              relation.isSet
+            )
+              return;
             return relation.isLoaded && !opts.forceReload ? undefined : (relation.load(opts) as Promise<any>);
           });
         });
@@ -958,8 +957,6 @@ export class EntityManager<C = unknown> {
         return Promise.all(loadPromises).then(() => {
           const nestedLoadPromises = hints.map(([key, nestedHint]) => {
             if (Object.keys(nestedHint).length === 0) return;
-            // Watch for hasPersistedAsyncProperty passing us a reactive hint...
-            if (allowFields) key = key.replace(suffixRe, "");
             // Unique for good measure?...
             const children = [...new Set(list.map((entity) => toArray(getEvenDeleted((entity as any)[key]))).flat())];
             if (children.length === 0) return;

--- a/packages/orm/src/reactiveHints.ts
+++ b/packages/orm/src/reactiveHints.ts
@@ -230,7 +230,7 @@ export async function followReverseHint(entities: Entity[], reverseHint: string[
   return current;
 }
 
-/** Converts a reactive `hint` into a load hint. */
+/** Converts a normalized reactive `hint` into a load hint. */
 export function convertToLoadHint<T extends Entity>(meta: EntityMetadata<T>, hint: ReactiveHint<T>): LoadHint<T> {
   const loadHint = {};
   // Process the hints individually instead of just calling Object.fromEntries so that
@@ -243,10 +243,14 @@ export function convertToLoadHint<T extends Entity>(meta: EntityMetadata<T>, hin
         case "m2m":
         case "m2o":
         case "o2m":
-        case "o2o": {
+        case "o2o":
           mergeNormalizedHints(loadHint, { [key]: convertToLoadHint(field.otherMetadata(), subHint) });
-        }
+          break;
         case "primitive":
+          if (field.derived === "async") {
+            mergeNormalizedHints(loadHint, { [key]: {} });
+          }
+          continue;
         case "enum":
           continue;
         default:

--- a/packages/orm/src/relations/hasPersistedAsyncProperty.ts
+++ b/packages/orm/src/relations/hasPersistedAsyncProperty.ts
@@ -91,9 +91,7 @@ export class PersistedAsyncPropertyImpl<T extends Entity, H extends ReactiveHint
     const { loadHint } = this;
     if (!this.loaded || opts?.forceReload) {
       return (this.loadPromise ??= this.#entity.em
-        // Usually populate takes a loadHint, but cheat and give it our reactive hint
-        // to make sure any downstream reactive derived fields are themselves populated.
-        .populate(this.#entity, { hint: this.reactiveHint, allowFields: true } as any)
+        .populate(this.#entity, { hint: this.loadHint, isPersistedAsyncPropertyLoad: true } as any)
         .then(() => {
           this.loadPromise = undefined;
           this.loaded = true;


### PR DESCRIPTION
    A previous fix allowed derived fields to .load() their dependencies,
    i.e. if those dependencies were themselves new and not yet calced.

    However, it did that conditionally, i.e. if the dependency was already
    calced, it would not re-calc it. Which is the desired behavior, to avoid
    re-calculating a whole tree of derived values unnecessary.

    That said, it broke that explicit `.populate` calls are the programmer
    requesting a fresh calc, i.e. where they know they've recently mutated
    the graph, so this PR restores the behavior.