### PR TITLE
fix: CTI BaseEntity.toJSON skipping parent fields

### DIFF
--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -13,7 +13,18 @@ import {
   update,
 } from "@src/entities/inserts";
 import { Loaded, sameEntity, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
-import { Author, Book, Color, Comment, Publisher, PublisherSize, PublisherType, newAuthor, newBook, newPublisher } from "./entities";
+import {
+  Author,
+  Book,
+  Color,
+  Comment,
+  Publisher,
+  PublisherSize,
+  PublisherType,
+  newAuthor,
+  newBook,
+  newPublisher,
+} from "./entities";
 import { knex, maybeBeginAndCommit, newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
 
 describe("EntityManager", () => {
@@ -1071,17 +1082,17 @@ describe("EntityManager", () => {
 
   it("has a simple toJSON for CTI entities", async () => {
     await insertPublisher({ name: "a1" });
-    await insertAuthor({first_name: "1"});
+    await insertAuthor({ first_name: "1" });
     const em = newEntityManager();
     const p1 = await em.load(Publisher, "1");
     const a1 = await em.load(Author, "1");
-    a1.setPartial({publisher: p1});
-    p1.setPartial({latitude: 12, longitude: 14});
+    a1.setPartial({ publisher: p1 });
+    p1.setPartial({ latitude: 12, longitude: 14 });
     await em.flush();
     expect(p1.toJSON()).toEqual({
       id: "p:1",
-      city: 'city',
-      name: 'a1',
+      city: "city",
+      name: "a1",
       latitude: 12,
       longitude: 14,
       allAuthorNames: "1",

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -1080,7 +1080,7 @@ describe("EntityManager", () => {
     });
   });
 
-  it("has a simple toJSON for CTI entities", async () => {
+  it("includes parent and child properties within toJSON", async () => {
     await insertPublisher({ name: "a1" });
     await insertAuthor({ first_name: "1" });
     const em = newEntityManager();

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -13,7 +13,7 @@ import {
   update,
 } from "@src/entities/inserts";
 import { Loaded, sameEntity, setDefaultEntityLimit, setEntityLimit } from "joist-orm";
-import { Author, Book, Color, Comment, Publisher, PublisherSize, newAuthor, newBook, newPublisher } from "./entities";
+import { Author, Book, Color, Comment, Publisher, PublisherSize, PublisherType, newAuthor, newBook, newPublisher } from "./entities";
 import { knex, maybeBeginAndCommit, newEntityManager, numberOfQueries, queries, resetQueryCount } from "./setupDbTests";
 
 describe("EntityManager", () => {
@@ -1066,6 +1066,31 @@ describe("EntityManager", () => {
       ssn: null,
       updatedAt: expect.anything(),
       wasEverPopular: null,
+    });
+  });
+
+  it("has a simple toJSON for CTI entities", async () => {
+    await insertPublisher({ name: "a1" });
+    await insertAuthor({first_name: "1"});
+    const em = newEntityManager();
+    const p1 = await em.load(Publisher, "1");
+    const a1 = await em.load(Author, "1");
+    a1.setPartial({publisher: p1});
+    p1.setPartial({latitude: 12, longitude: 14});
+    await em.flush();
+    expect(p1.toJSON()).toEqual({
+      id: "p:1",
+      city: 'city',
+      name: 'a1',
+      latitude: 12,
+      longitude: 14,
+      allAuthorNames: "1",
+      group: null,
+      hugeNumber: null,
+      size: null,
+      type: PublisherType.Big,
+      createdAt: expect.anything(),
+      updatedAt: expect.anything(),
     });
   });
 

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -121,7 +121,7 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
    */
   public toJSON(): object {
     return Object.fromEntries(
-      Object.values(getMetadata(this).fields)
+      Object.values(getMetadata(this).allFields)
         .map((f) => {
           switch (f.kind) {
             case "primaryKey":


### PR DESCRIPTION
Observed the below behaviour when serialising CTI entities with toJSON, of skipping fields of the parent class:
<img width="450" alt="joist-cti-logging-issue-demo" src="https://github.com/stephenh/joist-ts/assets/26485400/1f226186-5c59-4e08-9652-730252a1bce7">

On the assumption that this isn't the desired behaviour:
* Added a test case to repro + catch this
* Updated the toJSON function to use metadata.allFields instead of metadata.fields