### PR TITLE
feat: Codegen strict-mode

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -27,6 +27,7 @@ import {
   mapSimpleDbTypeToTypescriptType,
   parseOrder,
   tableToEntityName,
+  logWarning,
 } from "./utils";
 
 /** All the entities + enums in our database. */
@@ -508,9 +509,7 @@ function newManyToOneField(config: Config, entity: Entity, r: M2ORelation): Many
   const ignore = isFieldIgnored(config, entity, fieldName, notNull, column.default !== null);
   // Make sure the constraint is deferrable
   if (!r.foreignKey.isDeferred || !r.foreignKey.isDeferrable) {
-    console.log(
-      `WARNING: Foreign key ${r.foreignKey.name} is not DEFERRABLE/INITIALLY DEFERRED, see https://joist-orm.io/docs/getting-started/schema-assumptions#deferred-constraints`,
-    );
+    logWarning(config, `WARNING: Foreign key ${r.foreignKey.name} is not DEFERRABLE/INITIALLY DEFERRED, see https://joist-orm.io/docs/getting-started/schema-assumptions#deferred-constraints`);
   }
   const derived = fkFieldDerived(config, entity, fieldName);
   return { kind: "m2o", fieldName, columnName, otherEntity, otherFieldName, notNull, ignore, derived, dbType };

--- a/packages/codegen/src/config.test.ts
+++ b/packages/codegen/src/config.test.ts
@@ -1,5 +1,6 @@
 import { Config, defaultConfig, FieldConfig, isFieldIgnored } from "./config";
 import { makeEntity } from "./EntityDbMetadata";
+import { logWarning } from "./utils";
 
 describe("config", () => {
   describe("isFieldIgnored", () => {
@@ -54,6 +55,14 @@ describe("config", () => {
       );
     });
   });
+  it('Config strict mode', () => {
+    it("warn util throws when config set to strict", () => {
+      expect(logWarning({...defaultConfig, strictMode: true}, 'Some Error')).toThrow();
+    });
+    it("warn util does not throws when config not set to strict", () => {
+      expect(logWarning({...defaultConfig, strictMode: false}, 'Some Error')).not.toThrow();
+    });
+  })
 });
 
 function newAuthorConfig(fields?: Record<string, FieldConfig>): Config {

--- a/packages/codegen/src/config.test.ts
+++ b/packages/codegen/src/config.test.ts
@@ -1,6 +1,5 @@
 import { Config, defaultConfig, FieldConfig, isFieldIgnored } from "./config";
 import { makeEntity } from "./EntityDbMetadata";
-import { logWarning } from "./utils";
 
 describe("config", () => {
   describe("isFieldIgnored", () => {
@@ -55,14 +54,6 @@ describe("config", () => {
       );
     });
   });
-  it('Config strict mode', () => {
-    it("warn util throws when config set to strict", () => {
-      expect(logWarning({...defaultConfig, strictMode: true}, 'Some Error')).toThrow();
-    });
-    it("warn util does not throws when config not set to strict", () => {
-      expect(logWarning({...defaultConfig, strictMode: false}, 'Some Error')).not.toThrow();
-    });
-  })
 });
 
 function newAuthorConfig(fields?: Record<string, FieldConfig>): Config {

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -78,6 +78,10 @@ export interface Config {
   idType?: "untagged-string";
   // We don't persist this, and instead just use it as a cache
   __tableToEntityName?: Record<string, string>;
+  /**
+   * Allows the user to specify that codegen should throw when it would normally log a warning.
+   */
+  strictMode?: boolean;
 }
 
 export const defaultConfig: Config = {

--- a/packages/codegen/src/utils.test.ts
+++ b/packages/codegen/src/utils.test.ts
@@ -1,0 +1,13 @@
+import { defaultConfig } from "./config";
+import { logWarning } from "./utils";
+
+describe("utils", () => {
+  it("Config strict mode", () => {
+    it("warn util throws when config set to strict", () => {
+      expect(logWarning({ ...defaultConfig, strictMode: true }, "Some Error")).toThrow();
+    });
+    it("warn util does not throws when config not set to strict", () => {
+      expect(logWarning({ ...defaultConfig, strictMode: false }, "Some Error")).not.toThrow();
+    });
+  });
+});

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -5,6 +5,14 @@ import pluralize from "pluralize";
 import { DatabaseColumnType, PrimitiveTypescriptType } from "./EntityDbMetadata";
 import { Config, getTimestampConfig } from "./config";
 
+export function logWarning(config: Config, message: string) {
+  if(config.strictMode) {
+    throw new Error(message);
+  } else {
+    console.warn(message);
+  }
+}
+
 export function assertNever(x: never): never {
   throw new Error("Unexpected object: " + x);
 }


### PR DESCRIPTION
Introduces a new joist-config.json option, `strictMode`, defaulting to `false`, where warnings what would normally just be logged will instead throw. 
An example case being CI/DI running codegen and warning of a non-deferred FK, would probably want to throw rather than continue and knowingly deploy code that's going to fail on INSERT and UPDATE queries.

Non-deferred FKs are the principle target here. I do see there are additional logged warnings around the config containing references to non-existent fields. I've currently left them not using this feature, but that does feel a bit inconsistent with it being "strict". However those do not seem as actively dangerous as a non-deferred FK, so am open to input as to if those should should throw or not.

There's some interesting questions around testing this. I've extracted the feature into it's own tiny function that's easily tested. But I didn't see a decent place or way to fully test it with an integration style test within codegen, and am open to ideas on that (assuming it's even felt as necessary). 