### PR TITLE
feat: Codegen - Delayed throw on non-deferred FK Found

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -259,7 +259,7 @@ export class EntityDbMetadata {
       .filter((r) => !isComponentOfPolymorphicRelation(config, r))
       .filter((r) => !isBaseClassForeignKey(r))
       .map((r) => {
-        const {field, invalid} = newManyToOneField(config, this.entity, r);
+        const { field, invalid } = newManyToOneField(config, this.entity, r);
         if (invalid) {
           this.invalidDeferredFK = true;
         }
@@ -502,7 +502,11 @@ function newPgEnumField(config: Config, entity: Entity, column: Column): PgEnumF
   };
 }
 
-function newManyToOneField(config: Config, entity: Entity, r: M2ORelation): {field: ManyToOneField, invalid: boolean} {
+function newManyToOneField(
+  config: Config,
+  entity: Entity,
+  r: M2ORelation,
+): { field: ManyToOneField; invalid: boolean } {
   let invalid = false;
   const column = r.foreignKey.columns[0];
   const columnName = column.name;
@@ -523,7 +527,10 @@ function newManyToOneField(config: Config, entity: Entity, r: M2ORelation): {fie
     invalid = true;
   }
   const derived = fkFieldDerived(config, entity, fieldName);
-  return {field: { kind: "m2o", fieldName, columnName, otherEntity, otherFieldName, notNull, ignore, derived, dbType }, invalid};
+  return {
+    field: { kind: "m2o", fieldName, columnName, otherEntity, otherFieldName, notNull, ignore, derived, dbType },
+    invalid,
+  };
 }
 
 function newOneToMany(config: Config, entity: Entity, r: O2MRelation): OneToManyField {

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -56,9 +56,17 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
   const contextType = config.contextType ? imp(config.contextType) : "{}";
   const BaseEntity = imp("BaseEntity@joist-orm");
 
+  const invalidEntities = entities.filter((e) => e.invalidDeferredFK);
   const metadataFile: CodegenFile = {
     name: "./metadata.ts",
     contents: code`
+    ${
+      invalidEntities.length > 0
+        ? `throw new Error('Misconfigured Foreign Keys found in the following entities: ${invalidEntities
+            .map((e) => e.name)
+            .join(",")}');`
+        : ``
+    }
       export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}> {}
 
       export function getEm(e: ${BaseEntity}): EntityManager {

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -54,7 +54,7 @@ if (require.main === module) {
 
     const entityTables = db.tables.filter((t) => isEntityTable(config, t)).sortBy("name");
     const entities = entityTables.map((table) => new EntityDbMetadata(config, table, enums));
-    if(entities.some((entity) => entity.invalidDeferredFK)){
+    if (entities.some((entity) => entity.invalidDeferredFK)) {
       safeExit = false;
     }
 
@@ -93,8 +93,8 @@ if (require.main === module) {
     warnInvalidEntries(config, dbMetadata);
 
     await generateAndSaveFiles(config, dbMetadata);
-    if (!safeExit){
-      throw new Error('A warning was generated during codegen');
+    if (!safeExit) {
+      throw new Error("A warning was generated during codegen");
     }
   })().catch((err) => {
     console.error(err);

--- a/packages/graphql-codegen/src/testUtils.ts
+++ b/packages/graphql-codegen/src/testUtils.ts
@@ -56,6 +56,7 @@ export function newEntityMetadata(name: string, opts: Partial<EntityDbMetadata> 
     deletedAt: undefined,
     baseClassName: undefined,
     abstract: false,
+    invalidDeferredFK: false,
     ...opts,
   };
 }


### PR DESCRIPTION
A continuation / rework of: https://github.com/stephenh/joist-ts/pull/777

Summary: 
* Move to a console.warn for the warning around the FK not being deferred
* Crash with a non-zero exit code if any entities are deemed invalid for having an non-deferred FK
    * In this case also insert a throw within `metadata.ts` to ensure the generated code won't run in an unsafe manner despite the codegen throw