### PR TITLE
feat: Change id to behave like idOrFail.

### DIFF
--- a/docs/docs/testing/test-utils.md
+++ b/docs/docs/testing/test-utils.md
@@ -36,7 +36,7 @@ This means we can immediately assert against `a.books.get` without needing to lo
 const a1 = newAuthor(em);
 await performPostBook(em);
 // Example of what we _don't_ need to do: reload a1
-await a1_2 = em.load(Author, a1.idOrFail);
+await a1_2 = em.load(Author, a1.id);
 expect(a.books.get.length).toEqual(1);
 ```
 

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -361,10 +361,10 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
   const factoryMethod = imp(`new${entity.name}@./entities`);
   const EntityManager = imp("t:EntityManager@./entities");
 
-  const idCode =
+  const idMaybeCode =
     config.idType === "untagged-string"
-      ? code`return ${deTagId}(${metadata}, this.idTagged);`
-      : code`return this.idTagged;`;
+      ? code`return ${deTagId}(${metadata}, this.idTaggedMaybe);`
+      : code`return this.idTaggedMaybe;`;
 
   const maybeIsSoftDeleted = meta.deletedAt
     ? code`
@@ -506,20 +506,20 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
 
       ${cstr}
 
-      get id(): ${entityName}Id | undefined {
-        ${idCode}
+      get id(): ${entityName}Id {
+        return this.idMaybe || ${failSymbol}("${entityName} has no id yet");
       }
 
-      get idOrFail(): ${entityName}Id {
-        return this.id || ${failSymbol}("${entityName} has no id yet");
+      get idMaybe(): ${entityName}Id | undefined {
+        ${idMaybeCode}
       }
 
-      get idTagged(): ${entityName}Id | undefined {
+      get idTagged(): ${entityName}Id {
+        return this.idTaggedMaybe || ${failSymbol}("${entityName} has no id tagged yet");
+      }
+
+      get idTaggedMaybe(): ${entityName}Id | undefined {
         return this.__orm.data["id"];
-      }
-
-      get idTaggedOrFail(): ${entityName}Id {
-        return this.idTagged || ${failSymbol}("${entityName} has no id tagged yet");
       }
 
       ${primitives}

--- a/packages/graphql-resolver-utils/src/entityResolver.ts
+++ b/packages/graphql-resolver-utils/src/entityResolver.ts
@@ -85,7 +85,7 @@ export function entityResolver<T extends Entity, A extends Record<string, keyof 
               selectionSet.selections[0].kind === "Field" &&
               selectionSet.selections[0].name.value === "id"
             ) {
-              return (entity as any)[ormField.fieldName].id;
+              return (entity as any)[ormField.fieldName].idMaybe;
             }
           }
         }

--- a/packages/graphql-resolver-utils/src/entityResolver.ts
+++ b/packages/graphql-resolver-utils/src/entityResolver.ts
@@ -57,7 +57,7 @@ export function entityResolver<T extends Entity, A extends Record<string, keyof 
   aliases?: A,
 ): EntityResolver<T> & { [K in keyof A]: EntityResolver<T>[A[K]] } {
   const idResolver = (entityOrId: T | string) => {
-    return typeof entityOrId === "string" ? entityOrId : entityOrId.idOrFail;
+    return typeof entityOrId === "string" ? entityOrId : entityOrId.id;
   };
 
   const primitiveResolvers = Object.values(entityMetadata.fields)

--- a/packages/graphql-resolver-utils/src/makeRunObject.ts
+++ b/packages/graphql-resolver-utils/src/makeRunObject.ts
@@ -23,7 +23,7 @@ type RunResolverMethod<T, R> = <K extends keyof T, A extends ResolverArgs<T, K>>
 export function makeRunObject<T, R extends ResolverRoot<T>>(resolvers: T): RunResolverMethod<T, R> {
   return (ctx, root, key, args) =>
     run(ctx, async (ctx) => {
-      const _root = isEntity(root) ? await ctx.em.load((root as any).idOrFail) : root;
+      const _root = isEntity(root) ? await ctx.em.load((root as any).id) : root;
       return (resolvers[key] as any)(_root, args instanceof Function ? args() : args ?? {}, ctx, undefined!);
     });
 }

--- a/packages/graphql-resolver-utils/src/makeRunObjectFields.ts
+++ b/packages/graphql-resolver-utils/src/makeRunObjectFields.ts
@@ -7,7 +7,7 @@ import { ResolverResult, ResolverRoot } from "./makeRunObject";
 export function makeRunObjectFields<T, R extends ResolverRoot<T>>(resolver: T): RunKeysResolverMethod<T, R> {
   return (ctx, root, keys) => {
     return run(ctx, async (ctx) => {
-      const _root = isEntity(root) ? await ctx.em.load((root as any).idOrFail) : root;
+      const _root = isEntity(root) ? await ctx.em.load((root as any).id) : root;
       // Build a result with each key, where keys might return a promise, so we `await` to make assertions easier
       return Object.fromEntries(
         await Promise.all(keys.map(async (key) => [key, await (resolver[key] as any)(_root, {}, ctx, undefined!)])),

--- a/packages/integration-tests/src/EntityManager.assignNewIds.test.ts
+++ b/packages/integration-tests/src/EntityManager.assignNewIds.test.ts
@@ -8,7 +8,7 @@ describe("EntityManager.assignNewIds", () => {
 
     // Given an entity
     const p1 = newPublisher(em, { name: "p1" });
-    expect(p1.id).toBeUndefined();
+    expect(p1.idMaybe).toBeUndefined();
 
     // When I ask to assign the ids
     await em.assignNewIds();

--- a/packages/integration-tests/src/EntityManager.clone.test.ts
+++ b/packages/integration-tests/src/EntityManager.clone.test.ts
@@ -32,7 +32,7 @@ describe("EntityManager.clone", () => {
 
     // Then we expect the cloned entity to have the same properties as the original
     expect(a2.firstName).toEqual(a1.firstName);
-    expect(a2.publisher.idOrFail).toEqual(p1.id);
+    expect(a2.publisher.id).toEqual(p1.id);
     expect(a2.id).not.toEqual(a1.id);
     expect(await numberOf(em, Author, Publisher)).toEqual([2, 1]);
     expect(p1.authors.get).toEqual([a1, a2]);
@@ -64,7 +64,7 @@ describe("EntityManager.clone", () => {
 
     // When we clone it in a 2nd UoW
     const em2 = newEntityManager();
-    const a2 = await em2.load(Author, a1.idOrFail);
+    const a2 = await em2.load(Author, a1.id);
     const a3 = await em2.clone(a2);
 
     // Then the a3.publisher loaded state is correct
@@ -251,7 +251,7 @@ describe("EntityManager.clone", () => {
     await em.flush();
     // When we clone it in a new UoW
     const em2 = newEntityManager();
-    const c2 = await em2.load(Comment, c1.idOrFail);
+    const c2 = await em2.load(Comment, c1.id);
     const c3 = await em2.clone(c2);
     // Then the parent can be loaded
     expect(await c3.parent.load()).toBeInstanceOf(Author);

--- a/packages/integration-tests/src/EntityManager.lens.test.ts
+++ b/packages/integration-tests/src/EntityManager.lens.test.ts
@@ -158,7 +158,7 @@ describe("EntityManager.lens", () => {
     await insertBook({ title: "b1", author_id: 1 });
     const em = newEntityManager();
     const b1 = await em.load(Book, "1");
-    const p1Id = await b1.load((b) => b.author.publisher.idOrFail);
+    const p1Id = await b1.load((b) => b.author.publisher.id);
     expect(p1Id).toEqual("p:1");
   });
 

--- a/packages/integration-tests/src/EntityManager.test.ts
+++ b/packages/integration-tests/src/EntityManager.test.ts
@@ -793,7 +793,7 @@ describe("EntityManager", () => {
     new Author(em, { firstName: "a1" });
     await em.flush();
     const a = await em.findOrCreate(Author, { firstName: "a2" }, { age: 20 }, { lastName: "l" });
-    expect(a.id).toBeUndefined();
+    expect(a.idMaybe).toBeUndefined();
     expect(a.lastName).toEqual("l");
     expect(a.age).toEqual(20);
   });
@@ -803,7 +803,7 @@ describe("EntityManager", () => {
     const em = newEntityManager();
     const p1 = await em.load(Publisher, "p:1");
     const a = await em.findOrCreate(Author, { publisher: p1 }, { firstName: "a1" });
-    expect(a.id).toBeUndefined();
+    expect(a.idMaybe).toBeUndefined();
     expect(await p1.authors.load()).toMatchEntity([a]);
   });
 
@@ -812,7 +812,7 @@ describe("EntityManager", () => {
     const em = newEntityManager();
     const p1 = await em.load(Publisher, "p:1");
     const c = await em.findOrCreate(Comment, { parent: p1 }, {});
-    expect(c.id).toBeUndefined();
+    expect(c.idMaybe).toBeUndefined();
     expect(await p1.comments.load()).toMatchEntity([c]);
   });
 
@@ -1489,8 +1489,8 @@ describe("EntityManager", () => {
       await em.assignNewIds();
 
       expect(sameEntity(a1, a1)).toEqual(true);
-      expect(sameEntity(a1, a1.idOrFail)).toEqual(true);
-      expect(sameEntity(a1.idOrFail, a1)).toEqual(true);
+      expect(sameEntity(a1, a1.id)).toEqual(true);
+      expect(sameEntity(a1.id, a1)).toEqual(true);
     });
 
     it("handles existing entities", async () => {
@@ -1516,7 +1516,7 @@ describe("EntityManager", () => {
     await em.flush();
     // When we delete the author from a beforeFlush hook
     const em2 = newEntityManager();
-    const a2 = await em2.load(Author, a1.idOrFail);
+    const a2 = await em2.load(Author, a1.id);
     a2.transientFields.deleteDuringFlush = true;
     em2.touch(a2);
     await em2.flush();

--- a/packages/integration-tests/src/entities/AuthorCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorCodegen.ts
@@ -318,20 +318,20 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 
-  get id(): AuthorId | undefined {
-    return this.idTagged;
+  get id(): AuthorId {
+    return this.idMaybe || fail("Author has no id yet");
   }
 
-  get idOrFail(): AuthorId {
-    return this.id || fail("Author has no id yet");
+  get idMaybe(): AuthorId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): AuthorId | undefined {
+  get idTagged(): AuthorId {
+    return this.idTaggedMaybe || fail("Author has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): AuthorId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): AuthorId {
-    return this.idTagged || fail("Author has no id tagged yet");
   }
 
   get firstName(): string {

--- a/packages/integration-tests/src/entities/AuthorStatCodegen.ts
+++ b/packages/integration-tests/src/entities/AuthorStatCodegen.ts
@@ -152,20 +152,20 @@ export abstract class AuthorStatCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as AuthorStat, opts, { calledFromConstructor: true });
   }
 
-  get id(): AuthorStatId | undefined {
-    return this.idTagged;
+  get id(): AuthorStatId {
+    return this.idMaybe || fail("AuthorStat has no id yet");
   }
 
-  get idOrFail(): AuthorStatId {
-    return this.id || fail("AuthorStat has no id yet");
+  get idMaybe(): AuthorStatId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): AuthorStatId | undefined {
+  get idTagged(): AuthorStatId {
+    return this.idTaggedMaybe || fail("AuthorStat has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): AuthorStatId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): AuthorStatId {
-    return this.idTagged || fail("AuthorStat has no id tagged yet");
   }
 
   get smallint(): number {

--- a/packages/integration-tests/src/entities/Book.test.ts
+++ b/packages/integration-tests/src/entities/Book.test.ts
@@ -6,7 +6,7 @@ describe("Book", () => {
     const em = newEntityManager();
     const a1 = em.create(Author, { firstName: "a1" });
     const b1 = em.create(Book, { title: "b1", author: a1 });
-    expect(b1.author.id).toBeUndefined();
+    expect(() => b1.author.id).toThrow("Reference is assigned to a new entity");
     expect(b1.author.isSet).toBe(true);
   });
 

--- a/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
+++ b/packages/integration-tests/src/entities/BookAdvanceCodegen.ts
@@ -131,20 +131,20 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as BookAdvance, opts, { calledFromConstructor: true });
   }
 
-  get id(): BookAdvanceId | undefined {
-    return this.idTagged;
+  get id(): BookAdvanceId {
+    return this.idMaybe || fail("BookAdvance has no id yet");
   }
 
-  get idOrFail(): BookAdvanceId {
-    return this.id || fail("BookAdvance has no id yet");
+  get idMaybe(): BookAdvanceId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): BookAdvanceId | undefined {
+  get idTagged(): BookAdvanceId {
+    return this.idTaggedMaybe || fail("BookAdvance has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): BookAdvanceId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): BookAdvanceId {
-    return this.idTagged || fail("BookAdvance has no id tagged yet");
   }
 
   get createdAt(): Date {

--- a/packages/integration-tests/src/entities/BookCodegen.ts
+++ b/packages/integration-tests/src/entities/BookCodegen.ts
@@ -190,20 +190,20 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 
-  get id(): BookId | undefined {
-    return this.idTagged;
+  get id(): BookId {
+    return this.idMaybe || fail("Book has no id yet");
   }
 
-  get idOrFail(): BookId {
-    return this.id || fail("Book has no id yet");
+  get idMaybe(): BookId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): BookId | undefined {
+  get idTagged(): BookId {
+    return this.idTaggedMaybe || fail("Book has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): BookId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): BookId {
-    return this.idTagged || fail("Book has no id tagged yet");
   }
 
   get title(): string {

--- a/packages/integration-tests/src/entities/BookReviewCodegen.ts
+++ b/packages/integration-tests/src/entities/BookReviewCodegen.ts
@@ -140,20 +140,20 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as BookReview, opts, { calledFromConstructor: true });
   }
 
-  get id(): BookReviewId | undefined {
-    return this.idTagged;
+  get id(): BookReviewId {
+    return this.idMaybe || fail("BookReview has no id yet");
   }
 
-  get idOrFail(): BookReviewId {
-    return this.id || fail("BookReview has no id yet");
+  get idMaybe(): BookReviewId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): BookReviewId | undefined {
+  get idTagged(): BookReviewId {
+    return this.idTaggedMaybe || fail("BookReview has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): BookReviewId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): BookReviewId {
-    return this.idTagged || fail("BookReview has no id tagged yet");
   }
 
   get rating(): number {

--- a/packages/integration-tests/src/entities/CommentCodegen.ts
+++ b/packages/integration-tests/src/entities/CommentCodegen.ts
@@ -151,20 +151,20 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Comment, opts, { calledFromConstructor: true });
   }
 
-  get id(): CommentId | undefined {
-    return this.idTagged;
+  get id(): CommentId {
+    return this.idMaybe || fail("Comment has no id yet");
   }
 
-  get idOrFail(): CommentId {
-    return this.id || fail("Comment has no id yet");
+  get idMaybe(): CommentId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): CommentId | undefined {
+  get idTagged(): CommentId {
+    return this.idTaggedMaybe || fail("Comment has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): CommentId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): CommentId {
-    return this.idTagged || fail("Comment has no id tagged yet");
   }
 
   get text(): string | undefined {

--- a/packages/integration-tests/src/entities/CriticCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticCodegen.ts
@@ -147,20 +147,20 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Critic, opts, { calledFromConstructor: true });
   }
 
-  get id(): CriticId | undefined {
-    return this.idTagged;
+  get id(): CriticId {
+    return this.idMaybe || fail("Critic has no id yet");
   }
 
-  get idOrFail(): CriticId {
-    return this.id || fail("Critic has no id yet");
+  get idMaybe(): CriticId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): CriticId | undefined {
+  get idTagged(): CriticId {
+    return this.idTaggedMaybe || fail("Critic has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): CriticId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): CriticId {
-    return this.idTagged || fail("Critic has no id tagged yet");
   }
 
   get name(): string {

--- a/packages/integration-tests/src/entities/CriticColumnCodegen.ts
+++ b/packages/integration-tests/src/entities/CriticColumnCodegen.ts
@@ -104,20 +104,20 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as CriticColumn, opts, { calledFromConstructor: true });
   }
 
-  get id(): CriticColumnId | undefined {
-    return this.idTagged;
+  get id(): CriticColumnId {
+    return this.idMaybe || fail("CriticColumn has no id yet");
   }
 
-  get idOrFail(): CriticColumnId {
-    return this.id || fail("CriticColumn has no id yet");
+  get idMaybe(): CriticColumnId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): CriticColumnId | undefined {
+  get idTagged(): CriticColumnId {
+    return this.idTaggedMaybe || fail("CriticColumn has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): CriticColumnId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): CriticColumnId {
-    return this.idTagged || fail("CriticColumn has no id tagged yet");
   }
 
   get name(): string {

--- a/packages/integration-tests/src/entities/Image.test.ts
+++ b/packages/integration-tests/src/entities/Image.test.ts
@@ -8,7 +8,7 @@ describe("Image", () => {
     const a1 = em.create(Author, { firstName: "a1" });
     const i = em.create(Image, { type: ImageType.AuthorImage, author: a1, fileName: "f1" });
     await em.flush();
-    expect(i.idOrFail).toEqual("i:1");
+    expect(i.id).toEqual("i:1");
   });
 
   it("cannot have multiple owners", async () => {

--- a/packages/integration-tests/src/entities/ImageCodegen.ts
+++ b/packages/integration-tests/src/entities/ImageCodegen.ts
@@ -144,20 +144,20 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Image, opts, { calledFromConstructor: true });
   }
 
-  get id(): ImageId | undefined {
-    return this.idTagged;
+  get id(): ImageId {
+    return this.idMaybe || fail("Image has no id yet");
   }
 
-  get idOrFail(): ImageId {
-    return this.id || fail("Image has no id yet");
+  get idMaybe(): ImageId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): ImageId | undefined {
+  get idTagged(): ImageId {
+    return this.idTaggedMaybe || fail("Image has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): ImageId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): ImageId {
-    return this.idTagged || fail("Image has no id tagged yet");
   }
 
   get fileName(): string {

--- a/packages/integration-tests/src/entities/LargePublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/LargePublisherCodegen.ts
@@ -105,20 +105,20 @@ export abstract class LargePublisherCodegen extends Publisher {
     setOpts(this as any as LargePublisher, opts, { calledFromConstructor: true });
   }
 
-  get id(): LargePublisherId | undefined {
-    return this.idTagged;
+  get id(): LargePublisherId {
+    return this.idMaybe || fail("LargePublisher has no id yet");
   }
 
-  get idOrFail(): LargePublisherId {
-    return this.id || fail("LargePublisher has no id yet");
+  get idMaybe(): LargePublisherId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): LargePublisherId | undefined {
+  get idTagged(): LargePublisherId {
+    return this.idTaggedMaybe || fail("LargePublisher has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): LargePublisherId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): LargePublisherId {
-    return this.idTagged || fail("LargePublisher has no id tagged yet");
   }
 
   get country(): string | undefined {

--- a/packages/integration-tests/src/entities/PublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherCodegen.ts
@@ -232,20 +232,20 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager> {
     }
   }
 
-  get id(): PublisherId | undefined {
-    return this.idTagged;
+  get id(): PublisherId {
+    return this.idMaybe || fail("Publisher has no id yet");
   }
 
-  get idOrFail(): PublisherId {
-    return this.id || fail("Publisher has no id yet");
+  get idMaybe(): PublisherId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): PublisherId | undefined {
+  get idTagged(): PublisherId {
+    return this.idTaggedMaybe || fail("Publisher has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): PublisherId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): PublisherId {
-    return this.idTagged || fail("Publisher has no id tagged yet");
   }
 
   get name(): string {

--- a/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
+++ b/packages/integration-tests/src/entities/PublisherGroupCodegen.ts
@@ -119,20 +119,20 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as PublisherGroup, opts, { calledFromConstructor: true });
   }
 
-  get id(): PublisherGroupId | undefined {
-    return this.idTagged;
+  get id(): PublisherGroupId {
+    return this.idMaybe || fail("PublisherGroup has no id yet");
   }
 
-  get idOrFail(): PublisherGroupId {
-    return this.id || fail("PublisherGroup has no id yet");
+  get idMaybe(): PublisherGroupId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): PublisherGroupId | undefined {
+  get idTagged(): PublisherGroupId {
+    return this.idTaggedMaybe || fail("PublisherGroup has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): PublisherGroupId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): PublisherGroupId {
-    return this.idTagged || fail("PublisherGroup has no id tagged yet");
   }
 
   get name(): string | undefined {

--- a/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
+++ b/packages/integration-tests/src/entities/SmallPublisherCodegen.ts
@@ -92,20 +92,20 @@ export abstract class SmallPublisherCodegen extends Publisher {
     setOpts(this as any as SmallPublisher, opts, { calledFromConstructor: true });
   }
 
-  get id(): SmallPublisherId | undefined {
-    return this.idTagged;
+  get id(): SmallPublisherId {
+    return this.idMaybe || fail("SmallPublisher has no id yet");
   }
 
-  get idOrFail(): SmallPublisherId {
-    return this.id || fail("SmallPublisher has no id yet");
+  get idMaybe(): SmallPublisherId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): SmallPublisherId | undefined {
+  get idTagged(): SmallPublisherId {
+    return this.idTaggedMaybe || fail("SmallPublisher has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): SmallPublisherId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): SmallPublisherId {
-    return this.idTagged || fail("SmallPublisher has no id tagged yet");
   }
 
   get city(): string {

--- a/packages/integration-tests/src/entities/TagCodegen.ts
+++ b/packages/integration-tests/src/entities/TagCodegen.ts
@@ -144,20 +144,20 @@ export abstract class TagCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Tag, opts, { calledFromConstructor: true });
   }
 
-  get id(): TagId | undefined {
-    return this.idTagged;
+  get id(): TagId {
+    return this.idMaybe || fail("Tag has no id yet");
   }
 
-  get idOrFail(): TagId {
-    return this.id || fail("Tag has no id yet");
+  get idMaybe(): TagId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): TagId | undefined {
+  get idTagged(): TagId {
+    return this.idTaggedMaybe || fail("Tag has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): TagId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): TagId {
-    return this.idTagged || fail("Tag has no id tagged yet");
   }
 
   get name(): string {

--- a/packages/integration-tests/src/entities/UserCodegen.ts
+++ b/packages/integration-tests/src/entities/UserCodegen.ts
@@ -169,20 +169,20 @@ export abstract class UserCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as User, opts, { calledFromConstructor: true });
   }
 
-  get id(): UserId | undefined {
-    return this.idTagged;
+  get id(): UserId {
+    return this.idMaybe || fail("User has no id yet");
   }
 
-  get idOrFail(): UserId {
-    return this.id || fail("User has no id yet");
+  get idMaybe(): UserId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): UserId | undefined {
+  get idTagged(): UserId {
+    return this.idTaggedMaybe || fail("User has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): UserId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): UserId {
-    return this.idTagged || fail("User has no id tagged yet");
   }
 
   get name(): string {

--- a/packages/integration-tests/src/relations/ManyToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/ManyToManyCollection.test.ts
@@ -163,6 +163,25 @@ describe("ManyToManyCollection", () => {
     expect(await countOfBookToTags()).toEqual(1);
   });
 
+  it("can add a new 2nd tag to a existing book", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertTag({ name: "t1" });
+    await insertBookToTag({ book_id: 1, tag_id: 1 });
+
+    const em = newEntityManager();
+    const book = await em.load(Book, "b:1");
+    const tag = em.create(Tag, { name: "t2" });
+
+    book.tags.add(tag);
+    expect(tag.books.get).toContain(book);
+    expect((await book.tags.load()).length).toBe(1);
+
+    await em.flush();
+
+    expect(await countOfBookToTags()).toEqual(2);
+  });
+
   it("can remove a tag from a book", async () => {
     await insertAuthor({ id: 1, first_name: "a1" });
     await insertBook({ id: 2, title: "b1", author_id: 1 });
@@ -335,7 +354,7 @@ describe("ManyToManyCollection", () => {
     const em = newEntityManager();
     const book = await em.load(Book, "b:2");
     const [t4, t5] = await em.loadAll(Tag, ["t:4", "t:5"]);
-    await em.createOrUpdatePartial(Book, { id: book.idOrFail, tags: [t4, t5] });
+    await em.createOrUpdatePartial(Book, { id: book.id, tags: [t4, t5] });
     await em.flush();
 
     // We could recognize when M2M.set is called w/o a load, and issue a DELETE + INSERTs.

--- a/packages/integration-tests/src/relations/OneToManyCollection.test.ts
+++ b/packages/integration-tests/src/relations/OneToManyCollection.test.ts
@@ -146,7 +146,7 @@ describe("OneToManyCollection", () => {
     // Then the collection has both books in it
     expect(books.length).toEqual(2);
     expect(books[0].id).toEqual("b:1");
-    expect(books[1].id).toEqual(undefined);
+    expect(books[1].idMaybe).toEqual(undefined);
   });
 
   // Skipped due to the first/naive implementation causing performance issues
@@ -417,7 +417,7 @@ describe("OneToManyCollection", () => {
     // And add the book to it
     author.books.add(book);
     // Then we can answer find
-    const book_1 = await author.books.find(book.idOrFail);
+    const book_1 = await author.books.find(book.id);
     expect(book_1).toEqual(book);
     // And we did not make any db queries
     expect(numberOfQueries).toEqual(0);
@@ -451,8 +451,8 @@ describe("OneToManyCollection", () => {
     const b1 = newBook(em, { author: a, order: 2 });
     const b2 = newBook(em, { author: a, order: 1 });
     await em.flush();
-    expect(b1.idOrFail).toBe("b:1");
-    expect(b2.idOrFail).toBe("b:2");
+    expect(b1.id).toBe("b:1");
+    expect(b2.id).toBe("b:2");
     expect(a.books.get).toMatchEntity([b2, b1]);
   });
 });

--- a/packages/integration-tests/src/relations/OneToManyLargeCollection.test.ts
+++ b/packages/integration-tests/src/relations/OneToManyLargeCollection.test.ts
@@ -143,7 +143,7 @@ describe("OneToManyLargeCollection", () => {
     // And we put the critic in it
     c1.group.set(pg);
     // Then we can answer find
-    const c1_2 = await pg.critics.find(c1.idOrFail);
+    const c1_2 = await pg.critics.find(c1.id);
     expect(c1_2).toEqual(c1);
     // And we did not make any db queries
     expect(numberOfQueries).toEqual(0);

--- a/packages/integration-tests/src/relations/PersistedAsyncProperty.test.ts
+++ b/packages/integration-tests/src/relations/PersistedAsyncProperty.test.ts
@@ -74,8 +74,8 @@ describe("PersistedAsyncProperty", () => {
 
     // When the objects are loaded into a new Entity Manager
     const em2 = newEntityManager();
-    const a2 = await em2.load(Author, a1.idOrFail);
-    const br2 = await em2.load(BookReview, br.idOrFail);
+    const a2 = await em2.load(Author, a1.id);
+    const br2 = await em2.load(BookReview, br.id);
 
     // Then nothing has been touched
     expect(a2.numberOfPublicReviews2.get).toEqual(1);
@@ -100,7 +100,7 @@ describe("PersistedAsyncProperty", () => {
     await em.flush();
     // When we want to recalc numberOfPublicReviews2
     const em2 = newEntityManager();
-    const a2 = await em2.load(Author, a1.idOrFail, "books");
+    const a2 = await em2.load(Author, a1.id, "books");
     // And we make a new BookReview that doesn't have isPublic calculated yet
     const br2 = em.create(BookReview, { book: a2.books.get[0], rating: 2 });
     // Then the numberOfPublicReviews2.load will ensure br2.isPublic is loaded first

--- a/packages/integration-tests/src/relations/PolymorphicReference.test.ts
+++ b/packages/integration-tests/src/relations/PolymorphicReference.test.ts
@@ -20,6 +20,7 @@ describe("PolymorphicReference", () => {
     const em = newEntityManager();
     const comment = await em.load(Comment, "1", "parent");
     expect(comment.parent.get).toBeUndefined();
+    expect(() => comment.parent.id).toThrow("Reference is unset");
   });
 
   it("can save a foreign key", async () => {

--- a/packages/integration-tests/src/taggedIds.test.ts
+++ b/packages/integration-tests/src/taggedIds.test.ts
@@ -22,7 +22,7 @@ describe("taggedIds", () => {
     expect(tagIds(getMetadata(Author), ["1", "2"])).toEqual(["a:1", "a:2"]);
   });
 
-  it("is type-safe with id and idOrFail", async () => {
+  it("is type-safe with id and idMaybe", async () => {
     // Given we have an author
     const em = newEntityManager();
     const a = newAuthor(em);
@@ -33,7 +33,7 @@ describe("taggedIds", () => {
     // @ts-expect-error
     a2 = a.id;
     // @ts-expect-error
-    a2 = a.idOrFail;
+    a2 = a.idMaybe;
   });
 
   it("can detag ids", async () => {

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -1,9 +1,8 @@
 import {
-  deTagIds,
+  deTagId,
   Entity,
   EntityManager,
   EntityOrmField,
-  fail,
   getMetadata,
   isEntity,
   keyToNumber,
@@ -17,8 +16,6 @@ import {
  * Currently, this just adds the `.load(lensFn)` method for declarative reference traversal.
  */
 export abstract class BaseEntity<EM extends EntityManager = EntityManager> implements Entity {
-  abstract id: string | undefined;
-  abstract idTagged: string | undefined;
   readonly __orm!: EntityOrmField;
   // This gives rules a way to access the fully typed object instead of their Reacted view.
   // And we make it public so that a function that takes Reacted<...> can accept a Loaded<...>
@@ -43,15 +40,21 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
     em.register(metadata, this);
   }
 
-  get idUntagged(): string | undefined {
-    if (this.id) {
-      return deTagIds(getMetadata(this), [this.id])[0];
-    }
-    return undefined;
-  }
+  /** @returns the entity's id, tagged/untagged based on your config, or a runtime error if it's new/unassigned. */
+  abstract id: string;
 
-  get idUntaggedOrFail(): string {
-    return this.idUntagged || fail("Entity has no id yet");
+  /** @returns the entity's, tagged/untagged based on your config, or undefined if it's new/unassigned. */
+  abstract get idMaybe(): string | undefined;
+
+  /** @returns the entity's id, always tagged, or a runtime error if it's new/unassigned. */
+  abstract idTagged: string;
+
+  /** @returns the entity's id, always tagged, or undefined if it's new/unassigned. */
+  abstract get idTaggedMaybe(): string | undefined;
+
+  /** @returns the entity's id, always untagged, or a runtime error if it's unassigned. */
+  get idUntagged(): string {
+    return deTagId(getMetadata(this), this.id);
   }
 
   abstract set(values: Partial<OptsOf<Entity>>): void;
@@ -60,10 +63,6 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
    * Similar to `set` but applies "Partial API" semantics, i.e. `null` means unset and `undefined` means don't change.
    */
   abstract setPartial(values: PartialOrNull<OptsOf<Entity>>): void;
-
-  /** @returns the current entity id or a runtime error if it's unassigned, i.e. it's not been assigned from the db yet. */
-  abstract get idOrFail(): string;
-  abstract get idTaggedOrFail(): string;
 
   /**
    * Returns whether the entity is new.
@@ -93,7 +92,7 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager> imple
 
   toString(): string {
     const meta = getMetadata(this);
-    if (this.id) {
+    if (this.idMaybe) {
       // Strip the tag because we add back the entity prefix
       const id = keyToNumber(meta, this.id) || "new";
       // Returns `Author:1` instead of `author:1` to differentiate the instance's toString from the tagged id itself

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -13,11 +13,11 @@ export interface Entity {
    *
    * This will be a tagged id, i.e. `a:1`, unless idType is untagged in `joist-config.json`.
    */
-  id: string | undefined;
+  id: string;
+  idMaybe: string | undefined;
   /** The entity id that is always tagged, regardless of the idType config. */
-  idTagged: string | undefined;
-  idTaggedOrFail: string;
-  idOrFail: string;
+  idTagged: string;
+  idTaggedMaybe: string | undefined;
   /** Joist internal metadata, should be considered a private implementation detail. */
   readonly __orm: EntityOrmField;
   readonly em: EntityManager<any>;

--- a/packages/orm/src/JoinRows.ts
+++ b/packages/orm/src/JoinRows.ts
@@ -9,7 +9,10 @@ export class JoinRows {
   // The in-memory rows for our m2m table.
   private readonly rows: JoinRow[] = [];
 
-  constructor(readonly m2m: ManyToManyCollection<any, any>, private rm: ReactionsManager) {}
+  constructor(
+    readonly m2m: ManyToManyCollection<any, any>,
+    private rm: ReactionsManager,
+  ) {}
 
   /** Adds a new join row to this table. */
   addNew(m2m: ManyToManyCollection<any, any>, e1: Entity, e2: Entity): void {
@@ -54,8 +57,9 @@ export class JoinRows {
     const { meta: meta1, otherMeta: meta2 } = this.m2m;
     let row = this.rows.find((jr) => {
       return (
-        (jr[column1] as Entity).id === keyToString(meta1, dbRow[column1]) &&
-        (jr[column2] as Entity).id === keyToString(meta2, dbRow[column2])
+        // Use idMaybe because row join might be for a not-yet-flushed new entity
+        (jr[column1] as Entity).idMaybe === keyToString(meta1, dbRow[column1]) &&
+        (jr[column2] as Entity).idMaybe === keyToString(meta2, dbRow[column2])
       );
     });
     if (!row) {

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -491,8 +491,8 @@ export function parseEntityFilter(meta: EntityMetadata<any>, filter: any): Parse
     // that have an id, and so structurally match the entity filter without really being filters,
     // and convert them over here before getting into parseValueFilter.
     for (const [key, value] of Object.entries(filter)) {
-      if (value && typeof value === "object" && !isPlainObject(value) && "id" in value) {
-        filter[key] = value.id || nilIdValue(meta);
+      if (value && typeof value === "object" && !isPlainObject(value) && "idMaybe" in value) {
+        filter[key] = value.idMaybe || nilIdValue(meta);
       }
     }
     return { kind: "join", subFilter: filter };

--- a/packages/orm/src/drivers/IdAssigner.ts
+++ b/packages/orm/src/drivers/IdAssigner.ts
@@ -18,7 +18,7 @@ export class SequenceIdAssigner implements IdAssigner {
     const seqStatements: string[] = [];
     Object.values(todos).forEach((todo) => {
       // Even if we have INSERTs, the user may have already assigned ids...
-      const needsIds = todo.inserts.filter((e) => e.id === undefined);
+      const needsIds = todo.inserts.filter((e) => e.idMaybe === undefined);
       if (needsIds.length > 0) {
         const sequenceName = `${todo.metadata.tableName}_id_seq`;
         const sql = `select nextval('${sequenceName}') from generate_series(1, ${needsIds.length})`;
@@ -31,7 +31,7 @@ export class SequenceIdAssigner implements IdAssigner {
       const result = await knex.raw(sql);
       let i = 0;
       Object.values(todos).forEach((todo) => {
-        for (const insert of todo.inserts.filter((e) => e.id === undefined)) {
+        for (const insert of todo.inserts.filter((e) => e.idMaybe === undefined)) {
           // Use todo.metadata so that all subtypes get their base type's tag
           insert.__orm.data["id"] = keyToString(todo.metadata, result.rows![i++]["nextval"]);
         }

--- a/packages/orm/src/drivers/InMemoryDriver.ts
+++ b/packages/orm/src/drivers/InMemoryDriver.ts
@@ -101,7 +101,7 @@ export class InMemoryDriver implements Driver {
         this.onQuery();
         // TODO Do this in EntityManager instead of the drivers
         u.__orm.data["updatedAt"] = updatedAt;
-        const id = deTagId(todo.metadata, u.idOrFail);
+        const id = deTagId(todo.metadata, u.id);
         const row: Record<string, any> = {};
         Object.values(todo.metadata.fields)
           .filter(hasSerde)
@@ -114,7 +114,7 @@ export class InMemoryDriver implements Driver {
       });
       todo.deletes.forEach((d) => {
         this.onQuery();
-        const id = deTagId(todo.metadata, d.idOrFail);
+        const id = deTagId(todo.metadata, d.id);
         delete this.rowsOfTable(todo.metadata.tableName)[id];
       });
     });

--- a/packages/orm/src/keys.ts
+++ b/packages/orm/src/keys.ts
@@ -13,7 +13,7 @@ type HasTagName = { tagName: string; idType: "int" | "uuid" };
 // Before a referred-to object is saved, we keep its instance in our data
 // map, and then assume it will be persisted before we're asked to persist
 export function maybeResolveReferenceToId(value: any): string | undefined {
-  return typeof value === "number" || typeof value === "string" ? value : value?.idTagged;
+  return typeof value === "number" || typeof value === "string" ? value : value?.idTaggedMaybe;
 }
 
 /** Converts `value` to a number, i.e. for string ids, unless its undefined. */

--- a/packages/orm/src/loadHints.ts
+++ b/packages/orm/src/loadHints.ts
@@ -215,7 +215,7 @@ export function assertLoaded<T extends Entity, H extends LoadHint<T>, L extends 
   entity: T,
   hint: H,
 ): asserts entity is L {
-  if (!isLoaded(entity, hint)) fail(`${entity.idOrFail} is not loaded for ${JSON.stringify(hint)}`);
+  if (!isLoaded(entity, hint)) fail(`${entity.id} is not loaded for ${JSON.stringify(hint)}`);
 }
 
 export function ensureLoaded<T extends Entity, H extends LoadHint<T>, L extends Loaded<T, H>>(entity: T, hint: H): L {

--- a/packages/orm/src/loadLens.ts
+++ b/packages/orm/src/loadLens.ts
@@ -80,10 +80,10 @@ export async function loadLens<T extends Entity, U, V>(
       // TODO We can only do this is _none_ of the paths are loaded, otherwise we'll miss WIP mutations
       if (Array.isArray(start)) {
         const em = start[0].em;
-        return (await lensDataLoader(em, meta.cstr, true, paths).loadMany(start.map((e) => e.idOrFail))) as V;
+        return (await lensDataLoader(em, meta.cstr, true, paths).loadMany(start.map((e) => e.id))) as V;
       } else {
         const em = start.em;
-        return (await lensDataLoader(em, meta.cstr, false, paths).load(start.idOrFail)) as V;
+        return (await lensDataLoader(em, meta.cstr, false, paths).load(start.id)) as V;
       }
     }
   }

--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -224,7 +224,7 @@ function resolveFactoryOpt<T extends Entity>(
     return opt as T;
   } else if (isId(opt)) {
     // Try finding the entity in the UoW, otherwise fallback on just setting it as the id (which we support that now)
-    return (em.entities.find((e) => e.idTagged === opt || getTestId(em, e) === opt) as T) || opt;
+    return (em.entities.find((e) => e.idTaggedMaybe === opt || getTestId(em, e) === opt) as T) || opt;
   } else if (opt && !isPlainObject(opt) && !(opt instanceof MaybeNew)) {
     // If opt isn't a POJO, assume this is a completely-custom factory
     return meta.factory(em, opt);
@@ -426,7 +426,10 @@ export function maybeNewPoly<T extends Entity, NewT extends T = T>(
 }
 
 class MaybeNew<T extends Entity> {
-  constructor(public opts: FactoryOpts<T>, public polyRefPreferredOrder: MaybeAbstractEntityConstructor<T>[] = []) {}
+  constructor(
+    public opts: FactoryOpts<T>,
+    public polyRefPreferredOrder: MaybeAbstractEntityConstructor<T>[] = [],
+  ) {}
 }
 
 /**

--- a/packages/orm/src/relations/CustomReference.ts
+++ b/packages/orm/src/relations/CustomReference.ts
@@ -36,7 +36,10 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
   private loadPromise: Promise<unknown> | undefined;
   private _isLoaded = false;
 
-  constructor(entity: T, private opts: CustomReferenceOpts<T, U, N>) {
+  constructor(
+    entity: T,
+    private opts: CustomReferenceOpts<T, U, N>,
+  ) {
     super();
     this.#entity = entity;
   }
@@ -76,21 +79,20 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
     // this._isLoaded = true;
   }
 
-  get id(): IdOf<U> | undefined {
+  get id(): IdOf<U> {
     return fail(`CustomReference cannot resolve 'id'`);
   }
 
-  get idOrFail(): IdOf<U> {
-    return fail(`CustomReference cannot resolve 'idOrFail'`);
+  get idMaybe(): IdOf<U> | undefined {
+    return fail(`CustomReference cannot resolve 'idMaybe'`);
   }
 
-  get idUntagged(): string | undefined {
-    // We don't know the meta here but that is probably a feature in case this is polymorphic
-    return this.id && unsafeDeTagIds([this.id])[0];
+  get idUntagged(): string {
+    return fail(`CustomReference cannot resolve 'idUntagged'`);
   }
 
-  get idUntaggedOrFail(): string {
-    return this.idUntagged || fail("Reference is unset or assigned to a new entity");
+  get idUntaggedMaybe(): string | undefined {
+    return fail(`CustomReference cannot resolve 'idUntaggedMaybe'`);
   }
 
   get isSet(): boolean {

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -109,7 +109,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
         return false;
       }
       // Make a cacheable tuple to look up this specific m2m row
-      const key = `${this.columnName}=${this.#entity.idOrFail},${this.otherColumnName}=${other.idOrFail}`;
+      const key = `${this.columnName}=${this.#entity.id},${this.otherColumnName}=${other.id}`;
       return manyToManyFindDataLoader(this.#entity.em, this).load(key);
     }
   }

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -80,7 +80,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
         return added;
       }
       // Make a cacheable tuple to look up this specific o2m row
-      const key = `id=${id},${this.otherColumnName}=${this.#entity.idOrFail}`;
+      const key = `id=${id},${this.otherColumnName}=${this.#entity.id}`;
       return oneToManyFindDataLoader(this.#entity.em, this).load(key);
     }
   }
@@ -212,7 +212,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     const current = await this.load({ withDeleted: true });
     current.forEach((other) => {
       const m2o = this.getOtherRelation(other);
-      if (maybeResolveReferenceToId(m2o.current({ withDeleted: true })) === this.#entity.id) {
+      if (maybeResolveReferenceToId(m2o.current({ withDeleted: true })) === this.#entity.idMaybe) {
         // TODO What if other.otherFieldName is required/not-null?
         m2o.set(undefined);
       }

--- a/packages/orm/src/relations/OneToManyLargeCollection.ts
+++ b/packages/orm/src/relations/OneToManyLargeCollection.ts
@@ -53,7 +53,7 @@ export class OneToManyLargeCollection<T extends Entity, U extends Entity> implem
     }
 
     // Make a cacheable tuple to look up this specific o2m row
-    const key = `id=${id},${this.otherColumnName}=${this.entity.idOrFail}`;
+    const key = `id=${id},${this.otherColumnName}=${this.entity.id}`;
     return oneToManyFindDataLoader(this.entity.em, this).load(key);
   }
 

--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -39,6 +39,9 @@ export interface PolymorphicReference<T extends Entity, U extends Entity, N exte
   /** Returns the id of the current assigned entity, undefined if unset, or a runtime error if set to a new entity. */
   idIfSet: IdOf<U> | undefined;
 
+  /** Returns the id of the current assigned entity, undefined if unset, or undefined if set to a new entity. */
+  idMaybe: IdOf<U> | undefined;
+
   idUntagged: string;
 
   idUntaggedIfSet: string | undefined;
@@ -151,12 +154,12 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
     return this.idUntaggedMaybe;
   }
 
-  // private impl
-
-  private get idMaybe(): IdOf<U> | undefined {
+  get idMaybe(): IdOf<U> | undefined {
     ensureNotDeleted(this.entity, "pending");
     return maybeResolveReferenceToId(this.current()) as IdOf<U> | undefined;
   }
+
+  // private impl
 
   private get idUntaggedMaybe(): string | undefined {
     return this.idMaybe && deTagId(getMetadata(getConstructorFromTaggedId(this.idMaybe)), this.idMaybe);

--- a/packages/test-utils/src/run.ts
+++ b/packages/test-utils/src/run.ts
@@ -73,14 +73,12 @@ function gatherEntities(result: any): Entity[] {
 async function mapResultToOriginalEm<R>(em: EntityManager, result: R): Promise<R> {
   const newEmEntities = gatherEntities(result);
   // load any entities that don't exist in the original em
-  await Promise.all(newEmEntities.filter((e) => !em.findExistingInstance(e.idOrFail)).map((e) => em.load(e.idOrFail)));
+  await Promise.all(newEmEntities.filter((e) => !em.findExistingInstance(e.id)).map((e) => em.load(e.id)));
   // generate a cache of id -> entity in original em
-  const cache = Object.fromEntries(
-    newEmEntities.map((e) => [e.idOrFail, em.findExistingInstance(e.idOrFail) as Entity]),
-  );
+  const cache = Object.fromEntries(newEmEntities.map((e) => [e.id, em.findExistingInstance(e.id) as Entity]));
   function doMap(value: any): any {
     if (isEntity(value)) {
-      return cache[value.idOrFail];
+      return cache[value.id];
     } else if (Array.isArray(value)) {
       return value.map(doMap) as any;
     } else if (typeof value === "object" && value?.constructor === Object) {

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -97,7 +97,7 @@ function maybeTestId(maybeEntity: any): any {
 
 /** Returns either the persisted id or `tag#<offset-in-EntityManager>`. */
 function getTestId(em: EntityManager, entity: Entity): string {
-  if (entity.id) {
+  if (entity.idMaybe) {
     return entity.id;
   }
   const meta = getMetadata(entity);

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -113,20 +113,20 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Artist, opts, { calledFromConstructor: true });
   }
 
-  get id(): ArtistId | undefined {
-    return this.idTagged;
+  get id(): ArtistId {
+    return this.idMaybe || fail("Artist has no id yet");
   }
 
-  get idOrFail(): ArtistId {
-    return this.id || fail("Artist has no id yet");
+  get idMaybe(): ArtistId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): ArtistId | undefined {
+  get idTagged(): ArtistId {
+    return this.idTaggedMaybe || fail("Artist has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): ArtistId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): ArtistId {
-    return this.idTagged || fail("Artist has no id tagged yet");
   }
 
   get firstName(): string {

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -106,20 +106,20 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 
-  get id(): AuthorId | undefined {
-    return this.idTagged;
+  get id(): AuthorId {
+    return this.idMaybe || fail("Author has no id yet");
   }
 
-  get idOrFail(): AuthorId {
-    return this.id || fail("Author has no id yet");
+  get idMaybe(): AuthorId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): AuthorId | undefined {
+  get idTagged(): AuthorId {
+    return this.idTaggedMaybe || fail("Author has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): AuthorId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): AuthorId {
-    return this.idTagged || fail("Author has no id tagged yet");
   }
 
   get firstName(): string {

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -94,20 +94,20 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 
-  get id(): BookId | undefined {
-    return this.idTagged;
+  get id(): BookId {
+    return this.idMaybe || fail("Book has no id yet");
   }
 
-  get idOrFail(): BookId {
-    return this.id || fail("Book has no id yet");
+  get idMaybe(): BookId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): BookId | undefined {
+  get idTagged(): BookId {
+    return this.idTaggedMaybe || fail("Book has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): BookId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): BookId {
-    return this.idTagged || fail("Book has no id tagged yet");
   }
 
   get title(): string {

--- a/packages/tests/schema-misc/src/entities/DatabaseOwnerCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/DatabaseOwnerCodegen.ts
@@ -79,20 +79,20 @@ export abstract class DatabaseOwnerCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as DatabaseOwner, opts, { calledFromConstructor: true });
   }
 
-  get id(): DatabaseOwnerId | undefined {
-    return this.idTagged;
+  get id(): DatabaseOwnerId {
+    return this.idMaybe || fail("DatabaseOwner has no id yet");
   }
 
-  get idOrFail(): DatabaseOwnerId {
-    return this.id || fail("DatabaseOwner has no id yet");
+  get idMaybe(): DatabaseOwnerId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): DatabaseOwnerId | undefined {
+  get idTagged(): DatabaseOwnerId {
+    return this.idTaggedMaybe || fail("DatabaseOwner has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): DatabaseOwnerId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): DatabaseOwnerId {
-    return this.idTagged || fail("DatabaseOwner has no id tagged yet");
   }
 
   get name(): string {

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -104,20 +104,20 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Painting, opts, { calledFromConstructor: true });
   }
 
-  get id(): PaintingId | undefined {
-    return this.idTagged;
+  get id(): PaintingId {
+    return this.idMaybe || fail("Painting has no id yet");
   }
 
-  get idOrFail(): PaintingId {
-    return this.id || fail("Painting has no id yet");
+  get idMaybe(): PaintingId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): PaintingId | undefined {
+  get idTagged(): PaintingId {
+    return this.idTaggedMaybe || fail("Painting has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): PaintingId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): PaintingId {
-    return this.idTagged || fail("Painting has no id tagged yet");
   }
 
   get title(): string {

--- a/packages/tests/untagged-ids/src/entities/Author.test.ts
+++ b/packages/tests/untagged-ids/src/entities/Author.test.ts
@@ -24,7 +24,7 @@ describe("Author", () => {
     const em = newEntityManager({ idAssigner: new RandomUuidAssigner() });
     const a1 = newAuthor(em);
     await em.flush();
-    expect(a1.idOrFail.startsWith("a:")).toBe(false);
+    expect(a1.id.startsWith("a:")).toBe(false);
   });
 
   it("can load author and books", async () => {
@@ -44,7 +44,7 @@ describe("Author", () => {
     const em = newEntityManager();
     const a1 = newAuthor(em);
     await em.flush();
-    const b1 = em.create(Book, { title: "b1", author: a1.idOrFail });
+    const b1 = em.create(Book, { title: "b1", author: a1.id });
     await em.flush();
     expect(b1.toJSON()).toMatchObject({
       id: "00000000-0000-0000-000b-000000000000",
@@ -62,7 +62,7 @@ describe("Author", () => {
     // We can access the id and not see its tag
     expect(b1.author.id).toBe("00000000-0000-0000-000a-000000000000");
     // And we can change the id via a2's untagge did
-    b1.author.id = a2.idOrFail;
+    b1.author.id = a2.id;
     expect(b1.author.id).toBe("00000000-0000-0000-000a-000000000001");
     await em.flush();
   });

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -107,20 +107,20 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 
-  get id(): AuthorId | undefined {
-    return deTagId(authorMeta, this.idTagged);
+  get id(): AuthorId {
+    return this.idMaybe || fail("Author has no id yet");
   }
 
-  get idOrFail(): AuthorId {
-    return this.id || fail("Author has no id yet");
+  get idMaybe(): AuthorId | undefined {
+    return deTagId(authorMeta, this.idTaggedMaybe);
   }
 
-  get idTagged(): AuthorId | undefined {
+  get idTagged(): AuthorId {
+    return this.idTaggedMaybe || fail("Author has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): AuthorId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): AuthorId {
-    return this.idTagged || fail("Author has no id tagged yet");
   }
 
   get firstName(): string {

--- a/packages/tests/untagged-ids/src/entities/Book.test.ts
+++ b/packages/tests/untagged-ids/src/entities/Book.test.ts
@@ -8,7 +8,7 @@ describe("Book", () => {
     await em1.flush();
 
     const em2 = newEntityManager();
-    const b2 = await em2.load(Book, b1.idOrFail, "author");
+    const b2 = await em2.load(Book, b1.id, "author");
     expect(b2.title).toEqual("b1");
     expect(b2.author.get.firstName).toEqual("a1");
   });

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -105,20 +105,20 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 
-  get id(): BookId | undefined {
-    return deTagId(bookMeta, this.idTagged);
+  get id(): BookId {
+    return this.idMaybe || fail("Book has no id yet");
   }
 
-  get idOrFail(): BookId {
-    return this.id || fail("Book has no id yet");
+  get idMaybe(): BookId | undefined {
+    return deTagId(bookMeta, this.idTaggedMaybe);
   }
 
-  get idTagged(): BookId | undefined {
+  get idTagged(): BookId {
+    return this.idTaggedMaybe || fail("Book has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): BookId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): BookId {
-    return this.idTagged || fail("Book has no id tagged yet");
   }
 
   get title(): string {

--- a/packages/tests/uuid-ids/src/entities/Author.test.ts
+++ b/packages/tests/uuid-ids/src/entities/Author.test.ts
@@ -24,7 +24,7 @@ describe("Author", () => {
     const em = newEntityManager({ idAssigner: new RandomUuidAssigner() });
     const a1 = newAuthor(em);
     await em.flush();
-    expect(a1.idOrFail.startsWith("a:")).toBe(true);
+    expect(a1.id.startsWith("a:")).toBe(true);
   });
 
   it("can run multiple find calls", async () => {

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -106,20 +106,20 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Author, opts, { calledFromConstructor: true });
   }
 
-  get id(): AuthorId | undefined {
-    return this.idTagged;
+  get id(): AuthorId {
+    return this.idMaybe || fail("Author has no id yet");
   }
 
-  get idOrFail(): AuthorId {
-    return this.id || fail("Author has no id yet");
+  get idMaybe(): AuthorId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): AuthorId | undefined {
+  get idTagged(): AuthorId {
+    return this.idTaggedMaybe || fail("Author has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): AuthorId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): AuthorId {
-    return this.idTagged || fail("Author has no id tagged yet");
   }
 
   get firstName(): string {

--- a/packages/tests/uuid-ids/src/entities/Book.test.ts
+++ b/packages/tests/uuid-ids/src/entities/Book.test.ts
@@ -8,7 +8,7 @@ describe("Book", () => {
     await em1.flush();
 
     const em2 = newEntityManager();
-    const b2 = await em2.load(Book, b1.idOrFail, "author");
+    const b2 = await em2.load(Book, b1.id, "author");
     expect(b2.title).toEqual("b1");
     expect(b2.author.get.firstName).toEqual("a1");
   });

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -104,20 +104,20 @@ export abstract class BookCodegen extends BaseEntity<EntityManager> {
     setOpts(this as any as Book, opts, { calledFromConstructor: true });
   }
 
-  get id(): BookId | undefined {
-    return this.idTagged;
+  get id(): BookId {
+    return this.idMaybe || fail("Book has no id yet");
   }
 
-  get idOrFail(): BookId {
-    return this.id || fail("Book has no id yet");
+  get idMaybe(): BookId | undefined {
+    return this.idTaggedMaybe;
   }
 
-  get idTagged(): BookId | undefined {
+  get idTagged(): BookId {
+    return this.idTaggedMaybe || fail("Book has no id tagged yet");
+  }
+
+  get idTaggedMaybe(): BookId | undefined {
     return this.__orm.data["id"];
-  }
-
-  get idTaggedOrFail(): BookId {
-    return this.idTagged || fail("Book has no id tagged yet");
   }
 
   get title(): string {


### PR DESCRIPTION
We've had issues of developers "shooting themselves in the foot" by writing code like:

```ts
config.beforeFlush(book => {
  if (book.id !== someOtherThing.book.id) {
    // run different books
  }
});
```

And not realizing that `id` returns `undefined` for new entities, so `// run different books` logic _won't_ run when `book` and `someOtherThing.book` are different books (`b1` and `b2`), but are both new, and so have undefined ids (`undefined !== undefined` is false).

This foot gun seems to happen the most in hooks, but in general it can happen in any pre-`flush` code that is trying to work with/do comparison on ids of potentially-newly-created entities.

The worst thing about it, is that the code often "works in tests", where the entities all happen to be new, but then will fail in production/or other boundary cases that come up later.

Ironically, Joist's unit-of-work/identity cache is a great solution to this, b/c if you just lean into object identities, this code works all the time:

```ts
config.beforeFlush(book => {
  if (book !== someOtherThing.book.get) {
    // business logic
  }
});
```

However, this often requires an extra load hint to get `someOtherThing.book.get` populated/added to the type, and so developers will shy away from that option, as a premature but ill-fated optimization.

So, this PR flips the behavior of `.id` to blow up if the id is not set.

Specifically:

* We previously had `.id`, which was typed as `string | undefined` and would return `undefined` on new entities
* We previously had `.idOrFail`, which was typed as `string` and would blow up on new entities

We're flipping them, so now:

* We have `.id` typed as `string` and it will blow up on new entities
* We added `.idMaybe` typed as `string | undefined` to be the "call id and return undefined if new" method
* We've removed `.idOrFail` since it's replaced by `.id`

The rationale is that `.idMaybe` can be used for situations when you're aware of & opt-in to the "might return `undefined` behavior", but that otherwise the "`id` that people call without really thinking about it" has dramatically safer/safe-by-default behavior.


