### PR TITLE
fix: Fix toMatchEntity failing with pojos.

### DIFF
--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -37,7 +37,7 @@ export function toMatchEntity<T extends object>(actual: T, expected: MatchedEnti
   // After that, use `expected` as a template to pick keys out of actual. Finally, do the
   // same "clean clone" of actual, and compare the two.
   const cleanExpected = deepClone(expected);
-  const cleanActual = deepClone(deepMirror(expected, actual));
+  const cleanActual = deepClone(deepMirror(cleanExpected, actual));
   // Watch for `expect(someAuthor).toMatchEntity(a1)` as we'll turn `someAuthor` into "a:1`,
   // so can't use toMatchObject anymore.
   if (typeof cleanActual !== "object") {

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -98,10 +98,10 @@ export type MatchedEntity<T> =
  * out the expected as an object literal, so it shouldn't have cycles
  */
 function deepMirror(expected: any, actual: any): any {
-  // If we've hit a point where the `expected` input is not a POJO object literal
+  // If we've hit a point where the `expected` input is not a POJO object literal/array
   // declaring the subset of the shape to assert against, just return actual as-is.
-  // This might be a Date or an Entity or something else, but if so it will get
-  // cleaned up by the deepClone pass.
+  // This might be a Date (safe) or an Entity (unsafe) or something else, but if so it will
+  // get cleaned up by the `deepClone` pass.
   if (!isPlainObject(expected) && !Array.isArray(expected)) return actual;
   // Make a new actual that is a subset that matches expected
   const subset: any = Array.isArray(expected) ? [] : ({} as any);

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -106,10 +106,7 @@ function deepMirror(expected: any, actual: any): any {
   // Make a new actual that is a subset that matches expected
   const subset: any = Array.isArray(expected) ? [] : ({} as any);
   // If both are arrays, fill out the whole array
-  const keys =
-    Array.isArray(actual) && Array.isArray(expected)
-      ? [...Array(Math.max(actual.length, expected.length)).keys()]
-      : Object.keys(expected);
+  const keys = Array.isArray(actual) ? Object.keys(actual) : Object.keys(expected);
   for (const key of keys) {
     if (key in actual) {
       // Even if actualValue is an Entity, if expected has a key drilling in to it, we want to object literal-ize it


### PR DESCRIPTION
This basically totally rewrites `toMatchEntity` to be less adhoc/hacky, and instead step back and think about what it's really doing.

See in-source comments that describe how we use `expected` as a template to create our own copy of `actual`, to avoid Jest infinitely recursing into connection pools, but then also still handle entities being in either `expected` or `actual` as "terminal" values the user wants to assert against.
