### PR TITLE
fix: Fix double quoting in buildKnexQuery

### DIFF
--- a/packages/integration-tests/src/EntityManager.find.batch.test.ts
+++ b/packages/integration-tests/src/EntityManager.find.batch.test.ts
@@ -107,9 +107,7 @@ describe("EntityManager.find.batch", () => {
     // When they are executed in the same event loop
     await Promise.all([q1p, q2p]);
     // Then we issue a single SQL query without any of the CTE overhead
-    expect(queries).toEqual([
-      `select a.* from "authors" as "a" where "a"."deleted_at" is null order by "a"."id" ASC limit $1`,
-    ]);
+    expect(queries).toEqual([`select a.* from authors as a where a.deleted_at is null order by a.id ASC limit $1`]);
   });
 
   it("batches queries with same order bys", async () => {

--- a/packages/integration-tests/src/EntityManager.lens.test.ts
+++ b/packages/integration-tests/src/EntityManager.lens.test.ts
@@ -178,7 +178,7 @@ describe("EntityManager.lens", () => {
       expect(em.entities.length).toBe(2);
 
       expect(lastQuery()).toMatchInlineSnapshot(
-        `"select "p".*, p_s0.*, p_s1.*, p.id as id, CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class, "b".id as __source_id from "publishers" as "p" left outer join "large_publishers" as "p_s0" on "p"."id" = "p_s0"."id" left outer join "small_publishers" as "p_s1" on "p"."id" = "p_s1"."id" inner join "authors" as "a" on "a"."publisher_id" = "p"."id" inner join "books" as "b" on "b"."author_id" = "a"."id" where "a"."deleted_at" is null and "b"."deleted_at" is null and "b"."id" in ($1) order by "p"."id" ASC limit $2"`,
+        `"select "p".*, p_s0.*, p_s1.*, p.id as id, CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' WHEN p_s1.id IS NOT NULL THEN 'SmallPublisher' ELSE 'Publisher' END as __class, "b".id as __source_id from publishers as p left outer join large_publishers as p_s0 on p.id = p_s0.id left outer join small_publishers as p_s1 on p.id = p_s1.id inner join authors as a on a.publisher_id = p.id inner join books as b on b.author_id = a.id where a.deleted_at is null and b.deleted_at is null and b.id in ($1) order by p.id ASC limit $2"`,
       );
     });
 
@@ -197,7 +197,7 @@ describe("EntityManager.lens", () => {
       expect(em.entities.length).toBe(2);
 
       expect(lastQuery()).toMatchInlineSnapshot(
-        `"select "b".*, b.id as id, "a".publisher_id as __source_id from "books" as "b" inner join "authors" as "a" on "a"."id" = "b"."author_id" where "a"."deleted_at" is null and "a"."publisher_id" in ($1) order by "b"."title" ASC, "b"."id" ASC limit $2"`,
+        `"select "b".*, b.id as id, "a".publisher_id as __source_id from books as b inner join authors as a on a.id = b.author_id where a.deleted_at is null and a.publisher_id in ($1) order by b.title ASC, b.id ASC limit $2"`,
       );
     });
 

--- a/packages/integration-tests/src/QueryParser.quotes.test.ts
+++ b/packages/integration-tests/src/QueryParser.quotes.test.ts
@@ -14,14 +14,14 @@ describe("QueryParser", () => {
     expect(generateSql(parseFindQuery(bm, { author: { firstName: "jeff", schedules: { id: 4 } } }))).toEqual(
       [
         'select distinct b.*, "b"."title", "b"."id"',
-        ' from "books" as "b"',
-        ' inner join "authors" as "a" on b.author_id = a.id',
-        ' left outer join "author_schedules" as "as" on a.id = "as".author_id',
-        ' where "b"."deleted_at" is null',
-        ' and "a"."deleted_at" is null',
-        ' and "a"."first_name" = ?',
-        ' and "as"."id" = ?',
-        ' order by "b"."title" ASC, "b"."id" ASC',
+        " from books as b",
+        " inner join authors as a on b.author_id = a.id",
+        ' left outer join author_schedules as "as" on a.id = "as".author_id',
+        " where b.deleted_at is null",
+        " and a.deleted_at is null",
+        " and a.first_name = ?",
+        ' and "as".id = ?',
+        " order by b.title ASC, b.id ASC",
       ].join(""),
     );
   });

--- a/packages/integration-tests/src/QueryParser.quotes.test.ts
+++ b/packages/integration-tests/src/QueryParser.quotes.test.ts
@@ -1,7 +1,7 @@
-import {getMetadata, ParsedFindQuery, parseFindQuery} from "joist-orm";
-import {buildKnexQuery} from "joist-orm/build/src/drivers/buildKnexQuery";
-import {knex} from "@src/setupDbTests";
-import {Book} from "@src/entities";
+import { Book } from "@src/entities";
+import { knex } from "@src/setupDbTests";
+import { getMetadata, ParsedFindQuery, parseFindQuery } from "joist-orm";
+import { buildKnexQuery } from "joist-orm/build/src/drivers/buildKnexQuery";
 
 function generateSql(t: ParsedFindQuery) {
   return buildKnexQuery(knex, t, {}).toSQL().sql;
@@ -9,19 +9,20 @@ function generateSql(t: ParsedFindQuery) {
 
 const bm = getMetadata(Book);
 
-describe('QueryParser', () => {
-  it('quotes with abbreviation', () => {
-    expect(generateSql(parseFindQuery(bm, { author: { firstName: 'jeff', schedules: { id: 4 } } })))
-      .toEqual([
+describe("QueryParser", () => {
+  it("quotes with abbreviation", () => {
+    expect(generateSql(parseFindQuery(bm, { author: { firstName: "jeff", schedules: { id: 4 } } }))).toEqual(
+      [
         'select distinct b.*, "b"."title", "b"."id"',
         ' from "books" as "b"',
-        ' inner join "authors" as "a" on "b"."author_id" = "a"."id"',
-        ' left outer join "author_schedules" as "as" on "a"."id" = "as"."author_id"',
+        ' inner join "authors" as "a" on b.author_id = a.id',
+        ' left outer join "author_schedules" as "as" on a.id = "as".author_id',
         ' where "b"."deleted_at" is null',
         ' and "a"."deleted_at" is null',
         ' and "a"."first_name" = ?',
         ' and "as"."id" = ?',
-        ' order by "b"."title" ASC, "b"."id" ASC'
-      ].join(''));
-  })
+        ' order by "b"."title" ASC, "b"."id" ASC',
+      ].join(""),
+    );
+  });
 });

--- a/packages/integration-tests/src/QueryParser.quotes.test.ts
+++ b/packages/integration-tests/src/QueryParser.quotes.test.ts
@@ -1,0 +1,27 @@
+import {getMetadata, ParsedFindQuery, parseFindQuery} from "joist-orm";
+import {buildKnexQuery} from "joist-orm/build/src/drivers/buildKnexQuery";
+import {knex} from "@src/setupDbTests";
+import {Book} from "@src/entities";
+
+function generateSql(t: ParsedFindQuery) {
+  return buildKnexQuery(knex, t, {}).toSQL().sql;
+}
+
+const bm = getMetadata(Book);
+
+describe('QueryParser', () => {
+  it('quotes with abbreviation', () => {
+    expect(generateSql(parseFindQuery(bm, { author: { firstName: 'jeff', schedules: { id: 4 } } })))
+      .toEqual([
+        'select distinct b.*, "b"."title", "b"."id"',
+        ' from "books" as "b"',
+        ' inner join "authors" as "a" on "b"."author_id" = "a"."id"',
+        ' left outer join "author_schedules" as "as" on "a"."id" = "as"."author_id"',
+        ' where "b"."deleted_at" is null',
+        ' and "a"."deleted_at" is null',
+        ' and "a"."first_name" = ?',
+        ' and "as"."id" = ?',
+        ' order by "b"."title" ASC, "b"."id" ASC'
+      ].join(''));
+  })
+});

--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -35,10 +35,10 @@ export function buildKnexQuery(
   parsed.tables.forEach((t) => {
     switch (t.join) {
       case "inner":
-        query.join(`${t.table} AS ${t.alias}`, t.col1, t.col2);
+        query.join(`${t.table} AS ${t.alias}`, knex.raw(t.col1) as any, knex.raw(t.col2));
         break;
       case "outer":
-        query.leftOuterJoin(`${t.table} AS ${t.alias}`, t.col1, t.col2);
+        query.leftOuterJoin(`${t.table} AS ${t.alias}`, knex.raw(t.col1) as any, knex.raw(t.col2));
         break;
       case "primary":
         // ignore


### PR DESCRIPTION
Not sure on the best place for this, as it relies on both metadata + parseFindQuery and Knex's internals.