### PR TITLE
feat: Support em.find ordering by aggregates.

### DIFF
--- a/packages/integration-tests/src/EntityManager.queries.test.ts
+++ b/packages/integration-tests/src/EntityManager.queries.test.ts
@@ -19,6 +19,7 @@ import {
   UniqueFilter,
   alias,
   aliases,
+  exp,
   getMetadata,
   jan1,
   jan2,
@@ -1295,6 +1296,20 @@ describe("EntityManager.queries", () => {
         { alias: "a", column: "id", order: "ASC" },
       ],
     });
+  });
+
+  it("can order by aggregate expression", async () => {
+    await insertPublisher({ name: "p1" });
+    await insertPublisher({ id: 2, name: "p2" });
+    await insertAuthor({ first_name: "a1", publisher_id: 1, age: 30 });
+    await insertAuthor({ first_name: "a2", publisher_id: 2, age: 30 });
+    await insertAuthor({ first_name: "a3", publisher_id: 2, age: 30 });
+
+    const em = newEntityManager();
+    const a = alias(Author);
+    const [p2, p1] = await em.find(Publisher, { authors: a }, { orderBy: [exp`SUM(${a.age})`, "DESC"] });
+    expect(p2.name).toBe("p2");
+    expect(p1.name).toBe("p1");
   });
 
   it("can find empty results in a loop", async () => {

--- a/packages/orm/src/AliasAssigner.ts
+++ b/packages/orm/src/AliasAssigner.ts
@@ -1,0 +1,26 @@
+/** Keeps track of table aliases, i.e. `book_reviews` -> `br`, within a single query. */
+export class AliasAssigner {
+  static findOrCreate(args: object[]): AliasAssigner {
+    return new AliasAssigner();
+  }
+
+  #aliases: Record<string, number> = {};
+
+  constructor() {
+    this.getAlias = this.getAlias.bind(this);
+  }
+
+  getAlias(tableName: string): string {
+    const abbrev = abbreviation(tableName);
+    const i = this.#aliases[abbrev] || 0;
+    this.#aliases[abbrev] = i + 1;
+    return i === 0 ? abbrev : `${abbrev}${i}`;
+  }
+}
+
+export function abbreviation(tableName: string): string {
+  return tableName
+    .split("_")
+    .map((w) => w[0])
+    .join("");
+}

--- a/packages/orm/src/EntityFilter.ts
+++ b/packages/orm/src/EntityFilter.ts
@@ -1,13 +1,13 @@
 import { Alias } from "./Aliases";
 import { Entity } from "./Entity";
 import { FieldsOf, FilterOf, IdOf, OrderOf } from "./EntityManager";
-import { ColumnCondition } from "./QueryParser";
+import { ColumnCondition, ParsedExpression } from "./QueryParser";
 
 /** Combines a `where` filter with optional `orderBy`, `limit`, and `offset` settings. */
 export type FilterAndSettings<T extends Entity> = {
   where: FilterWithAlias<T>;
   conditions?: ExpressionFilter;
-  orderBy?: OrderOf<T>;
+  orderBy?: OrderOf<T> | [ParsedExpression, OrderBy];
   limit?: number;
   offset?: number;
   softDeletes?: "exclude" | "include";

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -28,6 +28,8 @@ import {
   Lens,
   ManyToManyCollection,
   OneToManyCollection,
+  OrderBy,
+  ParsedExpression,
   PartialOrNull,
   PolymorphicReferenceImpl,
   UniqueFilter,
@@ -55,7 +57,7 @@ import { followReverseHint } from "./reactiveHints";
 import { ManyToOneReferenceImpl, OneToOneReferenceImpl, PersistedAsyncReferenceImpl } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
 import { PersistedAsyncPropertyImpl } from "./relations/hasPersistedAsyncProperty";
-import {MaybePromise, assertNever, fail, getOrSet, toArray, groupBy, indexBy} from "./utils";
+import { MaybePromise, assertNever, fail, getOrSet, toArray } from "./utils";
 
 /**
  * The constructor for concrete entity types.
@@ -77,7 +79,7 @@ export interface EntityConstructor<T> {
 /** Options for the auto-batchable `em.find` queries, i.e. limit & offset aren't allowed. */
 export interface FindFilterOptions<T extends Entity> {
   conditions?: ExpressionFilter;
-  orderBy?: OrderOf<T>;
+  orderBy?: OrderOf<T> | [ParsedExpression, OrderBy];
   softDeletes?: "include" | "exclude";
 }
 

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -44,9 +44,5 @@ export function buildQuery<T extends Entity>(
   return buildKnexQuery(knex, parsed, { limit, offset });
 }
 
-export function abbreviation(tableName: string): string {
-  return tableName
-    .split("_")
-    .map((w) => w[0])
-    .join("");
-}
+// Legacy location
+export { abbreviation } from "./AliasAssigner";

--- a/packages/orm/src/dataloaders/loadDataLoader.ts
+++ b/packages/orm/src/dataloaders/loadDataLoader.ts
@@ -22,7 +22,7 @@ export function loadDataLoader<T extends Entity>(
       selects: [`"${alias}".*`],
       tables: [{ alias, join: "primary", table: meta.tableName }],
       conditions: [{ alias, column: "id", dbType: meta.idType, cond: { kind: "in", value: keys } }],
-      orderBys: [{ alias, column: "id", order: "ASC" }],
+      orderBys: [{ kind: "column", alias, column: "id", order: "ASC" }],
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);

--- a/packages/orm/src/dataloaders/manyToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyDataLoader.ts
@@ -62,7 +62,7 @@ async function load<T extends Entity, U extends Entity>(
         }),
       },
     ],
-    orderBys: [{ alias, column: "id", order: "ASC" }],
+    orderBys: [{ kind: "column", alias, column: "id", order: "ASC" }],
   };
 
   // maybeAddNotSoftDeleted(conditions, meta, alias, "include");

--- a/packages/orm/src/dataloaders/manyToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/manyToManyFindDataLoader.ts
@@ -63,7 +63,7 @@ async function load<T extends Entity, U extends Entity>(
         }),
       },
     ],
-    orderBys: [{ alias, column: "id", order: "ASC" }],
+    orderBys: [{ kind: "column", alias, column: "id", order: "ASC" }],
   };
 
   const rows = await em.driver.executeFind(em, query, {});

--- a/packages/orm/src/dataloaders/oneToManyDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyDataLoader.ts
@@ -32,7 +32,7 @@ export function oneToManyDataLoader<T extends Entity, U extends Entity>(
       conditions: [
         { alias, column: collection.otherColumnName, dbType: meta.idType, cond: { kind: "in", value: keys } },
       ],
-      orderBys: [{ alias, column: "id", order: "ASC" }],
+      orderBys: [{ kind: "column", alias, column: "id", order: "ASC" }],
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);

--- a/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
+++ b/packages/orm/src/dataloaders/oneToManyFindDataLoader.ts
@@ -57,7 +57,7 @@ export function oneToManyFindDataLoader<T extends Entity, U extends Entity>(
           }),
         },
       ],
-      orderBys: [{ alias, column: "id", order: "ASC" }],
+      orderBys: [{ kind: "column", alias, column: "id", order: "ASC" }],
     };
 
     addTablePerClassJoinsAndClassTag(query, meta, alias, true);


### PR DESCRIPTION
Current syntax is:

```
const [p2, p1] = await em.find(
  Publisher, { authors: a },
  { orderBy: [exp`SUM(${a.age})`, "DESC"]
});
```
