### PR TITLE
fix: complex filters on cti of parent fields do not filter to correct table

### DIFF
--- a/packages/integration-tests/src/EntityManager.ctiQueries.test.ts
+++ b/packages/integration-tests/src/EntityManager.ctiQueries.test.ts
@@ -1,0 +1,98 @@
+import {newEntityManager} from "@src/setupDbTests";
+import {Publisher, SmallPublisher} from "@src/entities";
+import {alias} from "joist-orm";
+
+describe('EntityManager cti queries', () => {
+
+  it('finds against child with simple parent filter', async () => {
+    const em = newEntityManager();
+
+    em.create(SmallPublisher, {
+      name: 'p1',
+      city: 'location'
+    });
+
+    await em.flush();
+
+    const res = await em.find(SmallPublisher, { name: 'p1' })
+
+    expect(res.length).toBe(1);
+  });
+
+  it('finds against parent with simple parent filter', async () => {
+    const em = newEntityManager();
+
+    em.create(SmallPublisher, {
+      name: 'p1',
+      city: 'location'
+    });
+
+    await em.flush();
+
+    const res = await em.find(Publisher, { name: 'p1' })
+
+    expect(res.length).toBe(1);
+  });
+
+  it('finds against child with simple child filter', async () => {
+    const em = newEntityManager();
+
+    em.create(SmallPublisher, {
+      name: 'p1',
+      city: 'location'
+    });
+
+    await em.flush();
+
+    const res = await em.find(SmallPublisher, { city: 'location' })
+
+    expect(res.length).toBe(1);
+  });
+
+  it('finds against child with simple child & parent filter', async () => {
+    const em = newEntityManager();
+
+    em.create(SmallPublisher, {
+      name: 'p1',
+      city: 'location'
+    });
+
+    await em.flush();
+
+    const res = await em.find(SmallPublisher, { name: 'p1', city: 'location' })
+
+    expect(res.length).toBe(1);
+  });
+
+  it('finds against child with complex child & parent filter, alias child', async () => {
+    const em = newEntityManager();
+
+    em.create(SmallPublisher, {
+      name: 'p1',
+      city: 'location'
+    });
+
+    await em.flush();
+
+    const sp = alias(SmallPublisher);
+    const res = await em.find(SmallPublisher, { as: sp }, { conditions: { and: [sp.name.eq('p1')]}})
+
+    expect(res.length).toBe(1);
+  });
+
+  it.only('finds against child with simple child & parent filter', async () => {
+    const em = newEntityManager();
+
+    em.create(SmallPublisher, {
+      name: 'p1',
+      city: 'location'
+    });
+
+    await em.flush();
+
+    const sp = alias(Publisher);
+    const res = await em.find(SmallPublisher, { as: sp }, { conditions: { and: [sp.name.eq('p1')]}})
+
+    expect(res.length).toBe(1);
+  });
+});

--- a/packages/integration-tests/src/EntityManager.ctiQueries.test.ts
+++ b/packages/integration-tests/src/EntityManager.ctiQueries.test.ts
@@ -44,7 +44,7 @@ describe("EntityManager.ctiQueries", () => {
     expect(res).toMatchEntity([sp1]);
   });
 
-  it("finds against child with simple child & parent filter", async () => {
+  it("finds against child with simple child & parent filter, parent alias", async () => {
     const em = newEntityManager();
     const sp1 = newSmallPublisher(em, { name: "p1", city: "location" });
     await em.flush();

--- a/packages/integration-tests/src/EntityManager.ctiQueries.test.ts
+++ b/packages/integration-tests/src/EntityManager.ctiQueries.test.ts
@@ -1,98 +1,55 @@
-import {newEntityManager} from "@src/setupDbTests";
-import {Publisher, SmallPublisher} from "@src/entities";
-import {alias} from "joist-orm";
+import { newSmallPublisher, Publisher, SmallPublisher } from "@src/entities";
+import { newEntityManager } from "@src/setupDbTests";
+import { alias } from "joist-orm";
 
-describe('EntityManager cti queries', () => {
-
-  it('finds against child with simple parent filter', async () => {
+describe("EntityManager.ctiQueries", () => {
+  it("finds against child with simple parent filter", async () => {
     const em = newEntityManager();
-
-    em.create(SmallPublisher, {
-      name: 'p1',
-      city: 'location'
-    });
-
+    const sp1 = newSmallPublisher(em, { name: "p1" });
     await em.flush();
-
-    const res = await em.find(SmallPublisher, { name: 'p1' })
-
-    expect(res.length).toBe(1);
+    const res = await em.find(SmallPublisher, { name: "p1" });
+    expect(res).toMatchEntity([sp1]);
   });
 
-  it('finds against parent with simple parent filter', async () => {
+  it("finds against parent with simple parent filter", async () => {
     const em = newEntityManager();
-
-    em.create(SmallPublisher, {
-      name: 'p1',
-      city: 'location'
-    });
-
+    const sp1 = newSmallPublisher(em, { name: "p1" });
     await em.flush();
-
-    const res = await em.find(Publisher, { name: 'p1' })
-
-    expect(res.length).toBe(1);
+    const res = await em.find(Publisher, { name: "p1" });
+    expect(res).toMatchEntity([sp1]);
   });
 
-  it('finds against child with simple child filter', async () => {
+  it("finds against child with simple child filter", async () => {
     const em = newEntityManager();
-
-    em.create(SmallPublisher, {
-      name: 'p1',
-      city: 'location'
-    });
-
+    const sp1 = newSmallPublisher(em, { name: "p1", city: "location" });
     await em.flush();
-
-    const res = await em.find(SmallPublisher, { city: 'location' })
-
-    expect(res.length).toBe(1);
+    const res = await em.find(SmallPublisher, { city: "location" });
+    expect(res).toMatchEntity([sp1]);
   });
 
-  it('finds against child with simple child & parent filter', async () => {
+  it("finds against child with simple child & parent filter", async () => {
     const em = newEntityManager();
-
-    em.create(SmallPublisher, {
-      name: 'p1',
-      city: 'location'
-    });
-
+    const sp1 = newSmallPublisher(em, { name: "p1", city: "location" });
     await em.flush();
-
-    const res = await em.find(SmallPublisher, { name: 'p1', city: 'location' })
-
-    expect(res.length).toBe(1);
+    const res = await em.find(SmallPublisher, { name: "p1", city: "location" });
+    expect(res).toMatchEntity([sp1]);
   });
 
-  it('finds against child with complex child & parent filter, alias child', async () => {
+  it("finds against child with complex child & parent filter, alias child", async () => {
     const em = newEntityManager();
-
-    em.create(SmallPublisher, {
-      name: 'p1',
-      city: 'location'
-    });
-
+    const sp1 = newSmallPublisher(em, { name: "p1", city: "location" });
     await em.flush();
-
     const sp = alias(SmallPublisher);
-    const res = await em.find(SmallPublisher, { as: sp }, { conditions: { and: [sp.name.eq('p1')]}})
-
-    expect(res.length).toBe(1);
+    const res = await em.find(SmallPublisher, { as: sp }, { conditions: { and: [sp.name.eq("p1")] } });
+    expect(res).toMatchEntity([sp1]);
   });
 
-  it.only('finds against child with simple child & parent filter', async () => {
+  it("finds against child with simple child & parent filter", async () => {
     const em = newEntityManager();
-
-    em.create(SmallPublisher, {
-      name: 'p1',
-      city: 'location'
-    });
-
+    const sp1 = newSmallPublisher(em, { name: "p1", city: "location" });
     await em.flush();
-
-    const sp = alias(Publisher);
-    const res = await em.find(SmallPublisher, { as: sp }, { conditions: { and: [sp.name.eq('p1')]}})
-
-    expect(res.length).toBe(1);
+    const p = alias(Publisher);
+    const res = await em.find(SmallPublisher, { as: p }, { conditions: { and: [p.name.eq("p1")] } });
+    expect(res).toMatchEntity([sp1]);
   });
 });

--- a/packages/integration-tests/src/entities/metadata.ts
+++ b/packages/integration-tests/src/entities/metadata.ts
@@ -291,11 +291,11 @@ export const commentMeta: EntityMetadata<Comment> = {
       fieldName: "parent",
       fieldIdName: "parentId",
       required: true,
-      components: [{ otherMetadata: () => authorMeta, otherFieldName: "comments", columnName: "parent_author_id" }, { otherMetadata: () => bookMeta, otherFieldName: "comments", columnName: "parent_book_id" }, {
-        otherMetadata: () => bookReviewMeta,
-        otherFieldName: "comment",
-        columnName: "parent_book_review_id",
-      }, { otherMetadata: () => publisherMeta, otherFieldName: "comments", columnName: "parent_publisher_id" }],
+      components: [{ otherMetadata: () => authorMeta, otherFieldName: "comments", columnName: "parent_author_id" }, { otherMetadata: () => bookMeta, otherFieldName: "comments", columnName: "parent_book_id" }, { otherMetadata: () => bookReviewMeta, otherFieldName: "comment", columnName: "parent_book_review_id" }, {
+        otherMetadata: () => publisherMeta,
+        otherFieldName: "comments",
+        columnName: "parent_publisher_id",
+      }],
       serde: new PolymorphicKeySerde(() => commentMeta, "parent"),
       immutable: false,
     },

--- a/packages/integration-tests/src/testDrivers.ts
+++ b/packages/integration-tests/src/testDrivers.ts
@@ -33,7 +33,7 @@ export class PostgresTestDriver implements TestDriver {
   constructor() {
     this.knex = createKnex({
       client: "pg",
-      connection: newPgConnectionConfig(),
+      connection: newPgConnectionConfig() as any,
       debug: false,
       asyncStackTraces: true,
     }).on("query", (e: any) => {

--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -149,9 +149,9 @@ export function parseFindQuery(
     // might actually be `a1` if there are two `authors` tables in the query, so push the
     // canonical alias value for the current clause into the Alias.
     if (filter && typeof filter === "object" && "as" in filter && isAlias(filter.as)) {
-      filter.as[aliasMgmt].setAlias(alias);
+      filter.as[aliasMgmt].setAlias(meta, alias);
     } else if (isAlias(filter)) {
-      filter[aliasMgmt].setAlias(alias);
+      filter[aliasMgmt].setAlias(meta, alias);
     }
 
     if (ef && ef.kind === "join") {

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -271,7 +271,6 @@ export function configureMetadata(metas: EntityMetadata<any>[]): void {
 
   // Setup subTypes/baseTypes
   metas.forEach((m) => {
-    const abbr = `${abbreviation(m.tableName)}0`;
     // This is basically m.fields.mapValues to assign the primary alias
     m.allFields = Object.fromEntries(
       Object.entries(m.fields).map(([name, field]) => [name, { ...field, aliasSuffix: "" }]),


### PR DESCRIPTION
Getting up some cases here to show the problem - can move them somewhere more appropriate once the fix is in - it's the last two.

Essentially it looks like complex filtering don't take in to account that they might be filtering on the parent table.

See how a complex condition (using either the Publisher or SmallPublisher as the alias) against `name`, which exists on the publisher table, has the filter condition's alias set to `sp` - i.e the child table.

```js
{
      selects: [ 'sp.*', 'sp_b0.*', 'sp.id as id' ],
      tables: [
        { alias: 'sp', table: 'small_publishers', join: 'primary' },
        {
          alias: 'sp_b0',
          table: 'publishers',
          join: 'outer',
          col1: 'sp.id',
          col2: 'sp_b0.id',
          distinct: false
        }
      ],
      conditions: [],
      orderBys: [ { alias: 'sp', column: 'id', order: 'ASC' } ],
      complexConditions: [
        {
          op: 'and',
          conditions: [
            {
              alias: 'sp',
              column: 'name',
              dbType: 'character varying',
              cond: { kind: 'eq', value: 'p1' }
            }
          ]
        }
      ]
    }
```

Haven't fiddled around with the QueryParser yet, so I'm having a look, @stephenh any pointers lmk!