### PR TITLE
feat: Generate an app-specific Entity type.

### DIFF
--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -1,6 +1,6 @@
 import { code, CodegenFile, def, imp } from "ts-poet";
 import { generateEntitiesFile } from "./generateEntitiesFile";
-import { generateEntityCodegenFile } from "./generateEntityCodegenFile";
+import { generateEntityCodegenFile, getIdType } from "./generateEntityCodegenFile";
 import { generateEnumFile } from "./generateEnumFile";
 import { generateFactoriesFiles } from "./generateFactoriesFiles";
 import { generateInitialEntityFile } from "./generateInitialEntityFile";
@@ -54,7 +54,8 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
     .reduce(merge, []);
 
   const contextType = config.contextType ? imp(config.contextType) : "{}";
-  const BaseEntity = imp("BaseEntity@joist-orm");
+  const JoistEntity = imp("Entity@joist-orm");
+  const idType = getIdType(config);
 
   const invalidEntities = entities.filter((e) => e.invalidDeferredFK);
   const metadataFile: CodegenFile = {
@@ -67,11 +68,9 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
             .join(",")}');`
         : ``
     }
-      export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}> {}
+      export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}, ${idType}> {}
 
-      export function getEm(e: ${BaseEntity}): EntityManager {
-        return e.em as EntityManager;
-      }
+      export type ${def("Entity")} = ${JoistEntity}<${idType}>;
 
       ${entities.map((meta) => generateMetadataFile(config, dbMeta, meta))}
 

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -841,7 +841,7 @@ function nullOrNever(notNull: boolean): string {
   return notNull ? "never" : "null";
 }
 
-function getIdType(config: Config) {
+export function getIdType(config: Config) {
   switch (config.idType) {
     case "untagged-string":
     case "tagged-string":

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -192,6 +192,10 @@ type ET<I extends IdType = IdType> = Entity<I>;
  * @param I The type of your application-specific IdType, i.e. `string | number`
  * @param Entity the Entity type but adapted to your app's IdType, i.e. `string | number`
  */
+// We purposefully use the name `Entity` for the type parameter, but have it mapped to the `Entity<string>`
+// or `Entity<number>` that will be specific for the application, as this keeps all our type signatures
+// clean (not having to repeat `Entity<I>` everywhere), while automatically ensuring any "Entity" usages
+// in our API methods is the application-specific adaptation.
 export class EntityManager<C = unknown, I extends IdType = IdType, Entity extends ET<I> = ET<I>> {
   public readonly ctx: C;
   public driver: Driver;

--- a/packages/tests/integration/src/entities/metadata.ts
+++ b/packages/tests/integration/src/entities/metadata.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, BigIntSerde, configureMetadata, CustomSerdeAdapter, DecimalToNumberSerde, EntityManager as EntityManager1, EntityMetadataTyped, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde, ZodSerde } from "joist-orm";
+import { BigIntSerde, configureMetadata, CustomSerdeAdapter, DecimalToNumberSerde, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde, ZodSerde } from "joist-orm";
 import { Context } from "src/context";
 import { address, AddressSchema, PasswordValueSerde, quotes } from "src/entities/types";
 import {
@@ -59,9 +59,7 @@ import {
 
 export class EntityManager extends EntityManager1<Context> {}
 
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
+export type Entity = Entity2<string>;
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/number-ids/src/entities/metadata.ts
+++ b/packages/tests/number-ids/src/entities/metadata.ts
@@ -1,12 +1,10 @@
-import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
 
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
+export type Entity = Entity2<number>;
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/schema-misc/src/entities/metadata.ts
+++ b/packages/tests/schema-misc/src/entities/metadata.ts
@@ -1,12 +1,10 @@
-import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Artist, artistConfig, Author, authorConfig, Book, bookConfig, DatabaseOwner, databaseOwnerConfig, newArtist, newAuthor, newBook, newDatabaseOwner, newPainting, Painting, paintingConfig } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
 
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
+export type Entity = Entity2<string>;
 
 export const artistMeta: EntityMetadataTyped<Artist> = {
   cstr: Artist,

--- a/packages/tests/untagged-ids/src/entities/metadata.ts
+++ b/packages/tests/untagged-ids/src/entities/metadata.ts
@@ -1,12 +1,10 @@
-import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
 
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
+export type Entity = Entity2<string>;
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/uuid-ids/src/entities/metadata.ts
+++ b/packages/tests/uuid-ids/src/entities/metadata.ts
@@ -1,12 +1,10 @@
-import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
 
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
+export type Entity = Entity2<string>;
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,


### PR DESCRIPTION
And then work it into the app-specific EntityManager as well.

Hopefully this will mitigate some of the "ids are now numbers or strings?!" fallout from the last Joist release, which added support for number-typed ids.