### PR TITLE
feat: Reroll per-application Entity

### DIFF
--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -7,7 +7,7 @@ import { generateInitialEntityFile } from "./generateInitialEntityFile";
 import { generateMetadataFile } from "./generateMetadataFile";
 import { generatePgEnumFile } from "./generatePgEnumFile";
 import { Config, DbMetadata } from "./index";
-import { configureMetadata, JoistEntityManager } from "./symbols";
+import {configureMetadata, EntityManager, Entity, JoistEntityManager} from "./symbols";
 import { merge, tableToEntityName } from "./utils";
 
 export type DPrintOptions = Record<string, unknown>;
@@ -67,6 +67,11 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
         : ``
     }
       export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}> {}
+
+      export interface ${def("Entity")} extends ${Entity} {
+        id: ${getIdType(config)};
+        em: EntityManager;
+      }
 
       ${entities.map((meta) => generateMetadataFile(config, dbMeta, meta))}
 

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -66,7 +66,7 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
             .join(",")}');`
         : ``
     }
-      export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}> {}
+      export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}, Entity> {}
 
       export interface ${def("Entity")} extends ${Entity} {
         id: ${getIdType(config)};

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -1,6 +1,6 @@
 import { code, CodegenFile, def, imp } from "ts-poet";
 import { generateEntitiesFile } from "./generateEntitiesFile";
-import { generateEntityCodegenFile } from "./generateEntityCodegenFile";
+import { generateEntityCodegenFile, getIdType } from "./generateEntityCodegenFile";
 import { generateEnumFile } from "./generateEnumFile";
 import { generateFactoriesFiles } from "./generateFactoriesFiles";
 import { generateInitialEntityFile } from "./generateInitialEntityFile";
@@ -54,7 +54,6 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
     .reduce(merge, []);
 
   const contextType = config.contextType ? imp(config.contextType) : "{}";
-  const BaseEntity = imp("BaseEntity@joist-orm");
 
   const invalidEntities = entities.filter((e) => e.invalidDeferredFK);
   const metadataFile: CodegenFile = {
@@ -68,10 +67,6 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
         : ``
     }
       export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}> {}
-
-      export function getEm(e: ${BaseEntity}): EntityManager {
-        return e.em as EntityManager;
-      }
 
       ${entities.map((meta) => generateMetadataFile(config, dbMeta, meta))}
 

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -841,7 +841,7 @@ function nullOrNever(notNull: boolean): string {
   return notNull ? "never" : "null";
 }
 
-function getIdType(config: Config) {
+export function getIdType(config: Config) {
   switch (config.idType) {
     case "untagged-string":
     case "tagged-string":

--- a/packages/graphql-resolver-utils/src/saveEntity.ts
+++ b/packages/graphql-resolver-utils/src/saveEntity.ts
@@ -1,8 +1,8 @@
-import { BaseEntity, DeepPartialOrNull, EntityConstructor, OptsOf } from "joist-orm";
+import { DeepPartialOrNull, Entity, EntityConstructor, OptsOf } from "joist-orm";
 import { Context } from "./context";
 
 /** Given an GraphQL input, creates-or-updates an entity of `type`. */
-export async function saveEntity<T extends BaseEntity>(
+export async function saveEntity<T extends Entity>(
   ctx: Context,
   type: EntityConstructor<T>,
   input: DeepPartialOrNull<T>,
@@ -12,7 +12,7 @@ export async function saveEntity<T extends BaseEntity>(
 }
 
 /** Given GraphQL inputs, creates-or-updates multiple entities of `type`. */
-export async function saveEntities<T extends BaseEntity>(
+export async function saveEntities<T extends Entity>(
   ctx: Context,
   type: EntityConstructor<T>,
   input: readonly DeepPartialOrNull<T>[],

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -39,7 +39,7 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
       this.__orm.data["id"] = opts;
       this.__orm.isNew = false;
     }
-    em.register(metadata, this as any);
+    em.register(metadata, this);
   }
 
   /** @returns the entity's id, tagged/untagged based on your config, or a runtime error if it's new/unassigned. */
@@ -126,7 +126,7 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
         .map((f) => {
           switch (f.kind) {
             case "primaryKey":
-              return [[f.fieldName, (this as any).idMaybe || null]];
+              return [[f.fieldName, this.idMaybe || null]];
             case "enum":
               return [[f.fieldName, (this as any)[f.fieldName] || null]];
             case "primitive":
@@ -139,7 +139,7 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
             case "m2o":
               // Don't recurse into new entities b/c the point is to stay shallow
               const value = (this as any)[f.fieldName].current();
-              return [[f.fieldName, isEntity(value) ? (value as any).idMaybe || null : value || null]];
+              return [[f.fieldName, isEntity(value) ? value.idMaybe || null : value || null]];
             default:
               return [];
           }

--- a/packages/orm/src/BaseEntity.ts
+++ b/packages/orm/src/BaseEntity.ts
@@ -17,16 +17,14 @@ import {
  *
  * Currently, this just adds the `.load(lensFn)` method for declarative reference traversal.
  */
-export abstract class BaseEntity<EM extends EntityManager = EntityManager, I extends IdType = string>
-  implements Entity<I>
-{
+export abstract class BaseEntity<EM extends EntityManager, I extends IdType = IdType> implements Entity {
   readonly __orm!: EntityOrmField;
   // This gives rules a way to access the fully typed object instead of their Reacted view.
   // And we make it public so that a function that takes Reacted<...> can accept a Loaded<...>
   // that sufficiently overlaps.
   readonly fullNonReactiveAccess!: this;
 
-  protected constructor(em: EntityManager, metadata: any, defaultValues: object, opts: any) {
+  protected constructor(em: EM, metadata: any, defaultValues: object, opts: any) {
     Object.defineProperty(this, "__orm", {
       value: new EntityOrmField(em, metadata, defaultValues),
       enumerable: false,
@@ -41,7 +39,7 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager, I ext
       this.__orm.data["id"] = opts;
       this.__orm.isNew = false;
     }
-    em.register(metadata, this);
+    em.register(metadata, this as any);
   }
 
   /** @returns the entity's id, tagged/untagged based on your config, or a runtime error if it's new/unassigned. */
@@ -141,7 +139,7 @@ export abstract class BaseEntity<EM extends EntityManager = EntityManager, I ext
             case "m2o":
               // Don't recurse into new entities b/c the point is to stay shallow
               const value = (this as any)[f.fieldName].current();
-              return [[f.fieldName, isEntity(value) ? value.idMaybe || null : value || null]];
+              return [[f.fieldName, isEntity(value) ? (value as any).idMaybe || null : value || null]];
             default:
               return [];
           }

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -10,20 +10,15 @@ export function isEntity(maybeEntity: any): maybeEntity is Entity {
 export type IdType = number | string;
 
 /** A marker/base interface for all of our entity types. */
-export interface Entity<I extends IdType = IdType> {
-  /**
-   * The entity's primary key, or undefined if it's new.
-   *
-   * This will be a tagged id, i.e. `a:1`, unless idType is untagged in `joist-config.json`.
-   */
-  id: I;
-  idMaybe: I | undefined;
+export interface Entity {
+  id: IdType;
+  idMaybe: IdType | undefined;
   /** The entity id that is always tagged, regardless of the idType config. */
   idTagged: TaggedId;
   idTaggedMaybe: TaggedId | undefined;
   /** Joist internal metadata, should be considered a private implementation detail. */
   readonly __orm: EntityOrmField;
-  readonly em: EntityManager<any>;
+  readonly em: EntityManager;
   readonly isNewEntity: boolean;
   readonly isDeletedEntity: boolean;
   readonly isDirtyEntity: boolean;

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1,6 +1,7 @@
 import DataLoader, { BatchLoadFn, Options } from "dataloader";
 import { Knex } from "knex";
-import { Entity, IdType, isEntity } from "./Entity";
+// We alias `Entity => EntityW` to denote "Entity wide" i.e. the non-narrowed Entity
+import { Entity, Entity as EntityW, IdType, isEntity } from "./Entity";
 import { FlushLock } from "./FlushLock";
 import { JoinRows } from "./JoinRows";
 import { ReactionsManager } from "./ReactionsManager";
@@ -66,7 +67,7 @@ import { MaybePromise, assertNever, fail, getOrSet, partition, toArray } from ".
  * implement this and instead only have the `AbsEntityConstructor` type.
  */
 export interface EntityConstructor<T> {
-  new (em: EntityManager<any>, opts: any): T;
+  new (em: EntityManager<any, any>, opts: any): T;
 
   defaultValues: object;
   // Use any for now to pass the `.includes` test in `EntityConstructor.test.ts`. We could
@@ -110,7 +111,7 @@ export interface FindCountFilterOptions<T extends Entity> {
  *
  * I.e. this is more like "MaybeAbstractEntityConstructor".
  */
-export type MaybeAbstractEntityConstructor<T> = abstract new (em: EntityManager<any>, opts: any) => T;
+export type MaybeAbstractEntityConstructor<T> = abstract new (em: EntityManager<any, any>, opts: any) => T;
 
 /** Return the `FooOpts` type a given `Foo` entity constructor. */
 export type OptsOf<T> = T extends { __orm: { optsType: infer O } } ? O : never;
@@ -188,7 +189,7 @@ export interface FlushOptions {
  *
  * @param C The type of your application-specific app-wide/request-wide Context object that will be passed to hooks
  */
-export class EntityManager<C = unknown> {
+export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
   public readonly ctx: C;
   public driver: Driver;
   public currentTxnKnex: Knex | undefined;
@@ -278,7 +279,7 @@ export class EntityManager<C = unknown> {
   }
 
   /** Looks up `id` in the list of already-loaded entities. */
-  getEntity<T extends Entity>(id: IdOf<T> & string): T | undefined;
+  getEntity<T extends Entity & { id: string }>(id: IdOf<T>): T | undefined;
   getEntity(id: TaggedId): Entity | undefined;
   getEntity(id: TaggedId): Entity | undefined {
     assertIdIsTagged(id);
@@ -297,13 +298,16 @@ export class EntityManager<C = unknown> {
    * to avoid N+1s. Because of this, it cannot be used with queries that want to use `LIMIT`
    * or `OFFSET`; for those, see `findPaginated`.
    */
-  public async find<T extends Entity>(type: MaybeAbstractEntityConstructor<T>, where: FilterWithAlias<T>): Promise<T[]>;
-  public async find<T extends Entity, const H extends LoadHint<T>>(
+  public async find<T extends EntityW>(
+    type: MaybeAbstractEntityConstructor<T>,
+    where: FilterWithAlias<T>,
+  ): Promise<T[]>;
+  public async find<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options?: FindFilterOptions<T> & { populate?: H },
   ): Promise<Loaded<T, H>[]>;
-  async find<T extends Entity>(
+  async find<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options?: FindFilterOptions<T> & { populate?: any },
@@ -328,17 +332,17 @@ export class EntityManager<C = unknown> {
    * This method is *NOT* batch-friendly, i.e. if called in a loop, it will cause N+1s. Because
    * of this, you should prefer using `find`, unless you explicitly pagination support.
    */
-  public async findPaginated<T extends Entity>(
+  public async findPaginated<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options: FindPaginatedFilterOptions<T>,
   ): Promise<T[]>;
-  public async findPaginated<T extends Entity, const H extends LoadHint<T>>(
+  public async findPaginated<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options: FindPaginatedFilterOptions<T> & { populate: H },
   ): Promise<Loaded<T, H>[]>;
-  async findPaginated<T extends Entity>(
+  async findPaginated<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options: FindPaginatedFilterOptions<T> & { populate?: any },
@@ -359,16 +363,16 @@ export class EntityManager<C = unknown> {
    *
    * I.e. filtering by `null` on fields that are non-`nullable`.
    */
-  public async findGql<T extends Entity>(
+  public async findGql<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: GraphQLFilterWithAlias<T>,
   ): Promise<T[]>;
-  public async findGql<T extends Entity, const H extends LoadHint<T>>(
+  public async findGql<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     where: GraphQLFilterWithAlias<T>,
     options?: FindFilterOptions<T> & { populate?: H },
   ): Promise<Loaded<T, H>[]>;
-  async findGql<T extends Entity>(
+  async findGql<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: GraphQLFilterOf<T>,
     options?: FindFilterOptions<T> & { populate?: any },
@@ -381,17 +385,17 @@ export class EntityManager<C = unknown> {
    *
    * I.e. filtering by `null` on fields that are non-`nullable`.
    */
-  public async findGqlPaginated<T extends Entity>(
+  public async findGqlPaginated<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: GraphQLFilterWithAlias<T>,
     options: FindGqlPaginatedFilterOptions<T>,
   ): Promise<T[]>;
-  public async findGqlPaginated<T extends Entity, const H extends LoadHint<T>>(
+  public async findGqlPaginated<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     where: GraphQLFilterWithAlias<T>,
     options: FindGqlPaginatedFilterOptions<T> & { populate: H },
   ): Promise<Loaded<T, H>[]>;
-  async findGqlPaginated<T extends Entity>(
+  async findGqlPaginated<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: GraphQLFilterWithAlias<T>,
     options: FindGqlPaginatedFilterOptions<T> & { populate?: any },
@@ -399,16 +403,16 @@ export class EntityManager<C = unknown> {
     return this.findPaginated(type, where as any, options as any);
   }
 
-  public async findOne<T extends Entity>(
+  public async findOne<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
   ): Promise<T | undefined>;
-  public async findOne<T extends Entity, const H extends LoadHint<T>>(
+  public async findOne<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options?: { populate?: H; softDeletes?: "include" | "exclude" },
   ): Promise<Loaded<T, H> | undefined>;
-  async findOne<T extends Entity>(
+  async findOne<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options?: { populate?: any; softDeletes?: "include" | "exclude" },
@@ -424,16 +428,16 @@ export class EntityManager<C = unknown> {
   }
 
   /** Executes a given query filter and returns exactly one result, otherwise throws `NotFoundError` or `TooManyError`. */
-  public async findOneOrFail<T extends Entity>(
+  public async findOneOrFail<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
   ): Promise<T>;
-  public async findOneOrFail<T extends Entity, const H extends LoadHint<T>>(
+  public async findOneOrFail<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options: { populate?: H; softDeletes?: "include" | "exclude" },
   ): Promise<Loaded<T, H>>;
-  async findOneOrFail<T extends Entity>(
+  async findOneOrFail<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options?: { populate?: any; softDeletes?: "include" | "exclude" },
@@ -447,16 +451,16 @@ export class EntityManager<C = unknown> {
     return list[0];
   }
 
-  public async findByUnique<T extends Entity>(
+  public async findByUnique<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: UniqueFilter<T>,
   ): Promise<T | undefined>;
-  public async findByUnique<T extends Entity, const H extends LoadHint<T>>(
+  public async findByUnique<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     where: UniqueFilter<T>,
     options?: { populate?: H; softDeletes?: "include" | "exclude" },
   ): Promise<Loaded<T, H> | undefined>;
-  async findByUnique<T extends Entity>(
+  async findByUnique<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: UniqueFilter<T>,
     options: { populate?: any; softDeletes?: "include" | "exclude" } = {},
@@ -488,7 +492,7 @@ export class EntityManager<C = unknown> {
    *
    * Note: this method is not currently auto-batched, so it will cause N+1s if called in a loop.
    */
-  async findCount<T extends Entity>(
+  async findCount<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     where: FilterWithAlias<T>,
     options: FindCountFilterOptions<T> = {},
@@ -536,13 +540,13 @@ export class EntityManager<C = unknown> {
    * @param upsert the fields to update if the entity is either existing or new
    */
   async findOrCreate<
-    T extends Entity,
+    T extends EntityW,
     F extends Partial<OptsOf<T>>,
     U extends Partial<OptsOf<T>> | {},
     N extends Omit<OptsOf<T>, keyof F | keyof U>,
   >(type: EntityConstructor<T>, where: F, ifNew: N, upsert?: U): Promise<T>;
   async findOrCreate<
-    T extends Entity,
+    T extends EntityW,
     F extends Partial<OptsOf<T>>,
     U extends Partial<OptsOf<T>> | {},
     N extends Omit<OptsOf<T>, keyof F | keyof U>,
@@ -555,7 +559,7 @@ export class EntityManager<C = unknown> {
     options?: { populate?: H; softDeletes?: "include" | "exclude" },
   ): Promise<Loaded<T, H>>;
   async findOrCreate<
-    T extends Entity,
+    T extends EntityW,
     F extends Partial<OptsOf<T>>,
     U extends Partial<OptsOf<T>> | {},
     N extends Omit<OptsOf<T>, keyof F | keyof U>,
@@ -580,13 +584,13 @@ export class EntityManager<C = unknown> {
   }
 
   /** Creates a new `type` and marks it as loaded, i.e. we know its collections are all safe to access in memory. */
-  public create<T extends Entity, O extends OptsOf<T>>(type: EntityConstructor<T>, opts: O): New<T, O> {
+  public create<T extends EntityW, O extends OptsOf<T>>(type: EntityConstructor<T>, opts: O): New<T, O> {
     // The constructor will run setOpts which handles defaulting collections to the right state.
     return new type(this, opts) as New<T, O>;
   }
 
   /** Creates a new `type` but with `opts` that are nullable, to accept partial-update-style input. */
-  public createPartial<T extends Entity>(type: EntityConstructor<T>, opts: PartialOrNull<OptsOf<T>>): T {
+  public createPartial<T extends EntityW>(type: EntityConstructor<T>, opts: PartialOrNull<OptsOf<T>>): T {
     // We force some manual calls to setOpts to mimic `setUnsafe`'s behavior that `undefined` should
     // mean "ignore" (and we assume validation rules will catch it later) but still set
     // `calledFromConstructor` because this is _basically_ like calling `new`.
@@ -597,7 +601,7 @@ export class EntityManager<C = unknown> {
   }
 
   /** Creates a new `type` but with `opts` that are nullable, to accept partial-update-style input. */
-  public createOrUpdatePartial<T extends Entity>(type: EntityConstructor<T>, opts: DeepPartialOrNull<T>): Promise<T> {
+  public createOrUpdatePartial<T extends EntityW>(type: EntityConstructor<T>, opts: DeepPartialOrNull<T>): Promise<T> {
     return createOrUpdatePartial(this, type, opts);
   }
 
@@ -631,7 +635,7 @@ export class EntityManager<C = unknown> {
    * // This will duplicate the author, but skip any book where the title includes `sea`
    * const duplicatedAuthor = await em.clone(author, { skipIf: (original) => original.title?.includes("sea") })
    */
-  public async clone<T extends Entity, H extends LoadHint<T>>(
+  public async clone<T extends EntityW, H extends LoadHint<T>>(
     entity: T,
     opts?: { deep?: H; skipIf?: (entity: Entity) => boolean; postClone?: (original: Entity, clone: Entity) => void },
   ): Promise<Loaded<T, H>>;
@@ -662,11 +666,11 @@ export class EntityManager<C = unknown> {
    * // This will duplicate the author's books, but skip any book where the title includes `sea`
    * const duplicatedBooks = await em.clone(author.books.get, { skipIf: (original) => original.title.includes("sea") })
    */
-  public async clone<T extends Entity, H extends LoadHint<T>>(
+  public async clone<T extends EntityW, H extends LoadHint<T>>(
     entities: readonly T[],
     opts?: { deep?: H; skipIf?: (entity: Entity) => boolean; postClone?: (original: Entity, clone: Entity) => void },
   ): Promise<Loaded<T, H>[]>;
-  public async clone<T extends Entity, H extends LoadHint<T>>(
+  public async clone<T extends EntityW, H extends LoadHint<T>>(
     entityOrArray: T | readonly T[],
     opts?: { deep?: H; skipIf?: (entity: Entity) => boolean; postClone?: (original: Entity, clone: Entity) => void },
   ): Promise<Loaded<T, H> | Loaded<T, H>[]> {
@@ -675,7 +679,7 @@ export class EntityManager<C = unknown> {
     const todo: Entity[] = [];
 
     // 1. Find all entities w/o mutating them yets
-    await crawl(todo, Array.isArray(entityOrArray) ? entityOrArray : [entityOrArray], deep, { skipIf });
+    await crawl(todo, Array.isArray(entityOrArray) ? entityOrArray : [entityOrArray], deep, { skipIf: skipIf as any });
 
     // 2. Clone each found entity
     const clones = todo.map((entity) => {
@@ -753,15 +757,15 @@ export class EntityManager<C = unknown> {
   }
 
   /** Returns an instance of `type` for the given `id`, resolving to an existing instance if in our Unit of Work. */
-  public async load<T>(id: IdOf<T> & string): Promise<T>;
+  public async load<T extends EntityW & { id: string }>(id: IdOf<T>): Promise<T>;
   public async load(id: TaggedId): Promise<Entity>;
-  public async load<T extends Entity>(type: MaybeAbstractEntityConstructor<T>, id: IdOf<T> | TaggedId): Promise<T>;
-  public async load<T extends Entity, const H extends LoadHint<T>>(
+  public async load<T extends EntityW>(type: MaybeAbstractEntityConstructor<T>, id: IdOf<T> | TaggedId): Promise<T>;
+  public async load<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     id: IdOf<T> | TaggedId,
     populate: H,
   ): Promise<Loaded<T, H>>;
-  async load<T extends Entity>(
+  async load<T extends EntityW>(
     typeOrId: MaybeAbstractEntityConstructor<T> | string,
     id?: IdType,
     hint?: any,
@@ -790,13 +794,16 @@ export class EntityManager<C = unknown> {
   }
 
   /** Returns instances of `type` for the given `ids`, resolving to an existing instance if in our Unit of Work. */
-  public async loadAll<T extends Entity>(type: MaybeAbstractEntityConstructor<T>, ids: readonly string[]): Promise<T[]>;
-  public async loadAll<T extends Entity, const H extends LoadHint<T>>(
+  public async loadAll<T extends EntityW>(
+    type: MaybeAbstractEntityConstructor<T>,
+    ids: readonly string[],
+  ): Promise<T[]>;
+  public async loadAll<T extends EntityW, const H extends LoadHint<T>>(
     type: MaybeAbstractEntityConstructor<T>,
     ids: readonly string[],
     populate: H,
   ): Promise<Loaded<T, H>[]>;
-  async loadAll<T extends Entity>(
+  async loadAll<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     _ids: readonly string[],
     hint?: any,
@@ -822,13 +829,13 @@ export class EntityManager<C = unknown> {
    * Returns instances of `type` for the given `ids`, resolving to an existing instance if in our Unit of Work. Ignores
    * IDs that are not found.
    */
-  public async loadAllIfExists<T extends Entity>(type: EntityConstructor<T>, ids: readonly string[]): Promise<T[]>;
-  public async loadAllIfExists<T extends Entity, const H extends LoadHint<T>>(
+  public async loadAllIfExists<T extends EntityW>(type: EntityConstructor<T>, ids: readonly string[]): Promise<T[]>;
+  public async loadAllIfExists<T extends EntityW, const H extends LoadHint<T>>(
     type: EntityConstructor<T>,
     ids: readonly string[],
     populate: H,
   ): Promise<Loaded<T, H>[]>;
-  async loadAllIfExists<T extends Entity>(
+  async loadAllIfExists<T extends EntityW>(
     type: EntityConstructor<T>,
     _ids: readonly string[],
     hint?: any,
@@ -854,13 +861,13 @@ export class EntityManager<C = unknown> {
    * Results are unique, i.e. if doing `em.loadLens([b1, b2], b => b.author.publisher)` point to the
    * same `Publisher`, it will only be returned as a single value.
    */
-  public async loadLens<T extends Entity, U, V>(entities: T[], fn: (lens: Lens<T>) => Lens<U, V>): Promise<U[]>;
-  public async loadLens<T extends Entity, U extends Entity, V, const H extends LoadHint<U>>(
+  public async loadLens<T extends EntityW, U, V>(entities: T[], fn: (lens: Lens<T>) => Lens<U, V>): Promise<U[]>;
+  public async loadLens<T extends EntityW, U extends EntityW, V, const H extends LoadHint<U>>(
     entities: T[],
     fn: (lens: Lens<T>) => Lens<U, V>,
     populate: H,
   ): Promise<Loaded<U, H>[]>;
-  public async loadLens<T extends Entity, U, V>(
+  public async loadLens<T extends EntityW, U, V>(
     entities: T[],
     fn: (lens: Lens<T>) => Lens<U, V>,
     populate?: any,
@@ -873,13 +880,13 @@ export class EntityManager<C = unknown> {
   }
 
   /** Loads entities from a knex QueryBuilder. */
-  public async loadFromQuery<T extends Entity>(type: EntityConstructor<T>, query: Knex.QueryBuilder): Promise<T[]>;
-  public async loadFromQuery<T extends Entity, const H extends LoadHint<T>>(
+  public async loadFromQuery<T extends EntityW>(type: EntityConstructor<T>, query: Knex.QueryBuilder): Promise<T[]>;
+  public async loadFromQuery<T extends EntityW, const H extends LoadHint<T>>(
     type: EntityConstructor<T>,
     query: Knex.QueryBuilder,
     populate: H,
   ): Promise<Loaded<T, H>[]>;
-  public async loadFromQuery<T extends Entity>(
+  public async loadFromQuery<T extends EntityW>(
     type: EntityConstructor<T>,
     query: Knex.QueryBuilder,
     populate?: any,
@@ -898,13 +905,13 @@ export class EntityManager<C = unknown> {
   }
 
   /** Loads entities from rows. */
-  public async loadFromRows<T extends Entity>(type: EntityConstructor<T>, rows: unknown[]): Promise<T[]>;
-  public async loadFromRows<T extends Entity, const H extends LoadHint<T>>(
+  public async loadFromRows<T extends EntityW>(type: EntityConstructor<T>, rows: unknown[]): Promise<T[]>;
+  public async loadFromRows<T extends EntityW, const H extends LoadHint<T>>(
     type: EntityConstructor<T>,
     rows: unknown[],
     populate: H,
   ): Promise<Loaded<T, H>[]>;
-  public async loadFromRows<T extends Entity>(
+  public async loadFromRows<T extends EntityW>(
     type: EntityConstructor<T>,
     rows: unknown[],
     populate?: any,
@@ -917,25 +924,25 @@ export class EntityManager<C = unknown> {
   }
 
   /** Given a hint `H` (a field, array of fields, or nested hash), pre-load that data into `entity` for sync access. */
-  public async populate<T extends Entity, const H extends LoadHint<T>, V = Loaded<T, H>>(
+  public async populate<T extends EntityW, const H extends LoadHint<T>, V = Loaded<T, H>>(
     entity: T,
     hint: H,
     fn?: (entity: Loaded<T, H>) => V,
   ): Promise<V>;
-  public async populate<T extends Entity, const H extends LoadHint<T>, V = Loaded<T, H>>(
+  public async populate<T extends EntityW, const H extends LoadHint<T>, V = Loaded<T, H>>(
     entity: T,
     opts: { hint: H; forceReload?: boolean },
     fn?: (entity: Loaded<T, H>) => V,
   ): Promise<V>;
-  public async populate<T extends Entity, const H extends LoadHint<T>>(
+  public async populate<T extends EntityW, const H extends LoadHint<T>>(
     entities: ReadonlyArray<T>,
     hint: H,
   ): Promise<Loaded<T, H>[]>;
-  public async populate<T extends Entity, const H extends LoadHint<T>>(
+  public async populate<T extends EntityW, const H extends LoadHint<T>>(
     entities: ReadonlyArray<T>,
     opts: { hint: H; forceReload?: boolean },
   ): Promise<Loaded<T, H>[]>;
-  async populate<T extends Entity, H extends LoadHint<T>, V>(
+  async populate<T extends EntityW, H extends LoadHint<T>, V>(
     entityOrList: T | T[],
     hintOrOpts: { hint: H; forceReload?: boolean } | H,
     fn?: (entity: Loaded<T, H>) => V,
@@ -1213,9 +1220,9 @@ export class EntityManager<C = unknown> {
    * `deepLoad` which should only be used by tests to avoid loading your entire database in memory.
    */
   async refresh(opts?: { deepLoad?: boolean }): Promise<void>;
-  async refresh(entity: Entity): Promise<void>;
-  async refresh(entities: ReadonlyArray<Entity>): Promise<void>;
-  async refresh(param?: Entity | ReadonlyArray<Entity> | { deepLoad?: boolean }): Promise<void> {
+  async refresh(entity: EntityW): Promise<void>;
+  async refresh(entities: ReadonlyArray<EntityW>): Promise<void>;
+  async refresh(param?: EntityW | ReadonlyArray<EntityW> | { deepLoad?: boolean }): Promise<void> {
     this.#dataloaders = {};
     this.#preloadedRelations = new Map();
     const deepLoad = param && "deepLoad" in param && param.deepLoad;
@@ -1291,7 +1298,7 @@ export class EntityManager<C = unknown> {
 
   // Handles our Unit of Work-style look up / deduplication of entity instances.
   // Currently only public for the driver impls
-  public findExistingInstance<T extends Entity>(id: string): T | undefined {
+  public findExistingInstance<T extends EntityW>(id: string): T | undefined {
     assertIdIsTagged(id);
     return this.#entityIndex.get(id) as T | undefined;
   }
@@ -1305,7 +1312,7 @@ export class EntityManager<C = unknown> {
    * i.e. when we're loading collections and have db results that are potentially stale compared to
    * the WIP entity state.
    */
-  public hydrate<T extends Entity>(
+  public hydrate<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
     row: any,
     options?: { overwriteExisting?: boolean },
@@ -1343,7 +1350,7 @@ export class EntityManager<C = unknown> {
    * - Recalc all async derived fields stored on the entity, and
    * - Rerun all simple & reactive rules on the entity.
    */
-  public touch(entity: Entity) {
+  public touch(entity: EntityW) {
     entity.__orm.isTouched = true;
   }
 

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -675,7 +675,7 @@ export class EntityManager<C = unknown> {
     const todo: Entity[] = [];
 
     // 1. Find all entities w/o mutating them yets
-    await crawl(todo, Array.isArray(entityOrArray) ? entityOrArray : [entityOrArray], deep, { skipIf: skipIf as any });
+    await crawl(todo, Array.isArray(entityOrArray) ? entityOrArray : [entityOrArray], deep, { skipIf });
 
     // 2. Clone each found entity
     const clones = todo.map((entity) => {
@@ -712,7 +712,7 @@ export class EntityManager<C = unknown> {
 
       // Call `new` just like the user would do
       // The `asConcreteCstr` is safe b/c we got meta from a concrete/already-instantiated entity
-      const clone = new (asConcreteCstr(meta.cstr))(this, copy) as Entity;
+      const clone = new (asConcreteCstr(meta.cstr))(this, copy);
 
       return [entity, clone] as const;
     });
@@ -784,7 +784,7 @@ export class EntityManager<C = unknown> {
       throw new NotFoundError(`${tagged} was not found`);
     }
     if (hint) {
-      await this.populate(entity as Entity, hint);
+      await this.populate(entity, hint);
     }
     return entity as T;
   }

--- a/packages/orm/src/EntityMetadata.ts
+++ b/packages/orm/src/EntityMetadata.ts
@@ -43,7 +43,7 @@ export interface EntityMetadata {
   config: ConfigApi<any, any>;
   orderBy: string | undefined;
   timestampFields: TimestampFields;
-  factory: (em: EntityManager<any>, opts?: any) => DeepNew<any>;
+  factory: (em: EntityManager<any, any>, opts?: any) => DeepNew<any>;
   /** The list of base types for this subtype, e.g. for Dog it'd be [Animal, Mammal]. */
   baseTypes: EntityMetadata[];
   /** The list of subtypes for this base type, e.g. for Animal it'd be `[Mammal, Dog]`. */

--- a/packages/orm/src/createOrUpdatePartial.ts
+++ b/packages/orm/src/createOrUpdatePartial.ts
@@ -41,7 +41,7 @@ type AllowRelationsToBeIdsOrEntitiesOrPartials<T> = {
  * A utility function to create-or-update entities coming from a partial-update style API.
  */
 export async function createOrUpdatePartial<T extends Entity>(
-  em: EntityManager<any>,
+  em: EntityManager<any, any>,
   constructor: MaybeAbstractEntityConstructor<T>,
   opts: DeepPartialOrNull<T>,
 ): Promise<T> {

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -4,7 +4,8 @@ import {
   EntityManager,
   MaybeAbstractEntityConstructor,
   OptsOf,
-  getEmInternalApi, TaggedId,
+  TaggedId,
+  getEmInternalApi,
 } from "./EntityManager";
 import { EntityMetadata, getAllMetas, getMetadata } from "./EntityMetadata";
 import { getFakeInstance, getProperties } from "./getProperties";

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -23,7 +23,7 @@ export { newPgConnectionConfig } from "joist-utils";
 export { AliasAssigner } from "./AliasAssigner";
 export * from "./Aliases";
 export { BaseEntity } from "./BaseEntity";
-export { Entity, EntityOrmField, isEntity } from "./Entity";
+export { Entity, EntityOrmField, isEntity, IdType } from "./Entity";
 export * from "./EntityFilter";
 export * from "./EntityGraphQLFilter";
 export * from "./EntityManager";

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -14,6 +14,8 @@ import {
 import {
   EntityFilter,
   ExpressionFilter,
+  FilterWithAlias,
+  MaybeAbstractEntityConstructor,
   NotFoundError,
   TooManyError,
   UniqueFilter,
@@ -23,7 +25,7 @@ import {
   jan1,
   jan2,
   jan3,
-  parseFindQuery,
+  parseFindQuery, Entity,
 } from "joist-orm";
 import {
   Author,

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -14,8 +14,6 @@ import {
 import {
   EntityFilter,
   ExpressionFilter,
-  FilterWithAlias,
-  MaybeAbstractEntityConstructor,
   NotFoundError,
   TooManyError,
   UniqueFilter,
@@ -25,7 +23,7 @@ import {
   jan1,
   jan2,
   jan3,
-  parseFindQuery, Entity,
+  parseFindQuery,
 } from "joist-orm";
 import {
   Author,

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -18,6 +18,7 @@ import {
   Book,
   Color,
   Comment,
+  EntityManager,
   Publisher,
   PublisherSize,
   PublisherType,
@@ -33,7 +34,7 @@ import {
   newEntityManager,
   numberOfQueries,
   queries,
-  resetQueryCount
+  resetQueryCount,
 } from "./setupDbTests";
 
 describe("EntityManager", () => {
@@ -1633,6 +1634,17 @@ describe("EntityManager", () => {
     em.create(Author, { publisher: "p:1", firstName: "Jim" });
     em.create(Author, { publisher: "p:1", firstName: "Jim" });
     await expect(em.flush()).rejects.toThrow("There is already a publisher with a Jim");
+  });
+
+  it("is typed correctly", async () => {
+    // Given our app-specific em
+    const em = newEntityManager();
+    // And a function that takes the app-specific em
+    function doSomething(_: EntityManager) {}
+    // When we have an entity and use its em field
+    const a = newAuthor(em);
+    // Then it works
+    doSomething(a.em);
   });
 });
 

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -12,12 +12,21 @@ import {
   select,
   update,
 } from "@src/entities/inserts";
-import { Loaded, sameEntity } from "joist-orm";
+import {
+  EntityConstructor,
+  FilterWithAlias,
+  Entity as JoistEntity,
+  Loaded,
+  MaybeAbstractEntityConstructor,
+  OptsOf,
+  sameEntity,
+} from "joist-orm";
 import {
   Author,
   Book,
   Color,
   Comment,
+  Entity,
   EntityManager,
   Publisher,
   PublisherSize,
@@ -1645,6 +1654,33 @@ describe("EntityManager", () => {
     const a = newAuthor(em);
     // Then it works
     doSomething(a.em);
+    // And also with our app-specific Entity
+    const a2: Entity = a;
+    doSomething(a2.em);
+  });
+
+  it("can accept non-narrowed constructors", async () => {
+    // Given our local EM that is typed to Entity narrowed to a string
+    const em = newEntityManager();
+    const id: string = em.entities[0].id;
+    async function foo() {
+      // And a type that uses the joist non-narrowed Entity that is string | number
+      const type = Author as MaybeAbstractEntityConstructor<JoistEntity>;
+      const type2 = Author as EntityConstructor<JoistEntity>;
+      const entity: JoistEntity = null!;
+      // Then we can use the non-narrowed Entity in various EM methods
+      await em.find(type, {} as FilterWithAlias<JoistEntity>);
+      await em.findCount(type, {} as FilterWithAlias<JoistEntity>);
+      await em.findOne(type, {} as FilterWithAlias<JoistEntity>);
+      await em.findOneOrFail(type, {} as FilterWithAlias<JoistEntity>);
+      await em.findByUnique(type, {} as FilterWithAlias<JoistEntity>);
+      await em.load(type, {} as OptsOf<JoistEntity>);
+      await em.loadAll(type, {} as FilterWithAlias<JoistEntity>);
+      await em.populate(entity, []);
+      await em.refresh(entity);
+      em.create(type2, {} as OptsOf<JoistEntity>);
+      em.touch(entity);
+    }
   });
 });
 

--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -1662,8 +1662,10 @@ describe("EntityManager", () => {
   it("can accept non-narrowed constructors", async () => {
     // Given our local EM that is typed to Entity narrowed to a string
     const em = newEntityManager();
-    const id: string = em.entities[0].id;
     async function foo() {
+      // And we verify the return values are typed as strings
+      const id1: string = em.entities[0].id;
+      const id2: string | undefined = em.getEntity("a:1")?.id;
       // And a type that uses the joist non-narrowed Entity that is string | number
       const type = Author as MaybeAbstractEntityConstructor<JoistEntity>;
       const type2 = Author as EntityConstructor<JoistEntity>;

--- a/packages/tests/integration/src/entities/metadata.ts
+++ b/packages/tests/integration/src/entities/metadata.ts
@@ -57,7 +57,7 @@ import {
   userConfig,
 } from "./entities";
 
-export class EntityManager extends EntityManager1<Context> {}
+export class EntityManager extends EntityManager1<Context, Entity> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/integration/src/entities/metadata.ts
+++ b/packages/tests/integration/src/entities/metadata.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, BigIntSerde, configureMetadata, CustomSerdeAdapter, DecimalToNumberSerde, EntityManager as EntityManager1, EntityMetadataTyped, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde, ZodSerde } from "joist-orm";
+import { BigIntSerde, configureMetadata, CustomSerdeAdapter, DecimalToNumberSerde, EntityManager as EntityManager1, EntityMetadataTyped, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde, ZodSerde } from "joist-orm";
 import { Context } from "src/context";
 import { address, AddressSchema, PasswordValueSerde, quotes } from "src/entities/types";
 import {
@@ -58,10 +58,6 @@ import {
 } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
-
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/integration/src/entities/metadata.ts
+++ b/packages/tests/integration/src/entities/metadata.ts
@@ -1,4 +1,4 @@
-import { BigIntSerde, configureMetadata, CustomSerdeAdapter, DecimalToNumberSerde, EntityManager as EntityManager1, EntityMetadataTyped, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde, ZodSerde } from "joist-orm";
+import { BigIntSerde, configureMetadata, CustomSerdeAdapter, DecimalToNumberSerde, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, EnumArrayFieldSerde, EnumFieldSerde, JsonSerde, KeySerde, PolymorphicKeySerde, PrimitiveSerde, SuperstructSerde, ZodSerde } from "joist-orm";
 import { Context } from "src/context";
 import { address, AddressSchema, PasswordValueSerde, quotes } from "src/entities/types";
 import {
@@ -58,6 +58,11 @@ import {
 } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
+
+export interface Entity extends Entity2 {
+  id: string;
+  em: EntityManager;
+}
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/integration/src/resolvers/mutations/utils.ts
+++ b/packages/tests/integration/src/resolvers/mutations/utils.ts
@@ -1,7 +1,7 @@
 import { Context } from "@src/context";
-import { BaseEntity, DeepPartialOrNull, EntityConstructor, IdOf } from "joist-orm";
+import { DeepPartialOrNull, Entity, EntityConstructor, IdOf } from "joist-orm";
 
-export async function saveEntities<T extends BaseEntity>(
+export async function saveEntities<T extends Entity>(
   ctx: Context,
   type: EntityConstructor<T>,
   input: DeepPartialOrNull<T>[],

--- a/packages/tests/integration/src/setupDbTests.ts
+++ b/packages/tests/integration/src/setupDbTests.ts
@@ -19,7 +19,7 @@ export let queries: string[] = [];
 const plugins = (process.env.PLUGINS ?? "join-preloading").split(",");
 export const isPreloadingEnabled = plugins.includes("join-preloading");
 
-export function newEntityManager() {
+export function newEntityManager(): EntityManager {
   const ctx = { knex };
   const opts: EntityManagerOpts = {
     driver,

--- a/packages/tests/number-ids/src/entities/metadata.ts
+++ b/packages/tests/number-ids/src/entities/metadata.ts
@@ -1,12 +1,8 @@
-import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
-
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/number-ids/src/entities/metadata.ts
+++ b/packages/tests/number-ids/src/entities/metadata.ts
@@ -1,8 +1,13 @@
-import { configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
+
+export interface Entity extends Entity2 {
+  id: number;
+  em: EntityManager;
+}
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/number-ids/src/entities/metadata.ts
+++ b/packages/tests/number-ids/src/entities/metadata.ts
@@ -2,7 +2,7 @@ import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, 
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
-export class EntityManager extends EntityManager1<Context> {}
+export class EntityManager extends EntityManager1<Context, Entity> {}
 
 export interface Entity extends Entity2 {
   id: number;

--- a/packages/tests/schema-misc/src/entities/metadata.ts
+++ b/packages/tests/schema-misc/src/entities/metadata.ts
@@ -2,7 +2,7 @@ import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, 
 import { Context } from "src/context";
 import { Artist, artistConfig, Author, authorConfig, Book, bookConfig, DatabaseOwner, databaseOwnerConfig, newArtist, newAuthor, newBook, newDatabaseOwner, newPainting, Painting, paintingConfig } from "./entities";
 
-export class EntityManager extends EntityManager1<Context> {}
+export class EntityManager extends EntityManager1<Context, Entity> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/schema-misc/src/entities/metadata.ts
+++ b/packages/tests/schema-misc/src/entities/metadata.ts
@@ -1,12 +1,8 @@
-import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Artist, artistConfig, Author, authorConfig, Book, bookConfig, DatabaseOwner, databaseOwnerConfig, newArtist, newAuthor, newBook, newDatabaseOwner, newPainting, Painting, paintingConfig } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
-
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
 
 export const artistMeta: EntityMetadataTyped<Artist> = {
   cstr: Artist,

--- a/packages/tests/schema-misc/src/entities/metadata.ts
+++ b/packages/tests/schema-misc/src/entities/metadata.ts
@@ -1,8 +1,13 @@
-import { configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Artist, artistConfig, Author, authorConfig, Book, bookConfig, DatabaseOwner, databaseOwnerConfig, newArtist, newAuthor, newBook, newDatabaseOwner, newPainting, Painting, paintingConfig } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
+
+export interface Entity extends Entity2 {
+  id: string;
+  em: EntityManager;
+}
 
 export const artistMeta: EntityMetadataTyped<Artist> = {
   cstr: Artist,

--- a/packages/tests/untagged-ids/src/entities/metadata.ts
+++ b/packages/tests/untagged-ids/src/entities/metadata.ts
@@ -1,12 +1,8 @@
-import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
-
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/untagged-ids/src/entities/metadata.ts
+++ b/packages/tests/untagged-ids/src/entities/metadata.ts
@@ -2,7 +2,7 @@ import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, 
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
-export class EntityManager extends EntityManager1<Context> {}
+export class EntityManager extends EntityManager1<Context, Entity> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/untagged-ids/src/entities/metadata.ts
+++ b/packages/tests/untagged-ids/src/entities/metadata.ts
@@ -1,8 +1,13 @@
-import { configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
+
+export interface Entity extends Entity2 {
+  id: string;
+  em: EntityManager;
+}
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/uuid-ids/src/entities/metadata.ts
+++ b/packages/tests/uuid-ids/src/entities/metadata.ts
@@ -1,12 +1,8 @@
-import { BaseEntity, configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
-
-export function getEm(e: BaseEntity): EntityManager {
-  return e.em as EntityManager;
-}
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,

--- a/packages/tests/uuid-ids/src/entities/metadata.ts
+++ b/packages/tests/uuid-ids/src/entities/metadata.ts
@@ -2,7 +2,7 @@ import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, 
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
-export class EntityManager extends EntityManager1<Context> {}
+export class EntityManager extends EntityManager1<Context, Entity> {}
 
 export interface Entity extends Entity2 {
   id: string;

--- a/packages/tests/uuid-ids/src/entities/metadata.ts
+++ b/packages/tests/uuid-ids/src/entities/metadata.ts
@@ -1,8 +1,13 @@
-import { configureMetadata, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
+import { configureMetadata, Entity as Entity2, EntityManager as EntityManager1, EntityMetadataTyped, KeySerde, PrimitiveSerde } from "joist-orm";
 import { Context } from "src/context";
 import { Author, authorConfig, Book, bookConfig, newAuthor, newBook } from "./entities";
 
 export class EntityManager extends EntityManager1<Context> {}
+
+export interface Entity extends Entity2 {
+  id: string;
+  em: EntityManager;
+}
 
 export const authorMeta: EntityMetadataTyped<Author> = {
   cstr: Author,


### PR DESCRIPTION
This extends our existing convention of an "application-specific `EntityManager`" (which is the EntityManager but bound/narrowed to your application's specific `Context` / `em.ctx` object), to an "application-specific `Entity`", that will have the `id` / `idMaybe` fields narrowed to "just string" or "just number" based on your `joist-config.json`'s `idType` setting.


This should give us the best of both worlds:

* Joist core is agnostic about `id: string | number` (and if anything these PRs have caught/enforced stragglers still treating `entity.id` as a tagged id), but
* Applications get their preferred `id: string` or `id: number`.

The cost is admittedly some increased complexity:

* The `EntityManager` itself is now typed on the application's narrowed `Entity`
* Applications generally need to use/prefer "their `Entity`" ... but we already have this notion for "their `EntityManager`".

...we could potentially explore killing the `EntityManager` and `Entity` exports from `joist-orm` and specifically naming them `GenericEntity` / `GenericEntityManager`, which would make auto-import in applications automatically choose the right now...

Now with the codegen having been ran, and types updated/fixed.