### PR TITLE
feat: Make codegen relations lazy.

### DIFF
--- a/.idea/joist-ts.iml
+++ b/.idea/joist-ts.iml
@@ -18,6 +18,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/plugins/join-preloading/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages/test-utils/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages/tests/integration/build" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/tests/integration/.clinic" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -555,10 +555,7 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
           return code`
             get ${r.fieldName}(): ${r.decl} {
               const { relations } = this.__orm;
-              if (relations.${r.fieldName} === undefined) {
-                relations.${r.fieldName} = ${r.init};
-              }
-              return relations.${r.fieldName} as any;
+              return relations.${r.fieldName} ??= ${r.init};
             }
           `;
         }

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -553,7 +553,8 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
         } else {
           return code`
             get ${r.fieldName}(): ${r.decl} {
-              return this.#${r.fieldName} ??= ${r.init};
+              if (this.#${r.fieldName} === undefined) this.#${r.fieldName} = ${r.init};
+              return this.#${r.fieldName};
             }
           `;
         }

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -557,7 +557,6 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
               const { relations } = this.__orm;
               if (relations.${r.fieldName} === undefined) {
                 relations.${r.fieldName} = ${r.init};
-                if (this.isNewEntity) relations.${r.fieldName}.initializeForNewEntity?.();
               }
               return relations.${r.fieldName} as any;
             }

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -493,7 +493,8 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
         if (r.kind === "abstract") {
           return r.line;
         } else {
-          return code`#${r.fieldName}: ${r.decl} | undefined = undefined;`;
+          return "";
+          // return code`#${r.fieldName}: ${r.decl} | undefined = undefined;`;
         }
       })}
 
@@ -553,8 +554,12 @@ export function generateEntityCodegenFile(config: Config, dbMeta: DbMetadata, me
         } else {
           return code`
             get ${r.fieldName}(): ${r.decl} {
-              if (this.#${r.fieldName} === undefined) this.#${r.fieldName} = ${r.init};
-              return this.#${r.fieldName};
+              const { relations } = this.__orm;
+              if (relations.${r.fieldName} === undefined) {
+                relations.${r.fieldName} = ${r.init};
+                if (this.isNewEntity) relations.${r.fieldName}.initializeForNewEntity?.();
+              }
+              return relations.${r.fieldName} as any;
             }
           `;
         }

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -53,6 +53,8 @@ export class EntityOrmField {
   isNew: boolean = true;
   /** Whether our entity should flush regardless of any other changes. */
   isTouched: boolean = false;
+  /** Whether we were created in this EM, even if we've since been flushed. */
+  wasNewInThisEm: boolean = false;
 
   constructor(em: EntityManager, metadata: EntityMetadata, defaultValues: Record<any, any>) {
     this.em = em;
@@ -64,9 +66,26 @@ export class EntityOrmField {
   resetAfterFlushed() {
     this.originalData = {};
     this.isTouched = false;
+    this.wasNewInThisEm ||= this.isNew;
     this.isNew = false;
     if (this.deleted === "pending") {
       this.deleted = "deleted";
     }
   }
+}
+
+/**
+ * Returns true if the entity is new or was new in this EM.
+ *
+ * This is primarily used for lazy-initializing relations, i.e. if:
+ *
+ * - A new `Author` is created
+ * - We `em.flush` the author to the database
+ * - Then `a1.books` is accessed for the first time
+ *
+ * We can have a high-confidence that `a1` has no books, because we just
+ * created it, so we can set the OneToManyCollection to loaded.
+ */
+export function isOrWasNew(entity: Entity): boolean {
+  return entity.isNewEntity || entity.__orm.wasNewInThisEm;
 }

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -54,7 +54,7 @@ export class EntityOrmField {
   /** Whether our entity should flush regardless of any other changes. */
   isTouched: boolean = false;
   /** Whether we were created in this EM, even if we've since been flushed. */
-  wasNewInThisEm: boolean = false;
+  wasNew: boolean = false;
 
   constructor(em: EntityManager, metadata: EntityMetadata, defaultValues: Record<any, any>) {
     this.em = em;
@@ -66,7 +66,7 @@ export class EntityOrmField {
   resetAfterFlushed() {
     this.originalData = {};
     this.isTouched = false;
-    this.wasNewInThisEm ||= this.isNew;
+    this.wasNew ||= this.isNew;
     this.isNew = false;
     if (this.deleted === "pending") {
       this.deleted = "deleted";
@@ -87,5 +87,5 @@ export class EntityOrmField {
  * created it, so we can set the OneToManyCollection to loaded.
  */
 export function isOrWasNew(entity: Entity): boolean {
-  return entity.isNewEntity || entity.__orm.wasNewInThisEm;
+  return entity.isNewEntity || entity.__orm.wasNew;
 }

--- a/packages/orm/src/Entity.ts
+++ b/packages/orm/src/Entity.ts
@@ -41,6 +41,8 @@ export class EntityOrmField {
   readonly em: EntityManager;
   /** A point to our entity type's metadata. */
   readonly metadata: EntityMetadata;
+  /** A bag for our lazy-initialized relations. */
+  relations: Record<any, any> = {};
   /** A bag for our primitives/fk column values. */
   data: Record<any, any>;
   /** A bag to keep the original values, lazily populated. */

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -725,7 +725,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
     // 3. Now mutate the m2o relations. We focus on only m2o's because they "own" the field/column,
     // and will drive percolation to keep the other-side o2m & o2o updated.
     clones.forEach(([, clone]) => {
-      Object.entries(clone).forEach(([fieldName, value]) => {
+      getRelationEntries(clone).forEach(([fieldName, value]) => {
         if (
           value instanceof ManyToOneReferenceImpl ||
           value instanceof PolymorphicReferenceImpl ||

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1403,7 +1403,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
       const todos = createTodos(entities);
       await beforeDelete(this.ctx, todos);
       // For all relations, unhook the entity from the other side
-      await Promise.all(entities.flatMap(getRelationEntries).map(([n, r]) => r.cleanupOnEntityDeleted()));
+      await Promise.all(entities.flatMap(getRelations).map((r) => r.cleanupOnEntityDeleted()));
       entities = this.#pendingCascadeDeletes;
       this.#pendingCascadeDeletes = [];
     }

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1403,7 +1403,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
       const todos = createTodos(entities);
       await beforeDelete(this.ctx, todos);
       // For all relations, unhook the entity from the other side
-      await Promise.all(entities.flatMap(getRelations).map((r) => r.cleanupOnEntityDeleted()));
+      await Promise.all(entities.flatMap(getRelationEntries).map(([n, r]) => r.cleanupOnEntityDeleted()));
       entities = this.#pendingCascadeDeletes;
       this.#pendingCascadeDeletes = [];
     }

--- a/packages/orm/src/getProperties.ts
+++ b/packages/orm/src/getProperties.ts
@@ -28,7 +28,13 @@ export function getProperties<T extends Entity>(meta: EntityMetadata): Record<st
   }
   const instance = getFakeInstance(meta);
   propertiesCache[meta.tagName] = Object.fromEntries(
-    [...Object.getOwnPropertyNames(meta.cstr.prototype), ...Object.keys(instance)]
+    [
+      ...Object.values(meta.allFields)
+        .filter((f) => f.kind !== "primaryKey" && f.kind !== "primitive" && f.kind !== "enum")
+        .map((f) => f.fieldName),
+      ...Object.getOwnPropertyNames(meta.cstr.prototype),
+      ...Object.keys(instance),
+    ]
       .filter((key) => key !== "constructor" && !key.startsWith("__"))
       .map((key) => {
         // Return the value of `instance[key]` but wrap it in a try/catch in case it's

--- a/packages/orm/src/getProperties.ts
+++ b/packages/orm/src/getProperties.ts
@@ -22,12 +22,13 @@ const em = EM;
  * Basically the values won't be `undefined`, to avoid throwing off `if getPropertyes(meta)[key]`
  * checks.
  */
-export function getProperties<T extends Entity>(meta: EntityMetadata): Record<string, any> {
-  if (propertiesCache[meta.tagName]) {
-    return propertiesCache[meta.tagName];
+export function getProperties(meta: EntityMetadata): Record<string, any> {
+  const key = meta.tableName;
+  if (propertiesCache[key]) {
+    return propertiesCache[key];
   }
   const instance = getFakeInstance(meta);
-  propertiesCache[meta.tagName] = Object.fromEntries(
+  propertiesCache[key] = Object.fromEntries(
     [
       ...Object.values(meta.allFields)
         .filter((f) => f.kind !== "primaryKey" && f.kind !== "primitive" && f.kind !== "enum")
@@ -48,7 +49,7 @@ export function getProperties<T extends Entity>(meta: EntityMetadata): Record<st
       // Purposefully return methods, primitives, etc. so that `entityResolver` can add them to the resolver
       .filter(([key]) => key !== "fullNonReactiveAccess" && key !== "transientFields"),
   );
-  return propertiesCache[meta.tagName];
+  return propertiesCache[key];
 }
 
 export class UnknownProperty {}

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -350,11 +350,23 @@ export function getEm(entity: Entity): EntityManager<any> {
 }
 
 export function getRelations(entity: Entity): AbstractRelationImpl<any>[] {
-  return Object.values(entity).filter((v: any) => v instanceof AbstractRelationImpl);
+  const fields = [
+    ...Object.values(entity),
+    ...Object.values(getMetadata(entity).allFields)
+      .filter((f) => f.fieldName !== "id")
+      .map((f) => (entity as any)[f.fieldName]),
+  ];
+  return fields.filter((v: any) => v instanceof AbstractRelationImpl);
 }
 
 export function getRelationEntries(entity: Entity): [string, AbstractRelationImpl<any>][] {
-  return Object.entries(entity).filter(([_, v]: any) => v instanceof AbstractRelationImpl);
+  const fields = [
+    ...Object.entries(entity),
+    ...Object.values(getMetadata(entity).allFields)
+      .filter((f) => f.fieldName !== "id")
+      .map((f) => [f.fieldName, (entity as any)[f.fieldName]] as const),
+  ];
+  return fields.filter(([_, v]) => v instanceof AbstractRelationImpl) as any;
 }
 
 export function getConstructorFromTaggedId(id: TaggedId): MaybeAbstractEntityConstructor<any> {

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -221,12 +221,6 @@ export function setOpts<T extends Entity>(
       (entity as any)[key] = value;
     }
   });
-  if (calledFromConstructor && !(entity.em as any).fakeInstance) {
-    // Because we're called from the AuthorCodegen constructor, the custom
-    // relation fields won't have been enabled yet ... thankfully none of them
-    // need the `initializeForNewEntity` call at the moment.
-    getRelations(entity).forEach((v) => v?.initializeForNewEntity());
-  }
 }
 
 export function ensureNotDeleted(entity: Entity, ignore?: EntityOrmField["deleted"]): void {

--- a/packages/orm/src/relations/AbstractRelationImpl.ts
+++ b/packages/orm/src/relations/AbstractRelationImpl.ts
@@ -5,9 +5,6 @@ export abstract class AbstractRelationImpl<U> {
   /** Called with the opts from a `new` or `em.create` call, i.e. on a new entity. */
   abstract setFromOpts(value: U): void;
 
-  /** Called on each relation of a new entity, since we know it defacto can be marked as loaded. */
-  abstract initializeForNewEntity(): void;
-
   /** Similar to setFromOpts, but called post-construction. */
   abstract set(value: U): void;
 

--- a/packages/orm/src/relations/CustomCollection.ts
+++ b/packages/orm/src/relations/CustomCollection.ts
@@ -81,14 +81,6 @@ export class CustomCollection<T extends Entity, U extends Entity>
     throw new Error("Not implemented");
   }
 
-  initializeForNewEntity(): void {
-    // Normally we flag relations as loaded if created on a new entity, however CustomCollections
-    // might require crawling N-layers down from our initial opts, i.e. if creating a BookReview
-    // with a book, accessing review.author maybe not necessarily be safe to do immediately b/c
-    // we need to load book.author to successfully evaluated review -> book -> author synchronously.
-    // this._isLoaded = true;
-  }
-
   set(values: U[]): void {
     this.ensureNewOrLoaded();
     const { set, add, remove } = this.opts;

--- a/packages/orm/src/relations/CustomReference.ts
+++ b/packages/orm/src/relations/CustomReference.ts
@@ -79,14 +79,6 @@ export class CustomReference<T extends Entity, U extends Entity, N extends never
     throw new Error("Not implemented");
   }
 
-  initializeForNewEntity(): void {
-    // Normally we flag relations as loaded if created on a new entity, however CustomReferences
-    // might require crawling N-layers down from our initial opts, i.e. if creating a BookReview
-    // with a book, accessing review.author maybe not necessarily be safe to do immediately b/c
-    // we need to load book.author to successfully evaluated review -> book -> author synchronously.
-    // this._isLoaded = true;
-  }
-
   get id(): IdOf<U> {
     return fail(`CustomReference cannot resolve 'id'`);
   }

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -63,6 +63,9 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     super();
     this.#entity = entity;
     this.#fieldName = fieldName;
+    if (entity.isNewEntity) {
+      this.loaded = [];
+    }
   }
 
   /** Removes pending-hard-delete or soft-deleted entities, unless explicitly asked for. */
@@ -210,13 +213,6 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   setFromOpts(others: U[]): void {
     this.loaded = [];
     others.forEach((o) => this.add(o));
-  }
-
-  initializeForNewEntity(): void {
-    // Don't overwrite any opts values
-    if (this.loaded === undefined) {
-      this.loaded = [];
-    }
   }
 
   maybeCascadeDelete() {

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -21,7 +21,7 @@ export function hasManyToMany<T extends Entity, U extends Entity>(
   joinTableName: string,
   fieldName: keyof T & string,
   columnName: string,
-  otherMeta: EntityMetadata,
+  otherMeta: EntityMetadata<U>,
   otherFieldName: keyof U & string,
   otherColumnName: string,
 ): Collection<T, U> {

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -11,6 +11,7 @@ import {
 } from "../";
 import { manyToManyDataLoader } from "../dataloaders/manyToManyDataLoader";
 import { manyToManyFindDataLoader } from "../dataloaders/manyToManyFindDataLoader";
+import { isOrWasNew } from "../Entity";
 import { maybeAdd, maybeRemove, remove } from "../utils";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { RelationT, RelationU } from "./Relation";
@@ -63,7 +64,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     super();
     this.#entity = entity;
     this.#fieldName = fieldName;
-    if (entity.isNewEntity) {
+    if (isOrWasNew(entity)) {
       this.loaded = [];
     }
   }

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -1,6 +1,5 @@
 import {
   Collection,
-  currentlyInstantiatingEntity,
   ensureNotDeleted,
   Entity,
   EntityMetadata,
@@ -18,6 +17,7 @@ import { RelationT, RelationU } from "./Relation";
 
 /** An alias for creating `ManyToManyCollections`s. */
 export function hasManyToMany<T extends Entity, U extends Entity>(
+  entity: T,
   joinTableName: string,
   fieldName: keyof T & string,
   columnName: string,
@@ -25,7 +25,6 @@ export function hasManyToMany<T extends Entity, U extends Entity>(
   otherFieldName: keyof U & string,
   otherColumnName: string,
 ): Collection<T, U> {
-  const entity = currentlyInstantiatingEntity as T;
   return new ManyToManyCollection<T, U>(
     joinTableName,
     entity,

--- a/packages/orm/src/relations/ManyToManyLargeCollection.ts
+++ b/packages/orm/src/relations/ManyToManyLargeCollection.ts
@@ -1,6 +1,6 @@
 import { manyToManyFindDataLoader } from "../dataloaders/manyToManyFindDataLoader";
 import { Entity } from "../Entity";
-import { currentlyInstantiatingEntity, IdOf } from "../EntityManager";
+import { IdOf } from "../EntityManager";
 import { EntityMetadata } from "../EntityMetadata";
 import { ensureNotDeleted, getMetadata, ManyToManyCollection, toTaggedId } from "../index";
 import { remove } from "../utils";
@@ -9,6 +9,7 @@ import { RelationT, RelationU } from "./Relation";
 
 /** An alias for creating `ManyToManyLargeCollection`s. */
 export function hasLargeManyToMany<T extends Entity, U extends Entity>(
+  entity: T,
   joinTableName: string,
   fieldName: keyof T & string,
   columnName: string,
@@ -16,7 +17,6 @@ export function hasLargeManyToMany<T extends Entity, U extends Entity>(
   otherFieldName: keyof U & string,
   otherColumnName: string,
 ): LargeCollection<T, U> {
-  const entity = currentlyInstantiatingEntity as T;
   return new ManyToManyLargeCollection(
     joinTableName,
     entity,

--- a/packages/orm/src/relations/ManyToManyLargeCollection.ts
+++ b/packages/orm/src/relations/ManyToManyLargeCollection.ts
@@ -13,7 +13,7 @@ export function hasLargeManyToMany<T extends Entity, U extends Entity>(
   joinTableName: string,
   fieldName: keyof T & string,
   columnName: string,
-  otherMeta: EntityMetadata,
+  otherMeta: EntityMetadata<U>,
   otherFieldName: keyof U & string,
   otherColumnName: string,
 ): LargeCollection<T, U> {

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -1,4 +1,4 @@
-import { Entity, isEntity } from "../Entity";
+import { Entity, isEntity, isOrWasNew } from "../Entity";
 import { IdOf, TaggedId, getEmInternalApi, sameEntity } from "../EntityManager";
 import { EntityMetadata, ManyToOneField, getMetadata } from "../EntityMetadata";
 import {
@@ -88,7 +88,8 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     this.#fieldName = fieldName;
     // We can be initialized with [entity | id | undefined], and if it's entity or id, then setImpl
     // will set loaded appropriately; but if we're initialized undefined, then mark loaded here
-    if (entity.isNewEntity && this.current() === undefined) {
+    // if ((entity.isNewEntity || entity.__orm.wasNewInThisEm) && this.current() === undefined) {
+    if (isOrWasNew(entity) && this.current() === undefined) {
       this._isLoaded = true;
     }
   }

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -24,7 +24,7 @@ import { RelationT,RelationU } from "./Relation";
 /** An alias for creating `ManyToOneReference`s. */
 export function hasOne<T extends Entity, U extends Entity, N extends never | undefined>(
   entity: T,
-  otherMeta: EntityMetadata,
+  otherMeta: EntityMetadata<U>,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
 ): ManyToOneReference<T, U, N> {

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -1,25 +1,25 @@
-import { Entity,isEntity } from "../Entity";
-import { IdOf,TaggedId,getEmInternalApi,sameEntity } from "../EntityManager";
-import { EntityMetadata,ManyToOneField,getMetadata } from "../EntityMetadata";
+import { Entity, isEntity } from "../Entity";
+import { IdOf, TaggedId, getEmInternalApi, sameEntity } from "../EntityManager";
+import { EntityMetadata, ManyToOneField, getMetadata } from "../EntityMetadata";
 import {
-BaseEntity,
-OneToManyLargeCollection,
-OneToOneReferenceImpl,
-Reference,
-deTagId,
-ensureNotDeleted,
-ensureTagged,
-fail,
-maybeResolveReferenceToId,
-setField,
-toIdOf,
-toTaggedId,
+  BaseEntity,
+  OneToManyLargeCollection,
+  OneToOneReferenceImpl,
+  Reference,
+  deTagId,
+  ensureNotDeleted,
+  ensureTagged,
+  fail,
+  maybeResolveReferenceToId,
+  setField,
+  toIdOf,
+  toTaggedId,
 } from "../index";
-import { maybeAdd,maybeRemove } from "../utils";
+import { maybeAdd, maybeRemove } from "../utils";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { OneToManyCollection } from "./OneToManyCollection";
 import { ReferenceN } from "./Reference";
-import { RelationT,RelationU } from "./Relation";
+import { RelationT, RelationU } from "./Relation";
 
 /** An alias for creating `ManyToOneReference`s. */
 export function hasOne<T extends Entity, U extends Entity, N extends never | undefined>(
@@ -86,6 +86,11 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     super();
     this.#entity = entity;
     this.#fieldName = fieldName;
+    // We can be initialized with [entity | id | undefined], and if it's entity or id, then setImpl
+    // will set loaded appropriately; but if we're initialized undefined, then mark loaded here
+    if (entity.isNewEntity && this.current() === undefined) {
+      this._isLoaded = true;
+    }
   }
 
   async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<U | N> {
@@ -231,14 +236,6 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
 
   setFromOpts(other: U | IdOf<U> | N): void {
     this.setImpl(other);
-  }
-
-  initializeForNewEntity(): void {
-    // We can be initialized with [entity | id | undefined], and if it's entity or id, then setImpl
-    // will set loaded appropriately; but if we're initialized undefined, then mark loaded here
-    if (this.current() === undefined) {
-      this._isLoaded = true;
-    }
   }
 
   maybeCascadeDelete(): void {

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -86,10 +86,7 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
     super();
     this.#entity = entity;
     this.#fieldName = fieldName;
-    // We can be initialized with [entity | id | undefined], and if it's entity or id, then setImpl
-    // will set loaded appropriately; but if we're initialized undefined, then mark loaded here
-    // if ((entity.isNewEntity || entity.__orm.wasNewInThisEm) && this.current() === undefined) {
-    if (isOrWasNew(entity) && this.current() === undefined) {
+    if (isOrWasNew(entity)) {
       this._isLoaded = true;
     }
   }

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -1,33 +1,33 @@
-import { Entity, isEntity } from "../Entity";
-import { IdOf, TaggedId, currentlyInstantiatingEntity, getEmInternalApi, sameEntity } from "../EntityManager";
-import { EntityMetadata, ManyToOneField, getMetadata } from "../EntityMetadata";
+import { Entity,isEntity } from "../Entity";
+import { IdOf,TaggedId,getEmInternalApi,sameEntity } from "../EntityManager";
+import { EntityMetadata,ManyToOneField,getMetadata } from "../EntityMetadata";
 import {
-  BaseEntity,
-  OneToManyLargeCollection,
-  OneToOneReferenceImpl,
-  Reference,
-  deTagId,
-  ensureNotDeleted,
-  ensureTagged,
-  fail,
-  maybeResolveReferenceToId,
-  setField,
-  toIdOf,
-  toTaggedId,
+BaseEntity,
+OneToManyLargeCollection,
+OneToOneReferenceImpl,
+Reference,
+deTagId,
+ensureNotDeleted,
+ensureTagged,
+fail,
+maybeResolveReferenceToId,
+setField,
+toIdOf,
+toTaggedId,
 } from "../index";
-import { maybeAdd, maybeRemove } from "../utils";
+import { maybeAdd,maybeRemove } from "../utils";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { OneToManyCollection } from "./OneToManyCollection";
 import { ReferenceN } from "./Reference";
-import { RelationT, RelationU } from "./Relation";
+import { RelationT,RelationU } from "./Relation";
 
 /** An alias for creating `ManyToOneReference`s. */
 export function hasOne<T extends Entity, U extends Entity, N extends never | undefined>(
+  entity: T,
   otherMeta: EntityMetadata,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
 ): ManyToOneReference<T, U, N> {
-  const entity = currentlyInstantiatingEntity as T;
   return new ManyToOneReferenceImpl<T, U, N>(entity, otherMeta, fieldName, otherFieldName);
 }
 

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -2,7 +2,6 @@ import { oneToManyDataLoader } from "../dataloaders/oneToManyDataLoader";
 import { oneToManyFindDataLoader } from "../dataloaders/oneToManyFindDataLoader";
 import {
   Collection,
-  currentlyInstantiatingEntity,
   ensureNotDeleted,
   Entity,
   EntityMetadata,
@@ -21,13 +20,13 @@ import { RelationT, RelationU } from "./Relation";
 
 /** An alias for creating `OneToManyCollection`s. */
 export function hasMany<T extends Entity, U extends Entity>(
+  entity: T,
   otherMeta: EntityMetadata,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,
   orderBy: { field: keyof U; direction: OrderBy } | undefined,
 ): Collection<T, U> {
-  const entity = currentlyInstantiatingEntity as T;
   return new OneToManyCollection(entity, otherMeta, fieldName, otherFieldName, otherColumnName, orderBy);
 }
 

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -21,7 +21,7 @@ import { RelationT, RelationU } from "./Relation";
 /** An alias for creating `OneToManyCollection`s. */
 export function hasMany<T extends Entity, U extends Entity>(
   entity: T,
-  otherMeta: EntityMetadata,
+  otherMeta: EntityMetadata<U>,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -1,16 +1,17 @@
+import { isOrWasNew } from "../Entity";
 import { oneToManyDataLoader } from "../dataloaders/oneToManyDataLoader";
 import { oneToManyFindDataLoader } from "../dataloaders/oneToManyFindDataLoader";
 import {
   Collection,
-  ensureNotDeleted,
   Entity,
   EntityMetadata,
-  getEmInternalApi,
-  getMetadata,
   IdOf,
-  maybeResolveReferenceToId,
   OneToManyField,
   OrderBy,
+  ensureNotDeleted,
+  getEmInternalApi,
+  getMetadata,
+  maybeResolveReferenceToId,
   sameEntity,
 } from "../index";
 import { clear, compareValues, maybeAdd, maybeRemove, remove } from "../utils";
@@ -59,8 +60,7 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     this.#entity = entity;
     this.#fieldName = fieldName;
     this.#orderBy = orderBy;
-    // Don't overwrite any opts values
-    if (entity.isNewEntity && this.loaded === undefined) {
+    if (isOrWasNew(entity)) {
       this.loaded = [];
     }
   }

--- a/packages/orm/src/relations/OneToManyCollection.ts
+++ b/packages/orm/src/relations/OneToManyCollection.ts
@@ -59,6 +59,10 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
     this.#entity = entity;
     this.#fieldName = fieldName;
     this.#orderBy = orderBy;
+    // Don't overwrite any opts values
+    if (entity.isNewEntity && this.loaded === undefined) {
+      this.loaded = [];
+    }
   }
 
   // opts is an internal parameter
@@ -197,13 +201,6 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   setFromOpts(others: U[]): void {
     this.loaded = [];
     others.forEach((o) => this.add(o));
-  }
-
-  initializeForNewEntity(): void {
-    // Don't overwrite any opts values
-    if (this.loaded === undefined) {
-      this.loaded = [];
-    }
   }
 
   removeIfLoaded(other: U) {

--- a/packages/orm/src/relations/OneToManyLargeCollection.ts
+++ b/packages/orm/src/relations/OneToManyLargeCollection.ts
@@ -10,7 +10,7 @@ import { RelationT, RelationU } from "./Relation";
 /** An alias for creating `OneToManyLargeCollection`s. */
 export function hasLargeMany<T extends Entity, U extends Entity>(
   entity: T,
-  otherMeta: EntityMetadata,
+  otherMeta: EntityMetadata<U>,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,

--- a/packages/orm/src/relations/OneToManyLargeCollection.ts
+++ b/packages/orm/src/relations/OneToManyLargeCollection.ts
@@ -1,6 +1,6 @@
 import { oneToManyFindDataLoader } from "../dataloaders/oneToManyFindDataLoader";
 import { Entity } from "../Entity";
-import { currentlyInstantiatingEntity, IdOf, sameEntity } from "../EntityManager";
+import { IdOf, sameEntity } from "../EntityManager";
 import { EntityMetadata } from "../EntityMetadata";
 import { ensureNotDeleted, getMetadata, ManyToOneReferenceImpl } from "../index";
 import { remove } from "../utils";
@@ -9,12 +9,12 @@ import { RelationT, RelationU } from "./Relation";
 
 /** An alias for creating `OneToManyLargeCollection`s. */
 export function hasLargeMany<T extends Entity, U extends Entity>(
+  entity: T,
   otherMeta: EntityMetadata,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,
 ): LargeCollection<T, U> {
-  const entity = currentlyInstantiatingEntity as T;
   return new OneToManyLargeCollection(entity, otherMeta, fieldName, otherFieldName, otherColumnName);
 }
 

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -1,6 +1,6 @@
 import { deTagId, ensureNotDeleted, getEmInternalApi, IdOf, LoadedReference, setField, TaggedId } from "../";
 import { oneToOneDataLoader } from "../dataloaders/oneToOneDataLoader";
-import { Entity } from "../Entity";
+import { Entity, isOrWasNew } from "../Entity";
 import { EntityMetadata, getMetadata } from "../EntityMetadata";
 import { AbstractRelationImpl } from "./AbstractRelationImpl";
 import { failIfNewEntity, failNoId, ManyToOneReference } from "./ManyToOneReference";
@@ -99,7 +99,7 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
     this.#entity = entity;
     this.#otherMeta = otherMeta;
     this.isCascadeDelete = getMetadata(entity).config.__data.cascadeDeleteFields.includes(fieldName as any);
-    if (entity.isNewEntity) {
+    if (isOrWasNew(entity)) {
       this._isLoaded = true;
     }
   }

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -99,6 +99,9 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
     this.#entity = entity;
     this.#otherMeta = otherMeta;
     this.isCascadeDelete = getMetadata(entity).config.__data.cascadeDeleteFields.includes(fieldName as any);
+    if (entity.isNewEntity) {
+      this._isLoaded = true;
+    }
   }
 
   get id(): IdOf<U> {
@@ -224,10 +227,6 @@ export class OneToOneReferenceImpl<T extends Entity, U extends Entity>
 
   setFromOpts(other: U): void {
     this.set(other);
-  }
-
-  initializeForNewEntity(): void {
-    this._isLoaded = true;
   }
 
   maybeCascadeDelete(): void {

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -1,13 +1,4 @@
-import {
-  currentlyInstantiatingEntity,
-  deTagId,
-  ensureNotDeleted,
-  getEmInternalApi,
-  IdOf,
-  LoadedReference,
-  setField,
-  TaggedId,
-} from "../";
+import { deTagId, ensureNotDeleted, getEmInternalApi, IdOf, LoadedReference, setField, TaggedId } from "../";
 import { oneToOneDataLoader } from "../dataloaders/oneToOneDataLoader";
 import { Entity } from "../Entity";
 import { EntityMetadata, getMetadata } from "../EntityMetadata";
@@ -60,12 +51,12 @@ export function isLoadedOneToOneReference(
 
 /** An alias for creating `OneToOneReference`s. */
 export function hasOneToOne<T extends Entity, U extends Entity>(
+  entity: T,
   otherMeta: EntityMetadata,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,
 ): OneToOneReference<T, U> {
-  const entity = currentlyInstantiatingEntity as T;
   return new OneToOneReferenceImpl<T, U>(entity, otherMeta, fieldName, otherFieldName, otherColumnName);
 }
 

--- a/packages/orm/src/relations/OneToOneReference.ts
+++ b/packages/orm/src/relations/OneToOneReference.ts
@@ -52,7 +52,7 @@ export function isLoadedOneToOneReference(
 /** An alias for creating `OneToOneReference`s. */
 export function hasOneToOne<T extends Entity, U extends Entity>(
   entity: T,
-  otherMeta: EntityMetadata,
+  otherMeta: EntityMetadata<U>,
   fieldName: keyof T & string,
   otherFieldName: keyof U & string,
   otherColumnName: string,

--- a/packages/orm/src/relations/PersistedAsyncReference.ts
+++ b/packages/orm/src/relations/PersistedAsyncReference.ts
@@ -95,6 +95,11 @@ export class PersistedAsyncReferenceImpl<
     this.#fieldName = fieldName;
     this.#otherMeta = otherMeta;
     this.#reactiveHint = reactiveHint;
+    // We can be initialized with [entity | id | undefined], and if it's entity or id, then setImpl
+    // will set loaded appropriately; but if we're initialized undefined, then mark loaded here
+    if (entity.isNewEntity) {
+      this._isLoaded = isEntity(this.current()) ? "ref" : false;
+    }
   }
 
   async load(opts?: { withDeleted?: true; forceReload?: true }): Promise<U | N> {
@@ -248,12 +253,6 @@ export class PersistedAsyncReferenceImpl<
 
   setFromOpts(other: U | IdOf<U> | N): void {
     this.setImpl(other);
-  }
-
-  initializeForNewEntity(): void {
-    // We can be initialized with [entity | id | undefined], and if it's entity or id, then setImpl
-    // will set loaded appropriately; but if we're initialized undefined, then mark loaded here
-    this._isLoaded = isEntity(this.current()) ? "ref" : false;
   }
 
   maybeCascadeDelete(): void {

--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -1,5 +1,5 @@
 import { Entity, isEntity } from "../Entity";
-import { IdOf, TaggedId, currentlyInstantiatingEntity, sameEntity } from "../EntityManager";
+import { IdOf, TaggedId, sameEntity } from "../EntityManager";
 import { PolymorphicFieldComponent, getMetadata } from "../EntityMetadata";
 import {
   OneToOneReference,
@@ -19,9 +19,9 @@ import { ReferenceN } from "./Reference";
 import { RelationT, RelationU } from "./Relation";
 
 export function hasOnePolymorphic<T extends Entity, U extends Entity, N extends never | undefined>(
+  entity: T,
   fieldName: keyof T & string,
 ): PolymorphicReference<T, U, N> {
-  const entity = currentlyInstantiatingEntity as T;
   return new PolymorphicReferenceImpl<T, U, N>(entity, fieldName);
 }
 

--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -1,4 +1,4 @@
-import { Entity, isEntity } from "../Entity";
+import { Entity, isEntity, isOrWasNew } from "../Entity";
 import { IdOf, TaggedId, sameEntity } from "../EntityManager";
 import { PolymorphicFieldComponent, getMetadata } from "../EntityMetadata";
 import {
@@ -73,9 +73,7 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
   ) {
     super();
     this.field = getMetadata(entity).fields[this.fieldName] as PolymorphicField;
-    // Usually our codegened opts ensures that polys are only initialized with entities,
-    // but em.clone currently passes in strings
-    if (entity.isNewEntity && this.current() === undefined) {
+    if (isOrWasNew(entity)) {
       this._isLoaded = true;
     }
   }

--- a/packages/orm/src/relations/PolymorphicReference.ts
+++ b/packages/orm/src/relations/PolymorphicReference.ts
@@ -73,6 +73,11 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
   ) {
     super();
     this.field = getMetadata(entity).fields[this.fieldName] as PolymorphicField;
+    // Usually our codegened opts ensures that polys are only initialized with entities,
+    // but em.clone currently passes in strings
+    if (entity.isNewEntity && this.current() === undefined) {
+      this._isLoaded = true;
+    }
   }
 
   private get currentComponent(): PolymorphicFieldComponent | N {
@@ -168,14 +173,6 @@ export class PolymorphicReferenceImpl<T extends Entity, U extends Entity, N exte
 
   setFromOpts(other: U): void {
     this.setImpl(other);
-  }
-
-  initializeForNewEntity(): void {
-    // Usually our codegened opts ensures that polys are only initialized with entities,
-    // but em.clone currently passes in strings
-    if (this.current() === undefined) {
-      this._isLoaded = true;
-    }
   }
 
   maybeCascadeDelete(): void {

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -63,13 +63,6 @@ describe("Entity", () => {
             "isReactive": true,
           },
         },
-        "authors": {
-          "fieldName": "authors",
-          "loaded": undefined,
-          "otherColumnName": "mentor_id",
-          "otherFieldName": "mentor",
-          "undefined": null,
-        },
         "bookComments": {
           "fieldName": "bookComments",
           "fn": {},
@@ -81,13 +74,6 @@ describe("Entity", () => {
             },
           },
         },
-        "books": {
-          "fieldName": "books",
-          "loaded": undefined,
-          "otherColumnName": "author_id",
-          "otherFieldName": "author",
-          "undefined": null,
-        },
         "booksTitles": {
           "fn": {},
           "loadPromise": undefined,
@@ -97,20 +83,6 @@ describe("Entity", () => {
           "fn": {},
           "loadPromise": undefined,
           "loaded": false,
-        },
-        "comments": {
-          "fieldName": "comments",
-          "loaded": undefined,
-          "otherColumnName": "parent_author_id",
-          "otherFieldName": "parent",
-          "undefined": null,
-        },
-        "currentDraftBook": {
-          "_isLoaded": false,
-          "fieldName": "currentDraftBook",
-          "loaded": undefined,
-          "otherFieldName": "currentDraftAuthor",
-          "undefined": null,
         },
         "favoriteBook": {
           "_isLoaded": false,
@@ -123,15 +95,6 @@ describe("Entity", () => {
               "reviews_ro": "rating",
             },
           },
-          "undefined": null,
-        },
-        "image": {
-          "_isLoaded": false,
-          "fieldName": "image",
-          "isCascadeDelete": true,
-          "loaded": undefined,
-          "otherColumnName": "author_id",
-          "otherFieldName": "author",
           "undefined": null,
         },
         "latestComment": {
@@ -157,13 +120,6 @@ describe("Entity", () => {
           "loadPromise": undefined,
           "loaded": false,
           "opts": {},
-        },
-        "mentor": {
-          "_isLoaded": false,
-          "fieldName": "mentor",
-          "loaded": undefined,
-          "otherFieldName": "authors",
-          "undefined": null,
         },
         "numberOfBooks": {
           "fieldName": "numberOfBooks",
@@ -213,13 +169,6 @@ describe("Entity", () => {
             },
           },
         },
-        "publisher": {
-          "_isLoaded": false,
-          "fieldName": "publisher",
-          "loaded": undefined,
-          "otherFieldName": "authors",
-          "undefined": null,
-        },
         "reviewedBooks": {
           "_isLoaded": false,
           "loadPromise": undefined,
@@ -240,23 +189,6 @@ describe("Entity", () => {
             "isLoaded": {},
             "load": {},
           },
-        },
-        "schedules": {
-          "fieldName": "schedules",
-          "loaded": undefined,
-          "otherColumnName": "author_id",
-          "otherFieldName": "author",
-          "undefined": null,
-        },
-        "tags": {
-          "addedBeforeLoaded": undefined,
-          "columnName": "author_id",
-          "fieldName": "tags",
-          "joinTableName": "authors_to_tags",
-          "loaded": undefined,
-          "otherColumnName": "tag_id",
-          "otherFieldName": "authors",
-          "removedBeforeLoaded": undefined,
         },
         "tagsOfAllBooks": {
           "fieldName": "tagsOfAllBooks",
@@ -287,15 +219,6 @@ describe("Entity", () => {
           "mentorRuleInvoked": 0,
           "numberOfBooksCalcInvoked": 0,
           "setGraduatedInFlush": false,
-        },
-        "userOneToOne": {
-          "_isLoaded": false,
-          "fieldName": "userOneToOne",
-          "isCascadeDelete": false,
-          "loaded": undefined,
-          "otherColumnName": "author_id",
-          "otherFieldName": "authorManyToOne",
-          "undefined": null,
         },
       }
     `);

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -62,8 +62,8 @@ describe("Author", () => {
   it("can have reactive validation rules", async () => {
     const em = newEntityManager();
     // Given the book and author start out with acceptable names
-    const a1 = new Author(em, { firstName: "a1" });
-    const b1 = new Book(em, { title: "b1", author: a1 });
+    const a1 = em.create(Author, { firstName: "a1" });
+    const b1 = em.create(Book, { title: "b1", author: a1 });
     await em.flush();
     // When the book name is later changed to collide with the author
     b1.title = "a1";

--- a/packages/tests/integration/src/entities/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorCodegen.ts
@@ -280,59 +280,17 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-
-  readonly authors: Collection<Author, Author> = hasMany(authorMeta, "authors", "mentor", "mentor_id", undefined);
-
-  readonly schedules: Collection<Author, AuthorSchedule> = hasMany(
-    authorScheduleMeta,
-    "schedules",
-    "author",
-    "author_id",
-    undefined,
-  );
-
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id", {
-    "field": "order",
-    "direction": "ASC",
-  });
-
-  readonly comments: Collection<Author, Comment> = hasMany(
-    commentMeta,
-    "comments",
-    "parent",
-    "parent_author_id",
-    undefined,
-  );
-
-  readonly mentor: ManyToOneReference<Author, Author, undefined> = hasOne(authorMeta, "mentor", "authors");
-
-  readonly currentDraftBook: ManyToOneReference<Author, Book, undefined> = hasOne(
-    bookMeta,
-    "currentDraftBook",
-    "currentDraftAuthor",
-  );
-
+  #authors: Collection<Author, Author> | undefined = undefined;
+  #schedules: Collection<Author, AuthorSchedule> | undefined = undefined;
+  #books: Collection<Author, Book> | undefined = undefined;
+  #comments: Collection<Author, Comment> | undefined = undefined;
+  #mentor: ManyToOneReference<Author, Author, undefined> | undefined = undefined;
+  #currentDraftBook: ManyToOneReference<Author, Book, undefined> | undefined = undefined;
   abstract readonly favoriteBook: PersistedAsyncReference<Author, Book, undefined>;
-
-  readonly publisher: ManyToOneReference<Author, Publisher, undefined> = hasOne(publisherMeta, "publisher", "authors");
-
-  readonly image: OneToOneReference<Author, Image> = hasOneToOne(imageMeta, "image", "author", "author_id");
-
-  readonly userOneToOne: OneToOneReference<Author, User> = hasOneToOne(
-    userMeta,
-    "userOneToOne",
-    "authorManyToOne",
-    "author_id",
-  );
-
-  readonly tags: Collection<Author, Tag> = hasManyToMany(
-    "authors_to_tags",
-    "tags",
-    "author_id",
-    tagMeta,
-    "authors",
-    "tag_id",
-  );
+  #publisher: ManyToOneReference<Author, Publisher, undefined> | undefined = undefined;
+  #image: OneToOneReference<Author, Image> | undefined = undefined;
+  #userOneToOne: OneToOneReference<Author, User> | undefined = undefined;
+  #tags: Collection<Author, Tag> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -569,5 +527,76 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {
     return isLoaded(this as any as Author, hint);
+  }
+
+  get authors(): Collection<Author, Author> {
+    return this.#authors ??= hasMany(this as any as Author, authorMeta, "authors", "mentor", "mentor_id", undefined);
+  }
+
+  get schedules(): Collection<Author, AuthorSchedule> {
+    return this.#schedules ??= hasMany(
+      this as any as Author,
+      authorScheduleMeta,
+      "schedules",
+      "author",
+      "author_id",
+      undefined,
+    );
+  }
+
+  get books(): Collection<Author, Book> {
+    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", {
+      "field": "order",
+      "direction": "ASC",
+    });
+  }
+
+  get comments(): Collection<Author, Comment> {
+    return this.#comments ??= hasMany(
+      this as any as Author,
+      commentMeta,
+      "comments",
+      "parent",
+      "parent_author_id",
+      undefined,
+    );
+  }
+
+  get mentor(): ManyToOneReference<Author, Author, undefined> {
+    return this.#mentor ??= hasOne(this as any as Author, authorMeta, "mentor", "authors");
+  }
+
+  get currentDraftBook(): ManyToOneReference<Author, Book, undefined> {
+    return this.#currentDraftBook ??= hasOne(this as any as Author, bookMeta, "currentDraftBook", "currentDraftAuthor");
+  }
+
+  get publisher(): ManyToOneReference<Author, Publisher, undefined> {
+    return this.#publisher ??= hasOne(this as any as Author, publisherMeta, "publisher", "authors");
+  }
+
+  get image(): OneToOneReference<Author, Image> {
+    return this.#image ??= hasOneToOne(this as any as Author, imageMeta, "image", "author", "author_id");
+  }
+
+  get userOneToOne(): OneToOneReference<Author, User> {
+    return this.#userOneToOne ??= hasOneToOne(
+      this as any as Author,
+      userMeta,
+      "userOneToOne",
+      "authorManyToOne",
+      "author_id",
+    );
+  }
+
+  get tags(): Collection<Author, Tag> {
+    return this.#tags ??= hasManyToMany(
+      this as any as Author,
+      "authors_to_tags",
+      "tags",
+      "author_id",
+      tagMeta,
+      "authors",
+      "tag_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorCodegen.ts
@@ -280,17 +280,8 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-  #authors: Collection<Author, Author> | undefined = undefined;
-  #schedules: Collection<Author, AuthorSchedule> | undefined = undefined;
-  #books: Collection<Author, Book> | undefined = undefined;
-  #comments: Collection<Author, Comment> | undefined = undefined;
-  #mentor: ManyToOneReference<Author, Author, undefined> | undefined = undefined;
-  #currentDraftBook: ManyToOneReference<Author, Book, undefined> | undefined = undefined;
+
   abstract readonly favoriteBook: PersistedAsyncReference<Author, Book, undefined>;
-  #publisher: ManyToOneReference<Author, Publisher, undefined> | undefined = undefined;
-  #image: OneToOneReference<Author, Image> | undefined = undefined;
-  #userOneToOne: OneToOneReference<Author, User> | undefined = undefined;
-  #tags: Collection<Author, Tag> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -530,15 +521,20 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get authors(): Collection<Author, Author> {
-    if (this.#authors === undefined) {
-      this.#authors = hasMany(this as any as Author, authorMeta, "authors", "mentor", "mentor_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.authors === undefined) {
+      relations.authors = hasMany(this as any as Author, authorMeta, "authors", "mentor", "mentor_id", undefined);
+      if (this.isNewEntity) {
+        relations.authors.initializeForNewEntity?.();
+      }
     }
-    return this.#authors;
+    return relations.authors as any;
   }
 
   get schedules(): Collection<Author, AuthorSchedule> {
-    if (this.#schedules === undefined) {
-      this.#schedules = hasMany(
+    const { relations } = this.__orm;
+    if (relations.schedules === undefined) {
+      relations.schedules = hasMany(
         this as any as Author,
         authorScheduleMeta,
         "schedules",
@@ -546,65 +542,110 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
         "author_id",
         undefined,
       );
+      if (this.isNewEntity) {
+        relations.schedules.initializeForNewEntity?.();
+      }
     }
-    return this.#schedules;
+    return relations.schedules as any;
   }
 
   get books(): Collection<Author, Book> {
-    if (this.#books === undefined) {
-      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", {
+    const { relations } = this.__orm;
+    if (relations.books === undefined) {
+      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", {
         "field": "order",
         "direction": "ASC",
       });
+      if (this.isNewEntity) {
+        relations.books.initializeForNewEntity?.();
+      }
     }
-    return this.#books;
+    return relations.books as any;
   }
 
   get comments(): Collection<Author, Comment> {
-    if (this.#comments === undefined) {
-      this.#comments = hasMany(this as any as Author, commentMeta, "comments", "parent", "parent_author_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.comments === undefined) {
+      relations.comments = hasMany(
+        this as any as Author,
+        commentMeta,
+        "comments",
+        "parent",
+        "parent_author_id",
+        undefined,
+      );
+      if (this.isNewEntity) {
+        relations.comments.initializeForNewEntity?.();
+      }
     }
-    return this.#comments;
+    return relations.comments as any;
   }
 
   get mentor(): ManyToOneReference<Author, Author, undefined> {
-    if (this.#mentor === undefined) {
-      this.#mentor = hasOne(this as any as Author, authorMeta, "mentor", "authors");
+    const { relations } = this.__orm;
+    if (relations.mentor === undefined) {
+      relations.mentor = hasOne(this as any as Author, authorMeta, "mentor", "authors");
+      if (this.isNewEntity) {
+        relations.mentor.initializeForNewEntity?.();
+      }
     }
-    return this.#mentor;
+    return relations.mentor as any;
   }
 
   get currentDraftBook(): ManyToOneReference<Author, Book, undefined> {
-    if (this.#currentDraftBook === undefined) {
-      this.#currentDraftBook = hasOne(this as any as Author, bookMeta, "currentDraftBook", "currentDraftAuthor");
+    const { relations } = this.__orm;
+    if (relations.currentDraftBook === undefined) {
+      relations.currentDraftBook = hasOne(this as any as Author, bookMeta, "currentDraftBook", "currentDraftAuthor");
+      if (this.isNewEntity) {
+        relations.currentDraftBook.initializeForNewEntity?.();
+      }
     }
-    return this.#currentDraftBook;
+    return relations.currentDraftBook as any;
   }
 
   get publisher(): ManyToOneReference<Author, Publisher, undefined> {
-    if (this.#publisher === undefined) {
-      this.#publisher = hasOne(this as any as Author, publisherMeta, "publisher", "authors");
+    const { relations } = this.__orm;
+    if (relations.publisher === undefined) {
+      relations.publisher = hasOne(this as any as Author, publisherMeta, "publisher", "authors");
+      if (this.isNewEntity) {
+        relations.publisher.initializeForNewEntity?.();
+      }
     }
-    return this.#publisher;
+    return relations.publisher as any;
   }
 
   get image(): OneToOneReference<Author, Image> {
-    if (this.#image === undefined) {
-      this.#image = hasOneToOne(this as any as Author, imageMeta, "image", "author", "author_id");
+    const { relations } = this.__orm;
+    if (relations.image === undefined) {
+      relations.image = hasOneToOne(this as any as Author, imageMeta, "image", "author", "author_id");
+      if (this.isNewEntity) {
+        relations.image.initializeForNewEntity?.();
+      }
     }
-    return this.#image;
+    return relations.image as any;
   }
 
   get userOneToOne(): OneToOneReference<Author, User> {
-    if (this.#userOneToOne === undefined) {
-      this.#userOneToOne = hasOneToOne(this as any as Author, userMeta, "userOneToOne", "authorManyToOne", "author_id");
+    const { relations } = this.__orm;
+    if (relations.userOneToOne === undefined) {
+      relations.userOneToOne = hasOneToOne(
+        this as any as Author,
+        userMeta,
+        "userOneToOne",
+        "authorManyToOne",
+        "author_id",
+      );
+      if (this.isNewEntity) {
+        relations.userOneToOne.initializeForNewEntity?.();
+      }
     }
-    return this.#userOneToOne;
+    return relations.userOneToOne as any;
   }
 
   get tags(): Collection<Author, Tag> {
-    if (this.#tags === undefined) {
-      this.#tags = hasManyToMany(
+    const { relations } = this.__orm;
+    if (relations.tags === undefined) {
+      relations.tags = hasManyToMany(
         this as any as Author,
         "authors_to_tags",
         "tags",
@@ -613,7 +654,10 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
         "authors",
         "tag_id",
       );
+      if (this.isNewEntity) {
+        relations.tags.initializeForNewEntity?.();
+      }
     }
-    return this.#tags;
+    return relations.tags as any;
   }
 }

--- a/packages/tests/integration/src/entities/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorCodegen.ts
@@ -530,73 +530,90 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get authors(): Collection<Author, Author> {
-    return this.#authors ??= hasMany(this as any as Author, authorMeta, "authors", "mentor", "mentor_id", undefined);
+    if (this.#authors === undefined) {
+      this.#authors = hasMany(this as any as Author, authorMeta, "authors", "mentor", "mentor_id", undefined);
+    }
+    return this.#authors;
   }
 
   get schedules(): Collection<Author, AuthorSchedule> {
-    return this.#schedules ??= hasMany(
-      this as any as Author,
-      authorScheduleMeta,
-      "schedules",
-      "author",
-      "author_id",
-      undefined,
-    );
+    if (this.#schedules === undefined) {
+      this.#schedules = hasMany(
+        this as any as Author,
+        authorScheduleMeta,
+        "schedules",
+        "author",
+        "author_id",
+        undefined,
+      );
+    }
+    return this.#schedules;
   }
 
   get books(): Collection<Author, Book> {
-    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", {
-      "field": "order",
-      "direction": "ASC",
-    });
+    if (this.#books === undefined) {
+      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", {
+        "field": "order",
+        "direction": "ASC",
+      });
+    }
+    return this.#books;
   }
 
   get comments(): Collection<Author, Comment> {
-    return this.#comments ??= hasMany(
-      this as any as Author,
-      commentMeta,
-      "comments",
-      "parent",
-      "parent_author_id",
-      undefined,
-    );
+    if (this.#comments === undefined) {
+      this.#comments = hasMany(this as any as Author, commentMeta, "comments", "parent", "parent_author_id", undefined);
+    }
+    return this.#comments;
   }
 
   get mentor(): ManyToOneReference<Author, Author, undefined> {
-    return this.#mentor ??= hasOne(this as any as Author, authorMeta, "mentor", "authors");
+    if (this.#mentor === undefined) {
+      this.#mentor = hasOne(this as any as Author, authorMeta, "mentor", "authors");
+    }
+    return this.#mentor;
   }
 
   get currentDraftBook(): ManyToOneReference<Author, Book, undefined> {
-    return this.#currentDraftBook ??= hasOne(this as any as Author, bookMeta, "currentDraftBook", "currentDraftAuthor");
+    if (this.#currentDraftBook === undefined) {
+      this.#currentDraftBook = hasOne(this as any as Author, bookMeta, "currentDraftBook", "currentDraftAuthor");
+    }
+    return this.#currentDraftBook;
   }
 
   get publisher(): ManyToOneReference<Author, Publisher, undefined> {
-    return this.#publisher ??= hasOne(this as any as Author, publisherMeta, "publisher", "authors");
+    if (this.#publisher === undefined) {
+      this.#publisher = hasOne(this as any as Author, publisherMeta, "publisher", "authors");
+    }
+    return this.#publisher;
   }
 
   get image(): OneToOneReference<Author, Image> {
-    return this.#image ??= hasOneToOne(this as any as Author, imageMeta, "image", "author", "author_id");
+    if (this.#image === undefined) {
+      this.#image = hasOneToOne(this as any as Author, imageMeta, "image", "author", "author_id");
+    }
+    return this.#image;
   }
 
   get userOneToOne(): OneToOneReference<Author, User> {
-    return this.#userOneToOne ??= hasOneToOne(
-      this as any as Author,
-      userMeta,
-      "userOneToOne",
-      "authorManyToOne",
-      "author_id",
-    );
+    if (this.#userOneToOne === undefined) {
+      this.#userOneToOne = hasOneToOne(this as any as Author, userMeta, "userOneToOne", "authorManyToOne", "author_id");
+    }
+    return this.#userOneToOne;
   }
 
   get tags(): Collection<Author, Tag> {
-    return this.#tags ??= hasManyToMany(
-      this as any as Author,
-      "authors_to_tags",
-      "tags",
-      "author_id",
-      tagMeta,
-      "authors",
-      "tag_id",
-    );
+    if (this.#tags === undefined) {
+      this.#tags = hasManyToMany(
+        this as any as Author,
+        "authors_to_tags",
+        "tags",
+        "author_id",
+        tagMeta,
+        "authors",
+        "tag_id",
+      );
+    }
+    return this.#tags;
   }
 }

--- a/packages/tests/integration/src/entities/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorCodegen.ts
@@ -524,9 +524,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.authors === undefined) {
       relations.authors = hasMany(this as any as Author, authorMeta, "authors", "mentor", "mentor_id", undefined);
-      if (this.isNewEntity) {
-        relations.authors.initializeForNewEntity?.();
-      }
     }
     return relations.authors as any;
   }
@@ -542,9 +539,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
         "author_id",
         undefined,
       );
-      if (this.isNewEntity) {
-        relations.schedules.initializeForNewEntity?.();
-      }
     }
     return relations.schedules as any;
   }
@@ -556,9 +550,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
         "field": "order",
         "direction": "ASC",
       });
-      if (this.isNewEntity) {
-        relations.books.initializeForNewEntity?.();
-      }
     }
     return relations.books as any;
   }
@@ -574,9 +565,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
         "parent_author_id",
         undefined,
       );
-      if (this.isNewEntity) {
-        relations.comments.initializeForNewEntity?.();
-      }
     }
     return relations.comments as any;
   }
@@ -585,9 +573,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.mentor === undefined) {
       relations.mentor = hasOne(this as any as Author, authorMeta, "mentor", "authors");
-      if (this.isNewEntity) {
-        relations.mentor.initializeForNewEntity?.();
-      }
     }
     return relations.mentor as any;
   }
@@ -596,9 +581,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.currentDraftBook === undefined) {
       relations.currentDraftBook = hasOne(this as any as Author, bookMeta, "currentDraftBook", "currentDraftAuthor");
-      if (this.isNewEntity) {
-        relations.currentDraftBook.initializeForNewEntity?.();
-      }
     }
     return relations.currentDraftBook as any;
   }
@@ -607,9 +589,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.publisher === undefined) {
       relations.publisher = hasOne(this as any as Author, publisherMeta, "publisher", "authors");
-      if (this.isNewEntity) {
-        relations.publisher.initializeForNewEntity?.();
-      }
     }
     return relations.publisher as any;
   }
@@ -618,9 +597,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.image === undefined) {
       relations.image = hasOneToOne(this as any as Author, imageMeta, "image", "author", "author_id");
-      if (this.isNewEntity) {
-        relations.image.initializeForNewEntity?.();
-      }
     }
     return relations.image as any;
   }
@@ -635,9 +611,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
         "authorManyToOne",
         "author_id",
       );
-      if (this.isNewEntity) {
-        relations.userOneToOne.initializeForNewEntity?.();
-      }
     }
     return relations.userOneToOne as any;
   }
@@ -654,9 +627,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
         "authors",
         "tag_id",
       );
-      if (this.isNewEntity) {
-        relations.tags.initializeForNewEntity?.();
-      }
     }
     return relations.tags as any;
   }

--- a/packages/tests/integration/src/entities/AuthorCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorCodegen.ts
@@ -522,112 +522,94 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
 
   get authors(): Collection<Author, Author> {
     const { relations } = this.__orm;
-    if (relations.authors === undefined) {
-      relations.authors = hasMany(this as any as Author, authorMeta, "authors", "mentor", "mentor_id", undefined);
-    }
-    return relations.authors as any;
+    return relations.authors ??= hasMany(
+      this as any as Author,
+      authorMeta,
+      "authors",
+      "mentor",
+      "mentor_id",
+      undefined,
+    );
   }
 
   get schedules(): Collection<Author, AuthorSchedule> {
     const { relations } = this.__orm;
-    if (relations.schedules === undefined) {
-      relations.schedules = hasMany(
-        this as any as Author,
-        authorScheduleMeta,
-        "schedules",
-        "author",
-        "author_id",
-        undefined,
-      );
-    }
-    return relations.schedules as any;
+    return relations.schedules ??= hasMany(
+      this as any as Author,
+      authorScheduleMeta,
+      "schedules",
+      "author",
+      "author_id",
+      undefined,
+    );
   }
 
   get books(): Collection<Author, Book> {
     const { relations } = this.__orm;
-    if (relations.books === undefined) {
-      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", {
-        "field": "order",
-        "direction": "ASC",
-      });
-    }
-    return relations.books as any;
+    return relations.books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", {
+      "field": "order",
+      "direction": "ASC",
+    });
   }
 
   get comments(): Collection<Author, Comment> {
     const { relations } = this.__orm;
-    if (relations.comments === undefined) {
-      relations.comments = hasMany(
-        this as any as Author,
-        commentMeta,
-        "comments",
-        "parent",
-        "parent_author_id",
-        undefined,
-      );
-    }
-    return relations.comments as any;
+    return relations.comments ??= hasMany(
+      this as any as Author,
+      commentMeta,
+      "comments",
+      "parent",
+      "parent_author_id",
+      undefined,
+    );
   }
 
   get mentor(): ManyToOneReference<Author, Author, undefined> {
     const { relations } = this.__orm;
-    if (relations.mentor === undefined) {
-      relations.mentor = hasOne(this as any as Author, authorMeta, "mentor", "authors");
-    }
-    return relations.mentor as any;
+    return relations.mentor ??= hasOne(this as any as Author, authorMeta, "mentor", "authors");
   }
 
   get currentDraftBook(): ManyToOneReference<Author, Book, undefined> {
     const { relations } = this.__orm;
-    if (relations.currentDraftBook === undefined) {
-      relations.currentDraftBook = hasOne(this as any as Author, bookMeta, "currentDraftBook", "currentDraftAuthor");
-    }
-    return relations.currentDraftBook as any;
+    return relations.currentDraftBook ??= hasOne(
+      this as any as Author,
+      bookMeta,
+      "currentDraftBook",
+      "currentDraftAuthor",
+    );
   }
 
   get publisher(): ManyToOneReference<Author, Publisher, undefined> {
     const { relations } = this.__orm;
-    if (relations.publisher === undefined) {
-      relations.publisher = hasOne(this as any as Author, publisherMeta, "publisher", "authors");
-    }
-    return relations.publisher as any;
+    return relations.publisher ??= hasOne(this as any as Author, publisherMeta, "publisher", "authors");
   }
 
   get image(): OneToOneReference<Author, Image> {
     const { relations } = this.__orm;
-    if (relations.image === undefined) {
-      relations.image = hasOneToOne(this as any as Author, imageMeta, "image", "author", "author_id");
-    }
-    return relations.image as any;
+    return relations.image ??= hasOneToOne(this as any as Author, imageMeta, "image", "author", "author_id");
   }
 
   get userOneToOne(): OneToOneReference<Author, User> {
     const { relations } = this.__orm;
-    if (relations.userOneToOne === undefined) {
-      relations.userOneToOne = hasOneToOne(
-        this as any as Author,
-        userMeta,
-        "userOneToOne",
-        "authorManyToOne",
-        "author_id",
-      );
-    }
-    return relations.userOneToOne as any;
+    return relations.userOneToOne ??= hasOneToOne(
+      this as any as Author,
+      userMeta,
+      "userOneToOne",
+      "authorManyToOne",
+      "author_id",
+    );
   }
 
   get tags(): Collection<Author, Tag> {
     const { relations } = this.__orm;
-    if (relations.tags === undefined) {
-      relations.tags = hasManyToMany(
-        this as any as Author,
-        "authors_to_tags",
-        "tags",
-        "author_id",
-        tagMeta,
-        "authors",
-        "tag_id",
-      );
-    }
-    return relations.tags as any;
+    return relations.tags ??= hasManyToMany(
+      this as any as Author,
+      "authors_to_tags",
+      "tags",
+      "author_id",
+      tagMeta,
+      "authors",
+      "tag_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
@@ -184,6 +184,9 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
   }
 
   get author(): ManyToOneReference<AuthorSchedule, Author, never> {
-    return this.#author ??= hasOne(this as any as AuthorSchedule, authorMeta, "author", "schedules");
+    if (this.#author === undefined) {
+      this.#author = hasOne(this as any as AuthorSchedule, authorMeta, "author", "schedules");
+    }
+    return this.#author;
   }
 }

--- a/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
@@ -184,9 +184,6 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
 
   get author(): ManyToOneReference<AuthorSchedule, Author, never> {
     const { relations } = this.__orm;
-    if (relations.author === undefined) {
-      relations.author = hasOne(this as any as AuthorSchedule, authorMeta, "author", "schedules");
-    }
-    return relations.author as any;
+    return relations.author ??= hasOne(this as any as AuthorSchedule, authorMeta, "author", "schedules");
   }
 }

--- a/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
@@ -186,9 +186,6 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
     const { relations } = this.__orm;
     if (relations.author === undefined) {
       relations.author = hasOne(this as any as AuthorSchedule, authorMeta, "author", "schedules");
-      if (this.isNewEntity) {
-        relations.author.initializeForNewEntity?.();
-      }
     }
     return relations.author as any;
   }

--- a/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
@@ -105,7 +105,6 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
     optIdsType: AuthorScheduleIdsOpts;
     factoryOptsType: Parameters<typeof newAuthorSchedule>[1];
   };
-  #author: ManyToOneReference<AuthorSchedule, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorScheduleOpts) {
     super(em, authorScheduleMeta, AuthorScheduleCodegen.defaultValues, opts);
@@ -184,9 +183,13 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
   }
 
   get author(): ManyToOneReference<AuthorSchedule, Author, never> {
-    if (this.#author === undefined) {
-      this.#author = hasOne(this as any as AuthorSchedule, authorMeta, "author", "schedules");
+    const { relations } = this.__orm;
+    if (relations.author === undefined) {
+      relations.author = hasOne(this as any as AuthorSchedule, authorMeta, "author", "schedules");
+      if (this.isNewEntity) {
+        relations.author.initializeForNewEntity?.();
+      }
     }
-    return this.#author;
+    return relations.author as any;
   }
 }

--- a/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
+++ b/packages/tests/integration/src/entities/AuthorScheduleCodegen.ts
@@ -105,8 +105,7 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
     optIdsType: AuthorScheduleIdsOpts;
     factoryOptsType: Parameters<typeof newAuthorSchedule>[1];
   };
-
-  readonly author: ManyToOneReference<AuthorSchedule, Author, never> = hasOne(authorMeta, "author", "schedules");
+  #author: ManyToOneReference<AuthorSchedule, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorScheduleOpts) {
     super(em, authorScheduleMeta, AuthorScheduleCodegen.defaultValues, opts);
@@ -182,5 +181,9 @@ export abstract class AuthorScheduleCodegen extends BaseEntity<EntityManager, st
 
   isLoaded<H extends LoadHint<AuthorSchedule>>(hint: H): this is Loaded<AuthorSchedule, H> {
     return isLoaded(this as any as AuthorSchedule, hint);
+  }
+
+  get author(): ManyToOneReference<AuthorSchedule, Author, never> {
+    return this.#author ??= hasOne(this as any as AuthorSchedule, authorMeta, "author", "schedules");
   }
 }

--- a/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
@@ -211,9 +211,6 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
     const { relations } = this.__orm;
     if (relations.book === undefined) {
       relations.book = hasOne(this as any as BookAdvance, bookMeta, "book", "advances");
-      if (this.isNewEntity) {
-        relations.book.initializeForNewEntity?.();
-      }
     }
     return relations.book as any;
   }
@@ -222,9 +219,6 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
     const { relations } = this.__orm;
     if (relations.publisher === undefined) {
       relations.publisher = hasOne(this as any as BookAdvance, publisherMeta, "publisher", "bookAdvances");
-      if (this.isNewEntity) {
-        relations.publisher.initializeForNewEntity?.();
-      }
     }
     return relations.publisher as any;
   }

--- a/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
@@ -209,17 +209,11 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
 
   get book(): ManyToOneReference<BookAdvance, Book, never> {
     const { relations } = this.__orm;
-    if (relations.book === undefined) {
-      relations.book = hasOne(this as any as BookAdvance, bookMeta, "book", "advances");
-    }
-    return relations.book as any;
+    return relations.book ??= hasOne(this as any as BookAdvance, bookMeta, "book", "advances");
   }
 
   get publisher(): ManyToOneReference<BookAdvance, Publisher, never> {
     const { relations } = this.__orm;
-    if (relations.publisher === undefined) {
-      relations.publisher = hasOne(this as any as BookAdvance, publisherMeta, "publisher", "bookAdvances");
-    }
-    return relations.publisher as any;
+    return relations.publisher ??= hasOne(this as any as BookAdvance, publisherMeta, "publisher", "bookAdvances");
   }
 }

--- a/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
@@ -210,10 +210,16 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
   }
 
   get book(): ManyToOneReference<BookAdvance, Book, never> {
-    return this.#book ??= hasOne(this as any as BookAdvance, bookMeta, "book", "advances");
+    if (this.#book === undefined) {
+      this.#book = hasOne(this as any as BookAdvance, bookMeta, "book", "advances");
+    }
+    return this.#book;
   }
 
   get publisher(): ManyToOneReference<BookAdvance, Publisher, never> {
-    return this.#publisher ??= hasOne(this as any as BookAdvance, publisherMeta, "publisher", "bookAdvances");
+    if (this.#publisher === undefined) {
+      this.#publisher = hasOne(this as any as BookAdvance, publisherMeta, "publisher", "bookAdvances");
+    }
+    return this.#publisher;
   }
 }

--- a/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
@@ -119,8 +119,6 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
     optIdsType: BookAdvanceIdsOpts;
     factoryOptsType: Parameters<typeof newBookAdvance>[1];
   };
-  #book: ManyToOneReference<BookAdvance, Book, never> | undefined = undefined;
-  #publisher: ManyToOneReference<BookAdvance, Publisher, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookAdvanceOpts) {
     super(em, bookAdvanceMeta, BookAdvanceCodegen.defaultValues, opts);
@@ -210,16 +208,24 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
   }
 
   get book(): ManyToOneReference<BookAdvance, Book, never> {
-    if (this.#book === undefined) {
-      this.#book = hasOne(this as any as BookAdvance, bookMeta, "book", "advances");
+    const { relations } = this.__orm;
+    if (relations.book === undefined) {
+      relations.book = hasOne(this as any as BookAdvance, bookMeta, "book", "advances");
+      if (this.isNewEntity) {
+        relations.book.initializeForNewEntity?.();
+      }
     }
-    return this.#book;
+    return relations.book as any;
   }
 
   get publisher(): ManyToOneReference<BookAdvance, Publisher, never> {
-    if (this.#publisher === undefined) {
-      this.#publisher = hasOne(this as any as BookAdvance, publisherMeta, "publisher", "bookAdvances");
+    const { relations } = this.__orm;
+    if (relations.publisher === undefined) {
+      relations.publisher = hasOne(this as any as BookAdvance, publisherMeta, "publisher", "bookAdvances");
+      if (this.isNewEntity) {
+        relations.publisher.initializeForNewEntity?.();
+      }
     }
-    return this.#publisher;
+    return relations.publisher as any;
   }
 }

--- a/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
+++ b/packages/tests/integration/src/entities/BookAdvanceCodegen.ts
@@ -119,14 +119,8 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
     optIdsType: BookAdvanceIdsOpts;
     factoryOptsType: Parameters<typeof newBookAdvance>[1];
   };
-
-  readonly book: ManyToOneReference<BookAdvance, Book, never> = hasOne(bookMeta, "book", "advances");
-
-  readonly publisher: ManyToOneReference<BookAdvance, Publisher, never> = hasOne(
-    publisherMeta,
-    "publisher",
-    "bookAdvances",
-  );
+  #book: ManyToOneReference<BookAdvance, Book, never> | undefined = undefined;
+  #publisher: ManyToOneReference<BookAdvance, Publisher, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookAdvanceOpts) {
     super(em, bookAdvanceMeta, BookAdvanceCodegen.defaultValues, opts);
@@ -213,5 +207,13 @@ export abstract class BookAdvanceCodegen extends BaseEntity<EntityManager, strin
 
   isLoaded<H extends LoadHint<BookAdvance>>(hint: H): this is Loaded<BookAdvance, H> {
     return isLoaded(this as any as BookAdvance, hint);
+  }
+
+  get book(): ManyToOneReference<BookAdvance, Book, never> {
+    return this.#book ??= hasOne(this as any as BookAdvance, bookMeta, "book", "advances");
+  }
+
+  get publisher(): ManyToOneReference<BookAdvance, Publisher, never> {
+    return this.#publisher ??= hasOne(this as any as BookAdvance, publisherMeta, "publisher", "bookAdvances");
   }
 }

--- a/packages/tests/integration/src/entities/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/BookCodegen.ts
@@ -161,13 +161,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-  #advances: Collection<Book, BookAdvance> | undefined = undefined;
-  #reviews: Collection<Book, BookReview> | undefined = undefined;
-  #comments: Collection<Book, Comment> | undefined = undefined;
-  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
-  #currentDraftAuthor: OneToOneReference<Book, Author> | undefined = undefined;
-  #image: OneToOneReference<Book, Image> | undefined = undefined;
-  #tags: Collection<Book, Tag> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -258,57 +251,93 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get advances(): Collection<Book, BookAdvance> {
-    if (this.#advances === undefined) {
-      this.#advances = hasMany(this as any as Book, bookAdvanceMeta, "advances", "book", "book_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.advances === undefined) {
+      relations.advances = hasMany(this as any as Book, bookAdvanceMeta, "advances", "book", "book_id", undefined);
+      if (this.isNewEntity) {
+        relations.advances.initializeForNewEntity?.();
+      }
     }
-    return this.#advances;
+    return relations.advances as any;
   }
 
   get reviews(): Collection<Book, BookReview> {
-    if (this.#reviews === undefined) {
-      this.#reviews = hasMany(this as any as Book, bookReviewMeta, "reviews", "book", "book_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.reviews === undefined) {
+      relations.reviews = hasMany(this as any as Book, bookReviewMeta, "reviews", "book", "book_id", undefined);
+      if (this.isNewEntity) {
+        relations.reviews.initializeForNewEntity?.();
+      }
     }
-    return this.#reviews;
+    return relations.reviews as any;
   }
 
   get comments(): Collection<Book, Comment> {
-    if (this.#comments === undefined) {
-      this.#comments = hasMany(this as any as Book, commentMeta, "comments", "parent", "parent_book_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.comments === undefined) {
+      relations.comments = hasMany(this as any as Book, commentMeta, "comments", "parent", "parent_book_id", undefined);
+      if (this.isNewEntity) {
+        relations.comments.initializeForNewEntity?.();
+      }
     }
-    return this.#comments;
+    return relations.comments as any;
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    if (this.#author === undefined) {
-      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    const { relations } = this.__orm;
+    if (relations.author === undefined) {
+      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
+      if (this.isNewEntity) {
+        relations.author.initializeForNewEntity?.();
+      }
     }
-    return this.#author;
+    return relations.author as any;
   }
 
   get currentDraftAuthor(): OneToOneReference<Book, Author> {
-    if (this.#currentDraftAuthor === undefined) {
-      this.#currentDraftAuthor = hasOneToOne(
+    const { relations } = this.__orm;
+    if (relations.currentDraftAuthor === undefined) {
+      relations.currentDraftAuthor = hasOneToOne(
         this as any as Book,
         authorMeta,
         "currentDraftAuthor",
         "currentDraftBook",
         "current_draft_book_id",
       );
+      if (this.isNewEntity) {
+        relations.currentDraftAuthor.initializeForNewEntity?.();
+      }
     }
-    return this.#currentDraftAuthor;
+    return relations.currentDraftAuthor as any;
   }
 
   get image(): OneToOneReference<Book, Image> {
-    if (this.#image === undefined) {
-      this.#image = hasOneToOne(this as any as Book, imageMeta, "image", "book", "book_id");
+    const { relations } = this.__orm;
+    if (relations.image === undefined) {
+      relations.image = hasOneToOne(this as any as Book, imageMeta, "image", "book", "book_id");
+      if (this.isNewEntity) {
+        relations.image.initializeForNewEntity?.();
+      }
     }
-    return this.#image;
+    return relations.image as any;
   }
 
   get tags(): Collection<Book, Tag> {
-    if (this.#tags === undefined) {
-      this.#tags = hasManyToMany(this as any as Book, "books_to_tags", "tags", "book_id", tagMeta, "books", "tag_id");
+    const { relations } = this.__orm;
+    if (relations.tags === undefined) {
+      relations.tags = hasManyToMany(
+        this as any as Book,
+        "books_to_tags",
+        "tags",
+        "book_id",
+        tagMeta,
+        "books",
+        "tag_id",
+      );
+      if (this.isNewEntity) {
+        relations.tags.initializeForNewEntity?.();
+      }
     }
-    return this.#tags;
+    return relations.tags as any;
   }
 }

--- a/packages/tests/integration/src/entities/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/BookCodegen.ts
@@ -252,71 +252,64 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
 
   get advances(): Collection<Book, BookAdvance> {
     const { relations } = this.__orm;
-    if (relations.advances === undefined) {
-      relations.advances = hasMany(this as any as Book, bookAdvanceMeta, "advances", "book", "book_id", undefined);
-    }
-    return relations.advances as any;
+    return relations.advances ??= hasMany(
+      this as any as Book,
+      bookAdvanceMeta,
+      "advances",
+      "book",
+      "book_id",
+      undefined,
+    );
   }
 
   get reviews(): Collection<Book, BookReview> {
     const { relations } = this.__orm;
-    if (relations.reviews === undefined) {
-      relations.reviews = hasMany(this as any as Book, bookReviewMeta, "reviews", "book", "book_id", undefined);
-    }
-    return relations.reviews as any;
+    return relations.reviews ??= hasMany(this as any as Book, bookReviewMeta, "reviews", "book", "book_id", undefined);
   }
 
   get comments(): Collection<Book, Comment> {
     const { relations } = this.__orm;
-    if (relations.comments === undefined) {
-      relations.comments = hasMany(this as any as Book, commentMeta, "comments", "parent", "parent_book_id", undefined);
-    }
-    return relations.comments as any;
+    return relations.comments ??= hasMany(
+      this as any as Book,
+      commentMeta,
+      "comments",
+      "parent",
+      "parent_book_id",
+      undefined,
+    );
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
     const { relations } = this.__orm;
-    if (relations.author === undefined) {
-      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-    }
-    return relations.author as any;
+    return relations.author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 
   get currentDraftAuthor(): OneToOneReference<Book, Author> {
     const { relations } = this.__orm;
-    if (relations.currentDraftAuthor === undefined) {
-      relations.currentDraftAuthor = hasOneToOne(
-        this as any as Book,
-        authorMeta,
-        "currentDraftAuthor",
-        "currentDraftBook",
-        "current_draft_book_id",
-      );
-    }
-    return relations.currentDraftAuthor as any;
+    return relations.currentDraftAuthor ??= hasOneToOne(
+      this as any as Book,
+      authorMeta,
+      "currentDraftAuthor",
+      "currentDraftBook",
+      "current_draft_book_id",
+    );
   }
 
   get image(): OneToOneReference<Book, Image> {
     const { relations } = this.__orm;
-    if (relations.image === undefined) {
-      relations.image = hasOneToOne(this as any as Book, imageMeta, "image", "book", "book_id");
-    }
-    return relations.image as any;
+    return relations.image ??= hasOneToOne(this as any as Book, imageMeta, "image", "book", "book_id");
   }
 
   get tags(): Collection<Book, Tag> {
     const { relations } = this.__orm;
-    if (relations.tags === undefined) {
-      relations.tags = hasManyToMany(
-        this as any as Book,
-        "books_to_tags",
-        "tags",
-        "book_id",
-        tagMeta,
-        "books",
-        "tag_id",
-      );
-    }
-    return relations.tags as any;
+    return relations.tags ??= hasManyToMany(
+      this as any as Book,
+      "books_to_tags",
+      "tags",
+      "book_id",
+      tagMeta,
+      "books",
+      "tag_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/BookCodegen.ts
@@ -258,51 +258,57 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get advances(): Collection<Book, BookAdvance> {
-    return this.#advances ??= hasMany(this as any as Book, bookAdvanceMeta, "advances", "book", "book_id", undefined);
+    if (this.#advances === undefined) {
+      this.#advances = hasMany(this as any as Book, bookAdvanceMeta, "advances", "book", "book_id", undefined);
+    }
+    return this.#advances;
   }
 
   get reviews(): Collection<Book, BookReview> {
-    return this.#reviews ??= hasMany(this as any as Book, bookReviewMeta, "reviews", "book", "book_id", undefined);
+    if (this.#reviews === undefined) {
+      this.#reviews = hasMany(this as any as Book, bookReviewMeta, "reviews", "book", "book_id", undefined);
+    }
+    return this.#reviews;
   }
 
   get comments(): Collection<Book, Comment> {
-    return this.#comments ??= hasMany(
-      this as any as Book,
-      commentMeta,
-      "comments",
-      "parent",
-      "parent_book_id",
-      undefined,
-    );
+    if (this.#comments === undefined) {
+      this.#comments = hasMany(this as any as Book, commentMeta, "comments", "parent", "parent_book_id", undefined);
+    }
+    return this.#comments;
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
+    if (this.#author === undefined) {
+      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    }
+    return this.#author;
   }
 
   get currentDraftAuthor(): OneToOneReference<Book, Author> {
-    return this.#currentDraftAuthor ??= hasOneToOne(
-      this as any as Book,
-      authorMeta,
-      "currentDraftAuthor",
-      "currentDraftBook",
-      "current_draft_book_id",
-    );
+    if (this.#currentDraftAuthor === undefined) {
+      this.#currentDraftAuthor = hasOneToOne(
+        this as any as Book,
+        authorMeta,
+        "currentDraftAuthor",
+        "currentDraftBook",
+        "current_draft_book_id",
+      );
+    }
+    return this.#currentDraftAuthor;
   }
 
   get image(): OneToOneReference<Book, Image> {
-    return this.#image ??= hasOneToOne(this as any as Book, imageMeta, "image", "book", "book_id");
+    if (this.#image === undefined) {
+      this.#image = hasOneToOne(this as any as Book, imageMeta, "image", "book", "book_id");
+    }
+    return this.#image;
   }
 
   get tags(): Collection<Book, Tag> {
-    return this.#tags ??= hasManyToMany(
-      this as any as Book,
-      "books_to_tags",
-      "tags",
-      "book_id",
-      tagMeta,
-      "books",
-      "tag_id",
-    );
+    if (this.#tags === undefined) {
+      this.#tags = hasManyToMany(this as any as Book, "books_to_tags", "tags", "book_id", tagMeta, "books", "tag_id");
+    }
+    return this.#tags;
   }
 }

--- a/packages/tests/integration/src/entities/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/BookCodegen.ts
@@ -161,31 +161,13 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-
-  readonly advances: Collection<Book, BookAdvance> = hasMany(bookAdvanceMeta, "advances", "book", "book_id", undefined);
-
-  readonly reviews: Collection<Book, BookReview> = hasMany(bookReviewMeta, "reviews", "book", "book_id", undefined);
-
-  readonly comments: Collection<Book, Comment> = hasMany(
-    commentMeta,
-    "comments",
-    "parent",
-    "parent_book_id",
-    undefined,
-  );
-
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
-
-  readonly currentDraftAuthor: OneToOneReference<Book, Author> = hasOneToOne(
-    authorMeta,
-    "currentDraftAuthor",
-    "currentDraftBook",
-    "current_draft_book_id",
-  );
-
-  readonly image: OneToOneReference<Book, Image> = hasOneToOne(imageMeta, "image", "book", "book_id");
-
-  readonly tags: Collection<Book, Tag> = hasManyToMany("books_to_tags", "tags", "book_id", tagMeta, "books", "tag_id");
+  #advances: Collection<Book, BookAdvance> | undefined = undefined;
+  #reviews: Collection<Book, BookReview> | undefined = undefined;
+  #comments: Collection<Book, Comment> | undefined = undefined;
+  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
+  #currentDraftAuthor: OneToOneReference<Book, Author> | undefined = undefined;
+  #image: OneToOneReference<Book, Image> | undefined = undefined;
+  #tags: Collection<Book, Tag> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -273,5 +255,54 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {
     return isLoaded(this as any as Book, hint);
+  }
+
+  get advances(): Collection<Book, BookAdvance> {
+    return this.#advances ??= hasMany(this as any as Book, bookAdvanceMeta, "advances", "book", "book_id", undefined);
+  }
+
+  get reviews(): Collection<Book, BookReview> {
+    return this.#reviews ??= hasMany(this as any as Book, bookReviewMeta, "reviews", "book", "book_id", undefined);
+  }
+
+  get comments(): Collection<Book, Comment> {
+    return this.#comments ??= hasMany(
+      this as any as Book,
+      commentMeta,
+      "comments",
+      "parent",
+      "parent_book_id",
+      undefined,
+    );
+  }
+
+  get author(): ManyToOneReference<Book, Author, never> {
+    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
+  }
+
+  get currentDraftAuthor(): OneToOneReference<Book, Author> {
+    return this.#currentDraftAuthor ??= hasOneToOne(
+      this as any as Book,
+      authorMeta,
+      "currentDraftAuthor",
+      "currentDraftBook",
+      "current_draft_book_id",
+    );
+  }
+
+  get image(): OneToOneReference<Book, Image> {
+    return this.#image ??= hasOneToOne(this as any as Book, imageMeta, "image", "book", "book_id");
+  }
+
+  get tags(): Collection<Book, Tag> {
+    return this.#tags ??= hasManyToMany(
+      this as any as Book,
+      "books_to_tags",
+      "tags",
+      "book_id",
+      tagMeta,
+      "books",
+      "tag_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/BookCodegen.ts
+++ b/packages/tests/integration/src/entities/BookCodegen.ts
@@ -254,9 +254,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.advances === undefined) {
       relations.advances = hasMany(this as any as Book, bookAdvanceMeta, "advances", "book", "book_id", undefined);
-      if (this.isNewEntity) {
-        relations.advances.initializeForNewEntity?.();
-      }
     }
     return relations.advances as any;
   }
@@ -265,9 +262,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.reviews === undefined) {
       relations.reviews = hasMany(this as any as Book, bookReviewMeta, "reviews", "book", "book_id", undefined);
-      if (this.isNewEntity) {
-        relations.reviews.initializeForNewEntity?.();
-      }
     }
     return relations.reviews as any;
   }
@@ -276,9 +270,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.comments === undefined) {
       relations.comments = hasMany(this as any as Book, commentMeta, "comments", "parent", "parent_book_id", undefined);
-      if (this.isNewEntity) {
-        relations.comments.initializeForNewEntity?.();
-      }
     }
     return relations.comments as any;
   }
@@ -287,9 +278,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.author === undefined) {
       relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-      if (this.isNewEntity) {
-        relations.author.initializeForNewEntity?.();
-      }
     }
     return relations.author as any;
   }
@@ -304,9 +292,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
         "currentDraftBook",
         "current_draft_book_id",
       );
-      if (this.isNewEntity) {
-        relations.currentDraftAuthor.initializeForNewEntity?.();
-      }
     }
     return relations.currentDraftAuthor as any;
   }
@@ -315,9 +300,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.image === undefined) {
       relations.image = hasOneToOne(this as any as Book, imageMeta, "image", "book", "book_id");
-      if (this.isNewEntity) {
-        relations.image.initializeForNewEntity?.();
-      }
     }
     return relations.image as any;
   }
@@ -334,9 +316,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
         "books",
         "tag_id",
       );
-      if (this.isNewEntity) {
-        relations.tags.initializeForNewEntity?.();
-      }
     }
     return relations.tags as any;
   }

--- a/packages/tests/integration/src/entities/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/BookReviewCodegen.ts
@@ -127,15 +127,8 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
     optIdsType: BookReviewIdsOpts;
     factoryOptsType: Parameters<typeof newBookReview>[1];
   };
-
-  readonly book: ManyToOneReference<BookReview, Book, never> = hasOne(bookMeta, "book", "reviews");
-
-  readonly comment: OneToOneReference<BookReview, Comment> = hasOneToOne(
-    commentMeta,
-    "comment",
-    "parent",
-    "parent_book_review_id",
-  );
+  #book: ManyToOneReference<BookReview, Book, never> | undefined = undefined;
+  #comment: OneToOneReference<BookReview, Comment> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookReviewOpts) {
     super(em, bookReviewMeta, BookReviewCodegen.defaultValues, opts);
@@ -210,5 +203,19 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
 
   isLoaded<H extends LoadHint<BookReview>>(hint: H): this is Loaded<BookReview, H> {
     return isLoaded(this as any as BookReview, hint);
+  }
+
+  get book(): ManyToOneReference<BookReview, Book, never> {
+    return this.#book ??= hasOne(this as any as BookReview, bookMeta, "book", "reviews");
+  }
+
+  get comment(): OneToOneReference<BookReview, Comment> {
+    return this.#comment ??= hasOneToOne(
+      this as any as BookReview,
+      commentMeta,
+      "comment",
+      "parent",
+      "parent_book_review_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/BookReviewCodegen.ts
@@ -205,23 +205,17 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
 
   get book(): ManyToOneReference<BookReview, Book, never> {
     const { relations } = this.__orm;
-    if (relations.book === undefined) {
-      relations.book = hasOne(this as any as BookReview, bookMeta, "book", "reviews");
-    }
-    return relations.book as any;
+    return relations.book ??= hasOne(this as any as BookReview, bookMeta, "book", "reviews");
   }
 
   get comment(): OneToOneReference<BookReview, Comment> {
     const { relations } = this.__orm;
-    if (relations.comment === undefined) {
-      relations.comment = hasOneToOne(
-        this as any as BookReview,
-        commentMeta,
-        "comment",
-        "parent",
-        "parent_book_review_id",
-      );
-    }
-    return relations.comment as any;
+    return relations.comment ??= hasOneToOne(
+      this as any as BookReview,
+      commentMeta,
+      "comment",
+      "parent",
+      "parent_book_review_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/BookReviewCodegen.ts
@@ -206,16 +206,16 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
   }
 
   get book(): ManyToOneReference<BookReview, Book, never> {
-    return this.#book ??= hasOne(this as any as BookReview, bookMeta, "book", "reviews");
+    if (this.#book === undefined) {
+      this.#book = hasOne(this as any as BookReview, bookMeta, "book", "reviews");
+    }
+    return this.#book;
   }
 
   get comment(): OneToOneReference<BookReview, Comment> {
-    return this.#comment ??= hasOneToOne(
-      this as any as BookReview,
-      commentMeta,
-      "comment",
-      "parent",
-      "parent_book_review_id",
-    );
+    if (this.#comment === undefined) {
+      this.#comment = hasOneToOne(this as any as BookReview, commentMeta, "comment", "parent", "parent_book_review_id");
+    }
+    return this.#comment;
   }
 }

--- a/packages/tests/integration/src/entities/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/BookReviewCodegen.ts
@@ -127,8 +127,6 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
     optIdsType: BookReviewIdsOpts;
     factoryOptsType: Parameters<typeof newBookReview>[1];
   };
-  #book: ManyToOneReference<BookReview, Book, never> | undefined = undefined;
-  #comment: OneToOneReference<BookReview, Comment> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookReviewOpts) {
     super(em, bookReviewMeta, BookReviewCodegen.defaultValues, opts);
@@ -206,16 +204,30 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
   }
 
   get book(): ManyToOneReference<BookReview, Book, never> {
-    if (this.#book === undefined) {
-      this.#book = hasOne(this as any as BookReview, bookMeta, "book", "reviews");
+    const { relations } = this.__orm;
+    if (relations.book === undefined) {
+      relations.book = hasOne(this as any as BookReview, bookMeta, "book", "reviews");
+      if (this.isNewEntity) {
+        relations.book.initializeForNewEntity?.();
+      }
     }
-    return this.#book;
+    return relations.book as any;
   }
 
   get comment(): OneToOneReference<BookReview, Comment> {
-    if (this.#comment === undefined) {
-      this.#comment = hasOneToOne(this as any as BookReview, commentMeta, "comment", "parent", "parent_book_review_id");
+    const { relations } = this.__orm;
+    if (relations.comment === undefined) {
+      relations.comment = hasOneToOne(
+        this as any as BookReview,
+        commentMeta,
+        "comment",
+        "parent",
+        "parent_book_review_id",
+      );
+      if (this.isNewEntity) {
+        relations.comment.initializeForNewEntity?.();
+      }
     }
-    return this.#comment;
+    return relations.comment as any;
   }
 }

--- a/packages/tests/integration/src/entities/BookReviewCodegen.ts
+++ b/packages/tests/integration/src/entities/BookReviewCodegen.ts
@@ -207,9 +207,6 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
     const { relations } = this.__orm;
     if (relations.book === undefined) {
       relations.book = hasOne(this as any as BookReview, bookMeta, "book", "reviews");
-      if (this.isNewEntity) {
-        relations.book.initializeForNewEntity?.();
-      }
     }
     return relations.book as any;
   }
@@ -224,9 +221,6 @@ export abstract class BookReviewCodegen extends BaseEntity<EntityManager, string
         "parent",
         "parent_book_review_id",
       );
-      if (this.isNewEntity) {
-        relations.comment.initializeForNewEntity?.();
-      }
     }
     return relations.comment as any;
   }

--- a/packages/tests/integration/src/entities/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/CommentCodegen.ts
@@ -209,22 +209,31 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get user(): ManyToOneReference<Comment, User, undefined> {
-    return this.#user ??= hasOne(this as any as Comment, userMeta, "user", "createdComments");
+    if (this.#user === undefined) {
+      this.#user = hasOne(this as any as Comment, userMeta, "user", "createdComments");
+    }
+    return this.#user;
   }
 
   get likedByUsers(): Collection<Comment, User> {
-    return this.#likedByUsers ??= hasManyToMany(
-      this as any as Comment,
-      "users_to_comments",
-      "likedByUsers",
-      "comment_id",
-      userMeta,
-      "likedComments",
-      "liked_by_user_id",
-    );
+    if (this.#likedByUsers === undefined) {
+      this.#likedByUsers = hasManyToMany(
+        this as any as Comment,
+        "users_to_comments",
+        "likedByUsers",
+        "comment_id",
+        userMeta,
+        "likedComments",
+        "liked_by_user_id",
+      );
+    }
+    return this.#likedByUsers;
   }
 
   get parent(): PolymorphicReference<Comment, CommentParent, never> {
-    return this.#parent ??= hasOnePolymorphic(this as any as Comment, "parent");
+    if (this.#parent === undefined) {
+      this.#parent = hasOnePolymorphic(this as any as Comment, "parent");
+    }
+    return this.#parent;
   }
 }

--- a/packages/tests/integration/src/entities/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/CommentCodegen.ts
@@ -207,33 +207,24 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
 
   get user(): ManyToOneReference<Comment, User, undefined> {
     const { relations } = this.__orm;
-    if (relations.user === undefined) {
-      relations.user = hasOne(this as any as Comment, userMeta, "user", "createdComments");
-    }
-    return relations.user as any;
+    return relations.user ??= hasOne(this as any as Comment, userMeta, "user", "createdComments");
   }
 
   get likedByUsers(): Collection<Comment, User> {
     const { relations } = this.__orm;
-    if (relations.likedByUsers === undefined) {
-      relations.likedByUsers = hasManyToMany(
-        this as any as Comment,
-        "users_to_comments",
-        "likedByUsers",
-        "comment_id",
-        userMeta,
-        "likedComments",
-        "liked_by_user_id",
-      );
-    }
-    return relations.likedByUsers as any;
+    return relations.likedByUsers ??= hasManyToMany(
+      this as any as Comment,
+      "users_to_comments",
+      "likedByUsers",
+      "comment_id",
+      userMeta,
+      "likedComments",
+      "liked_by_user_id",
+    );
   }
 
   get parent(): PolymorphicReference<Comment, CommentParent, never> {
     const { relations } = this.__orm;
-    if (relations.parent === undefined) {
-      relations.parent = hasOnePolymorphic(this as any as Comment, "parent");
-    }
-    return relations.parent as any;
+    return relations.parent ??= hasOnePolymorphic(this as any as Comment, "parent");
   }
 }

--- a/packages/tests/integration/src/entities/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/CommentCodegen.ts
@@ -133,19 +133,9 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: CommentIdsOpts;
     factoryOptsType: Parameters<typeof newComment>[1];
   };
-
-  readonly user: ManyToOneReference<Comment, User, undefined> = hasOne(userMeta, "user", "createdComments");
-
-  readonly likedByUsers: Collection<Comment, User> = hasManyToMany(
-    "users_to_comments",
-    "likedByUsers",
-    "comment_id",
-    userMeta,
-    "likedComments",
-    "liked_by_user_id",
-  );
-
-  readonly parent: PolymorphicReference<Comment, CommentParent, never> = hasOnePolymorphic("parent");
+  #user: ManyToOneReference<Comment, User, undefined> | undefined = undefined;
+  #likedByUsers: Collection<Comment, User> | undefined = undefined;
+  #parent: PolymorphicReference<Comment, CommentParent, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: CommentOpts) {
     super(em, commentMeta, CommentCodegen.defaultValues, opts);
@@ -216,5 +206,25 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Comment>>(hint: H): this is Loaded<Comment, H> {
     return isLoaded(this as any as Comment, hint);
+  }
+
+  get user(): ManyToOneReference<Comment, User, undefined> {
+    return this.#user ??= hasOne(this as any as Comment, userMeta, "user", "createdComments");
+  }
+
+  get likedByUsers(): Collection<Comment, User> {
+    return this.#likedByUsers ??= hasManyToMany(
+      this as any as Comment,
+      "users_to_comments",
+      "likedByUsers",
+      "comment_id",
+      userMeta,
+      "likedComments",
+      "liked_by_user_id",
+    );
+  }
+
+  get parent(): PolymorphicReference<Comment, CommentParent, never> {
+    return this.#parent ??= hasOnePolymorphic(this as any as Comment, "parent");
   }
 }

--- a/packages/tests/integration/src/entities/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/CommentCodegen.ts
@@ -209,9 +209,6 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.user === undefined) {
       relations.user = hasOne(this as any as Comment, userMeta, "user", "createdComments");
-      if (this.isNewEntity) {
-        relations.user.initializeForNewEntity?.();
-      }
     }
     return relations.user as any;
   }
@@ -228,9 +225,6 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
         "likedComments",
         "liked_by_user_id",
       );
-      if (this.isNewEntity) {
-        relations.likedByUsers.initializeForNewEntity?.();
-      }
     }
     return relations.likedByUsers as any;
   }
@@ -239,9 +233,6 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.parent === undefined) {
       relations.parent = hasOnePolymorphic(this as any as Comment, "parent");
-      if (this.isNewEntity) {
-        relations.parent.initializeForNewEntity?.();
-      }
     }
     return relations.parent as any;
   }

--- a/packages/tests/integration/src/entities/CommentCodegen.ts
+++ b/packages/tests/integration/src/entities/CommentCodegen.ts
@@ -133,9 +133,6 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: CommentIdsOpts;
     factoryOptsType: Parameters<typeof newComment>[1];
   };
-  #user: ManyToOneReference<Comment, User, undefined> | undefined = undefined;
-  #likedByUsers: Collection<Comment, User> | undefined = undefined;
-  #parent: PolymorphicReference<Comment, CommentParent, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: CommentOpts) {
     super(em, commentMeta, CommentCodegen.defaultValues, opts);
@@ -209,15 +206,20 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get user(): ManyToOneReference<Comment, User, undefined> {
-    if (this.#user === undefined) {
-      this.#user = hasOne(this as any as Comment, userMeta, "user", "createdComments");
+    const { relations } = this.__orm;
+    if (relations.user === undefined) {
+      relations.user = hasOne(this as any as Comment, userMeta, "user", "createdComments");
+      if (this.isNewEntity) {
+        relations.user.initializeForNewEntity?.();
+      }
     }
-    return this.#user;
+    return relations.user as any;
   }
 
   get likedByUsers(): Collection<Comment, User> {
-    if (this.#likedByUsers === undefined) {
-      this.#likedByUsers = hasManyToMany(
+    const { relations } = this.__orm;
+    if (relations.likedByUsers === undefined) {
+      relations.likedByUsers = hasManyToMany(
         this as any as Comment,
         "users_to_comments",
         "likedByUsers",
@@ -226,14 +228,21 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> {
         "likedComments",
         "liked_by_user_id",
       );
+      if (this.isNewEntity) {
+        relations.likedByUsers.initializeForNewEntity?.();
+      }
     }
-    return this.#likedByUsers;
+    return relations.likedByUsers as any;
   }
 
   get parent(): PolymorphicReference<Comment, CommentParent, never> {
-    if (this.#parent === undefined) {
-      this.#parent = hasOnePolymorphic(this as any as Comment, "parent");
+    const { relations } = this.__orm;
+    if (relations.parent === undefined) {
+      relations.parent = hasOnePolymorphic(this as any as Comment, "parent");
+      if (this.isNewEntity) {
+        relations.parent.initializeForNewEntity?.();
+      }
     }
-    return this.#parent;
+    return relations.parent as any;
   }
 }

--- a/packages/tests/integration/src/entities/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticCodegen.ts
@@ -124,9 +124,6 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: CriticIdsOpts;
     factoryOptsType: Parameters<typeof newCritic>[1];
   };
-  #favoriteLargePublisher: ManyToOneReference<Critic, LargePublisher, undefined> | undefined = undefined;
-  #group: ManyToOneReference<Critic, PublisherGroup, undefined> | undefined = undefined;
-  #criticColumn: OneToOneReference<Critic, CriticColumn> | undefined = undefined;
 
   constructor(em: EntityManager, opts: CriticOpts) {
     super(em, criticMeta, CriticCodegen.defaultValues, opts);
@@ -200,28 +197,46 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get favoriteLargePublisher(): ManyToOneReference<Critic, LargePublisher, undefined> {
-    if (this.#favoriteLargePublisher === undefined) {
-      this.#favoriteLargePublisher = hasOne(
+    const { relations } = this.__orm;
+    if (relations.favoriteLargePublisher === undefined) {
+      relations.favoriteLargePublisher = hasOne(
         this as any as Critic,
         largePublisherMeta,
         "favoriteLargePublisher",
         "critics",
       );
+      if (this.isNewEntity) {
+        relations.favoriteLargePublisher.initializeForNewEntity?.();
+      }
     }
-    return this.#favoriteLargePublisher;
+    return relations.favoriteLargePublisher as any;
   }
 
   get group(): ManyToOneReference<Critic, PublisherGroup, undefined> {
-    if (this.#group === undefined) {
-      this.#group = hasOne(this as any as Critic, publisherGroupMeta, "group", "critics");
+    const { relations } = this.__orm;
+    if (relations.group === undefined) {
+      relations.group = hasOne(this as any as Critic, publisherGroupMeta, "group", "critics");
+      if (this.isNewEntity) {
+        relations.group.initializeForNewEntity?.();
+      }
     }
-    return this.#group;
+    return relations.group as any;
   }
 
   get criticColumn(): OneToOneReference<Critic, CriticColumn> {
-    if (this.#criticColumn === undefined) {
-      this.#criticColumn = hasOneToOne(this as any as Critic, criticColumnMeta, "criticColumn", "critic", "critic_id");
+    const { relations } = this.__orm;
+    if (relations.criticColumn === undefined) {
+      relations.criticColumn = hasOneToOne(
+        this as any as Critic,
+        criticColumnMeta,
+        "criticColumn",
+        "critic",
+        "critic_id",
+      );
+      if (this.isNewEntity) {
+        relations.criticColumn.initializeForNewEntity?.();
+      }
     }
-    return this.#criticColumn;
+    return relations.criticColumn as any;
   }
 }

--- a/packages/tests/integration/src/entities/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticCodegen.ts
@@ -124,25 +124,9 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: CriticIdsOpts;
     factoryOptsType: Parameters<typeof newCritic>[1];
   };
-
-  readonly favoriteLargePublisher: ManyToOneReference<Critic, LargePublisher, undefined> = hasOne(
-    largePublisherMeta,
-    "favoriteLargePublisher",
-    "critics",
-  );
-
-  readonly group: ManyToOneReference<Critic, PublisherGroup, undefined> = hasOne(
-    publisherGroupMeta,
-    "group",
-    "critics",
-  );
-
-  readonly criticColumn: OneToOneReference<Critic, CriticColumn> = hasOneToOne(
-    criticColumnMeta,
-    "criticColumn",
-    "critic",
-    "critic_id",
-  );
+  #favoriteLargePublisher: ManyToOneReference<Critic, LargePublisher, undefined> | undefined = undefined;
+  #group: ManyToOneReference<Critic, PublisherGroup, undefined> | undefined = undefined;
+  #criticColumn: OneToOneReference<Critic, CriticColumn> | undefined = undefined;
 
   constructor(em: EntityManager, opts: CriticOpts) {
     super(em, criticMeta, CriticCodegen.defaultValues, opts);
@@ -213,5 +197,28 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Critic>>(hint: H): this is Loaded<Critic, H> {
     return isLoaded(this as any as Critic, hint);
+  }
+
+  get favoriteLargePublisher(): ManyToOneReference<Critic, LargePublisher, undefined> {
+    return this.#favoriteLargePublisher ??= hasOne(
+      this as any as Critic,
+      largePublisherMeta,
+      "favoriteLargePublisher",
+      "critics",
+    );
+  }
+
+  get group(): ManyToOneReference<Critic, PublisherGroup, undefined> {
+    return this.#group ??= hasOne(this as any as Critic, publisherGroupMeta, "group", "critics");
+  }
+
+  get criticColumn(): OneToOneReference<Critic, CriticColumn> {
+    return this.#criticColumn ??= hasOneToOne(
+      this as any as Critic,
+      criticColumnMeta,
+      "criticColumn",
+      "critic",
+      "critic_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticCodegen.ts
@@ -205,9 +205,6 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
         "favoriteLargePublisher",
         "critics",
       );
-      if (this.isNewEntity) {
-        relations.favoriteLargePublisher.initializeForNewEntity?.();
-      }
     }
     return relations.favoriteLargePublisher as any;
   }
@@ -216,9 +213,6 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.group === undefined) {
       relations.group = hasOne(this as any as Critic, publisherGroupMeta, "group", "critics");
-      if (this.isNewEntity) {
-        relations.group.initializeForNewEntity?.();
-      }
     }
     return relations.group as any;
   }
@@ -233,9 +227,6 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
         "critic",
         "critic_id",
       );
-      if (this.isNewEntity) {
-        relations.criticColumn.initializeForNewEntity?.();
-      }
     }
     return relations.criticColumn as any;
   }

--- a/packages/tests/integration/src/entities/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticCodegen.ts
@@ -198,36 +198,27 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
 
   get favoriteLargePublisher(): ManyToOneReference<Critic, LargePublisher, undefined> {
     const { relations } = this.__orm;
-    if (relations.favoriteLargePublisher === undefined) {
-      relations.favoriteLargePublisher = hasOne(
-        this as any as Critic,
-        largePublisherMeta,
-        "favoriteLargePublisher",
-        "critics",
-      );
-    }
-    return relations.favoriteLargePublisher as any;
+    return relations.favoriteLargePublisher ??= hasOne(
+      this as any as Critic,
+      largePublisherMeta,
+      "favoriteLargePublisher",
+      "critics",
+    );
   }
 
   get group(): ManyToOneReference<Critic, PublisherGroup, undefined> {
     const { relations } = this.__orm;
-    if (relations.group === undefined) {
-      relations.group = hasOne(this as any as Critic, publisherGroupMeta, "group", "critics");
-    }
-    return relations.group as any;
+    return relations.group ??= hasOne(this as any as Critic, publisherGroupMeta, "group", "critics");
   }
 
   get criticColumn(): OneToOneReference<Critic, CriticColumn> {
     const { relations } = this.__orm;
-    if (relations.criticColumn === undefined) {
-      relations.criticColumn = hasOneToOne(
-        this as any as Critic,
-        criticColumnMeta,
-        "criticColumn",
-        "critic",
-        "critic_id",
-      );
-    }
-    return relations.criticColumn as any;
+    return relations.criticColumn ??= hasOneToOne(
+      this as any as Critic,
+      criticColumnMeta,
+      "criticColumn",
+      "critic",
+      "critic_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/CriticCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticCodegen.ts
@@ -200,25 +200,28 @@ export abstract class CriticCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get favoriteLargePublisher(): ManyToOneReference<Critic, LargePublisher, undefined> {
-    return this.#favoriteLargePublisher ??= hasOne(
-      this as any as Critic,
-      largePublisherMeta,
-      "favoriteLargePublisher",
-      "critics",
-    );
+    if (this.#favoriteLargePublisher === undefined) {
+      this.#favoriteLargePublisher = hasOne(
+        this as any as Critic,
+        largePublisherMeta,
+        "favoriteLargePublisher",
+        "critics",
+      );
+    }
+    return this.#favoriteLargePublisher;
   }
 
   get group(): ManyToOneReference<Critic, PublisherGroup, undefined> {
-    return this.#group ??= hasOne(this as any as Critic, publisherGroupMeta, "group", "critics");
+    if (this.#group === undefined) {
+      this.#group = hasOne(this as any as Critic, publisherGroupMeta, "group", "critics");
+    }
+    return this.#group;
   }
 
   get criticColumn(): OneToOneReference<Critic, CriticColumn> {
-    return this.#criticColumn ??= hasOneToOne(
-      this as any as Critic,
-      criticColumnMeta,
-      "criticColumn",
-      "critic",
-      "critic_id",
-    );
+    if (this.#criticColumn === undefined) {
+      this.#criticColumn = hasOneToOne(this as any as Critic, criticColumnMeta, "criticColumn", "critic", "critic_id");
+    }
+    return this.#criticColumn;
   }
 }

--- a/packages/tests/integration/src/entities/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticColumnCodegen.ts
@@ -98,7 +98,6 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
     optIdsType: CriticColumnIdsOpts;
     factoryOptsType: Parameters<typeof newCriticColumn>[1];
   };
-  #critic: ManyToOneReference<CriticColumn, Critic, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: CriticColumnOpts) {
     super(em, criticColumnMeta, CriticColumnCodegen.defaultValues, opts);
@@ -174,9 +173,13 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
   }
 
   get critic(): ManyToOneReference<CriticColumn, Critic, never> {
-    if (this.#critic === undefined) {
-      this.#critic = hasOne(this as any as CriticColumn, criticMeta, "critic", "criticColumn");
+    const { relations } = this.__orm;
+    if (relations.critic === undefined) {
+      relations.critic = hasOne(this as any as CriticColumn, criticMeta, "critic", "criticColumn");
+      if (this.isNewEntity) {
+        relations.critic.initializeForNewEntity?.();
+      }
     }
-    return this.#critic;
+    return relations.critic as any;
   }
 }

--- a/packages/tests/integration/src/entities/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticColumnCodegen.ts
@@ -174,9 +174,6 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
 
   get critic(): ManyToOneReference<CriticColumn, Critic, never> {
     const { relations } = this.__orm;
-    if (relations.critic === undefined) {
-      relations.critic = hasOne(this as any as CriticColumn, criticMeta, "critic", "criticColumn");
-    }
-    return relations.critic as any;
+    return relations.critic ??= hasOne(this as any as CriticColumn, criticMeta, "critic", "criticColumn");
   }
 }

--- a/packages/tests/integration/src/entities/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticColumnCodegen.ts
@@ -98,8 +98,7 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
     optIdsType: CriticColumnIdsOpts;
     factoryOptsType: Parameters<typeof newCriticColumn>[1];
   };
-
-  readonly critic: ManyToOneReference<CriticColumn, Critic, never> = hasOne(criticMeta, "critic", "criticColumn");
+  #critic: ManyToOneReference<CriticColumn, Critic, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: CriticColumnOpts) {
     super(em, criticColumnMeta, CriticColumnCodegen.defaultValues, opts);
@@ -172,5 +171,9 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
 
   isLoaded<H extends LoadHint<CriticColumn>>(hint: H): this is Loaded<CriticColumn, H> {
     return isLoaded(this as any as CriticColumn, hint);
+  }
+
+  get critic(): ManyToOneReference<CriticColumn, Critic, never> {
+    return this.#critic ??= hasOne(this as any as CriticColumn, criticMeta, "critic", "criticColumn");
   }
 }

--- a/packages/tests/integration/src/entities/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticColumnCodegen.ts
@@ -174,6 +174,9 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
   }
 
   get critic(): ManyToOneReference<CriticColumn, Critic, never> {
-    return this.#critic ??= hasOne(this as any as CriticColumn, criticMeta, "critic", "criticColumn");
+    if (this.#critic === undefined) {
+      this.#critic = hasOne(this as any as CriticColumn, criticMeta, "critic", "criticColumn");
+    }
+    return this.#critic;
   }
 }

--- a/packages/tests/integration/src/entities/CriticColumnCodegen.ts
+++ b/packages/tests/integration/src/entities/CriticColumnCodegen.ts
@@ -176,9 +176,6 @@ export abstract class CriticColumnCodegen extends BaseEntity<EntityManager, stri
     const { relations } = this.__orm;
     if (relations.critic === undefined) {
       relations.critic = hasOne(this as any as CriticColumn, criticMeta, "critic", "criticColumn");
-      if (this.isNewEntity) {
-        relations.critic.initializeForNewEntity?.();
-      }
     }
     return relations.critic as any;
   }

--- a/packages/tests/integration/src/entities/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/ImageCodegen.ts
@@ -134,9 +134,6 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: ImageIdsOpts;
     factoryOptsType: Parameters<typeof newImage>[1];
   };
-  #author: ManyToOneReference<Image, Author, undefined> | undefined = undefined;
-  #book: ManyToOneReference<Image, Book, undefined> | undefined = undefined;
-  #publisher: ManyToOneReference<Image, Publisher, undefined> | undefined = undefined;
 
   constructor(em: EntityManager, opts: ImageOpts) {
     super(em, imageMeta, ImageCodegen.defaultValues, opts);
@@ -234,23 +231,35 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get author(): ManyToOneReference<Image, Author, undefined> {
-    if (this.#author === undefined) {
-      this.#author = hasOne(this as any as Image, authorMeta, "author", "image");
+    const { relations } = this.__orm;
+    if (relations.author === undefined) {
+      relations.author = hasOne(this as any as Image, authorMeta, "author", "image");
+      if (this.isNewEntity) {
+        relations.author.initializeForNewEntity?.();
+      }
     }
-    return this.#author;
+    return relations.author as any;
   }
 
   get book(): ManyToOneReference<Image, Book, undefined> {
-    if (this.#book === undefined) {
-      this.#book = hasOne(this as any as Image, bookMeta, "book", "image");
+    const { relations } = this.__orm;
+    if (relations.book === undefined) {
+      relations.book = hasOne(this as any as Image, bookMeta, "book", "image");
+      if (this.isNewEntity) {
+        relations.book.initializeForNewEntity?.();
+      }
     }
-    return this.#book;
+    return relations.book as any;
   }
 
   get publisher(): ManyToOneReference<Image, Publisher, undefined> {
-    if (this.#publisher === undefined) {
-      this.#publisher = hasOne(this as any as Image, publisherMeta, "publisher", "images");
+    const { relations } = this.__orm;
+    if (relations.publisher === undefined) {
+      relations.publisher = hasOne(this as any as Image, publisherMeta, "publisher", "images");
+      if (this.isNewEntity) {
+        relations.publisher.initializeForNewEntity?.();
+      }
     }
-    return this.#publisher;
+    return relations.publisher as any;
   }
 }

--- a/packages/tests/integration/src/entities/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/ImageCodegen.ts
@@ -134,12 +134,9 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: ImageIdsOpts;
     factoryOptsType: Parameters<typeof newImage>[1];
   };
-
-  readonly author: ManyToOneReference<Image, Author, undefined> = hasOne(authorMeta, "author", "image");
-
-  readonly book: ManyToOneReference<Image, Book, undefined> = hasOne(bookMeta, "book", "image");
-
-  readonly publisher: ManyToOneReference<Image, Publisher, undefined> = hasOne(publisherMeta, "publisher", "images");
+  #author: ManyToOneReference<Image, Author, undefined> | undefined = undefined;
+  #book: ManyToOneReference<Image, Book, undefined> | undefined = undefined;
+  #publisher: ManyToOneReference<Image, Publisher, undefined> | undefined = undefined;
 
   constructor(em: EntityManager, opts: ImageOpts) {
     super(em, imageMeta, ImageCodegen.defaultValues, opts);
@@ -234,5 +231,17 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Image>>(hint: H): this is Loaded<Image, H> {
     return isLoaded(this as any as Image, hint);
+  }
+
+  get author(): ManyToOneReference<Image, Author, undefined> {
+    return this.#author ??= hasOne(this as any as Image, authorMeta, "author", "image");
+  }
+
+  get book(): ManyToOneReference<Image, Book, undefined> {
+    return this.#book ??= hasOne(this as any as Image, bookMeta, "book", "image");
+  }
+
+  get publisher(): ManyToOneReference<Image, Publisher, undefined> {
+    return this.#publisher ??= hasOne(this as any as Image, publisherMeta, "publisher", "images");
   }
 }

--- a/packages/tests/integration/src/entities/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/ImageCodegen.ts
@@ -232,25 +232,16 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
 
   get author(): ManyToOneReference<Image, Author, undefined> {
     const { relations } = this.__orm;
-    if (relations.author === undefined) {
-      relations.author = hasOne(this as any as Image, authorMeta, "author", "image");
-    }
-    return relations.author as any;
+    return relations.author ??= hasOne(this as any as Image, authorMeta, "author", "image");
   }
 
   get book(): ManyToOneReference<Image, Book, undefined> {
     const { relations } = this.__orm;
-    if (relations.book === undefined) {
-      relations.book = hasOne(this as any as Image, bookMeta, "book", "image");
-    }
-    return relations.book as any;
+    return relations.book ??= hasOne(this as any as Image, bookMeta, "book", "image");
   }
 
   get publisher(): ManyToOneReference<Image, Publisher, undefined> {
     const { relations } = this.__orm;
-    if (relations.publisher === undefined) {
-      relations.publisher = hasOne(this as any as Image, publisherMeta, "publisher", "images");
-    }
-    return relations.publisher as any;
+    return relations.publisher ??= hasOne(this as any as Image, publisherMeta, "publisher", "images");
   }
 }

--- a/packages/tests/integration/src/entities/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/ImageCodegen.ts
@@ -234,14 +234,23 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get author(): ManyToOneReference<Image, Author, undefined> {
-    return this.#author ??= hasOne(this as any as Image, authorMeta, "author", "image");
+    if (this.#author === undefined) {
+      this.#author = hasOne(this as any as Image, authorMeta, "author", "image");
+    }
+    return this.#author;
   }
 
   get book(): ManyToOneReference<Image, Book, undefined> {
-    return this.#book ??= hasOne(this as any as Image, bookMeta, "book", "image");
+    if (this.#book === undefined) {
+      this.#book = hasOne(this as any as Image, bookMeta, "book", "image");
+    }
+    return this.#book;
   }
 
   get publisher(): ManyToOneReference<Image, Publisher, undefined> {
-    return this.#publisher ??= hasOne(this as any as Image, publisherMeta, "publisher", "images");
+    if (this.#publisher === undefined) {
+      this.#publisher = hasOne(this as any as Image, publisherMeta, "publisher", "images");
+    }
+    return this.#publisher;
   }
 }

--- a/packages/tests/integration/src/entities/ImageCodegen.ts
+++ b/packages/tests/integration/src/entities/ImageCodegen.ts
@@ -234,9 +234,6 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.author === undefined) {
       relations.author = hasOne(this as any as Image, authorMeta, "author", "image");
-      if (this.isNewEntity) {
-        relations.author.initializeForNewEntity?.();
-      }
     }
     return relations.author as any;
   }
@@ -245,9 +242,6 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.book === undefined) {
       relations.book = hasOne(this as any as Image, bookMeta, "book", "image");
-      if (this.isNewEntity) {
-        relations.book.initializeForNewEntity?.();
-      }
     }
     return relations.book as any;
   }
@@ -256,9 +250,6 @@ export abstract class ImageCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.publisher === undefined) {
       relations.publisher = hasOne(this as any as Image, publisherMeta, "publisher", "images");
-      if (this.isNewEntity) {
-        relations.publisher.initializeForNewEntity?.();
-      }
     }
     return relations.publisher as any;
   }

--- a/packages/tests/integration/src/entities/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/LargePublisherCodegen.ts
@@ -92,7 +92,6 @@ export abstract class LargePublisherCodegen extends Publisher {
     optIdsType: LargePublisherIdsOpts;
     factoryOptsType: Parameters<typeof newLargePublisher>[1];
   };
-  #critics: Collection<LargePublisher, Critic> | undefined = undefined;
 
   constructor(em: EntityManager, opts: LargePublisherOpts) {
     // @ts-ignore
@@ -161,8 +160,9 @@ export abstract class LargePublisherCodegen extends Publisher {
   }
 
   get critics(): Collection<LargePublisher, Critic> {
-    if (this.#critics === undefined) {
-      this.#critics = hasMany(
+    const { relations } = this.__orm;
+    if (relations.critics === undefined) {
+      relations.critics = hasMany(
         this as any as LargePublisher,
         criticMeta,
         "critics",
@@ -170,7 +170,10 @@ export abstract class LargePublisherCodegen extends Publisher {
         "favorite_large_publisher_id",
         undefined,
       );
+      if (this.isNewEntity) {
+        relations.critics.initializeForNewEntity?.();
+      }
     }
-    return this.#critics;
+    return relations.critics as any;
   }
 }

--- a/packages/tests/integration/src/entities/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/LargePublisherCodegen.ts
@@ -161,13 +161,16 @@ export abstract class LargePublisherCodegen extends Publisher {
   }
 
   get critics(): Collection<LargePublisher, Critic> {
-    return this.#critics ??= hasMany(
-      this as any as LargePublisher,
-      criticMeta,
-      "critics",
-      "favoriteLargePublisher",
-      "favorite_large_publisher_id",
-      undefined,
-    );
+    if (this.#critics === undefined) {
+      this.#critics = hasMany(
+        this as any as LargePublisher,
+        criticMeta,
+        "critics",
+        "favoriteLargePublisher",
+        "favorite_large_publisher_id",
+        undefined,
+      );
+    }
+    return this.#critics;
   }
 }

--- a/packages/tests/integration/src/entities/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/LargePublisherCodegen.ts
@@ -170,9 +170,6 @@ export abstract class LargePublisherCodegen extends Publisher {
         "favorite_large_publisher_id",
         undefined,
       );
-      if (this.isNewEntity) {
-        relations.critics.initializeForNewEntity?.();
-      }
     }
     return relations.critics as any;
   }

--- a/packages/tests/integration/src/entities/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/LargePublisherCodegen.ts
@@ -92,14 +92,7 @@ export abstract class LargePublisherCodegen extends Publisher {
     optIdsType: LargePublisherIdsOpts;
     factoryOptsType: Parameters<typeof newLargePublisher>[1];
   };
-
-  readonly critics: Collection<LargePublisher, Critic> = hasMany(
-    criticMeta,
-    "critics",
-    "favoriteLargePublisher",
-    "favorite_large_publisher_id",
-    undefined,
-  );
+  #critics: Collection<LargePublisher, Critic> | undefined = undefined;
 
   constructor(em: EntityManager, opts: LargePublisherOpts) {
     // @ts-ignore
@@ -165,5 +158,16 @@ export abstract class LargePublisherCodegen extends Publisher {
 
   isLoaded<H extends LoadHint<LargePublisher>>(hint: H): this is Loaded<LargePublisher | Publisher, H> {
     return isLoaded(this as any as LargePublisher, hint);
+  }
+
+  get critics(): Collection<LargePublisher, Critic> {
+    return this.#critics ??= hasMany(
+      this as any as LargePublisher,
+      criticMeta,
+      "critics",
+      "favoriteLargePublisher",
+      "favorite_large_publisher_id",
+      undefined,
+    );
   }
 }

--- a/packages/tests/integration/src/entities/LargePublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/LargePublisherCodegen.ts
@@ -161,16 +161,13 @@ export abstract class LargePublisherCodegen extends Publisher {
 
   get critics(): Collection<LargePublisher, Critic> {
     const { relations } = this.__orm;
-    if (relations.critics === undefined) {
-      relations.critics = hasMany(
-        this as any as LargePublisher,
-        criticMeta,
-        "critics",
-        "favoriteLargePublisher",
-        "favorite_large_publisher_id",
-        undefined,
-      );
-    }
-    return relations.critics as any;
+    return relations.critics ??= hasMany(
+      this as any as LargePublisher,
+      criticMeta,
+      "critics",
+      "favoriteLargePublisher",
+      "favorite_large_publisher_id",
+      undefined,
+    );
   }
 }

--- a/packages/tests/integration/src/entities/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherCodegen.ts
@@ -178,47 +178,12 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
     optIdsType: PublisherIdsOpts;
     factoryOptsType: Parameters<typeof newPublisher>[1];
   };
-
-  readonly authors: Collection<Publisher, Author> = hasMany(
-    authorMeta,
-    "authors",
-    "publisher",
-    "publisher_id",
-    undefined,
-  );
-
-  readonly bookAdvances: Collection<Publisher, BookAdvance> = hasMany(
-    bookAdvanceMeta,
-    "bookAdvances",
-    "publisher",
-    "publisher_id",
-    undefined,
-  );
-
-  readonly comments: Collection<Publisher, Comment> = hasMany(
-    commentMeta,
-    "comments",
-    "parent",
-    "parent_publisher_id",
-    undefined,
-  );
-
-  readonly images: Collection<Publisher, Image> = hasMany(imageMeta, "images", "publisher", "publisher_id", undefined);
-
-  readonly group: ManyToOneReference<Publisher, PublisherGroup, undefined> = hasOne(
-    publisherGroupMeta,
-    "group",
-    "publishers",
-  );
-
-  readonly tags: Collection<Publisher, Tag> = hasManyToMany(
-    "publishers_to_tags",
-    "tags",
-    "publisher_id",
-    tagMeta,
-    "publishers",
-    "tag_id",
-  );
+  #authors: Collection<Publisher, Author> | undefined = undefined;
+  #bookAdvances: Collection<Publisher, BookAdvance> | undefined = undefined;
+  #comments: Collection<Publisher, Comment> | undefined = undefined;
+  #images: Collection<Publisher, Image> | undefined = undefined;
+  #group: ManyToOneReference<Publisher, PublisherGroup, undefined> | undefined = undefined;
+  #tags: Collection<Publisher, Tag> | undefined = undefined;
 
   constructor(em: EntityManager, opts: PublisherOpts) {
     if (arguments.length === 4) {
@@ -365,5 +330,65 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
 
   isLoaded<H extends LoadHint<Publisher>>(hint: H): this is Loaded<Publisher, H> {
     return isLoaded(this as any as Publisher, hint);
+  }
+
+  get authors(): Collection<Publisher, Author> {
+    return this.#authors ??= hasMany(
+      this as any as Publisher,
+      authorMeta,
+      "authors",
+      "publisher",
+      "publisher_id",
+      undefined,
+    );
+  }
+
+  get bookAdvances(): Collection<Publisher, BookAdvance> {
+    return this.#bookAdvances ??= hasMany(
+      this as any as Publisher,
+      bookAdvanceMeta,
+      "bookAdvances",
+      "publisher",
+      "publisher_id",
+      undefined,
+    );
+  }
+
+  get comments(): Collection<Publisher, Comment> {
+    return this.#comments ??= hasMany(
+      this as any as Publisher,
+      commentMeta,
+      "comments",
+      "parent",
+      "parent_publisher_id",
+      undefined,
+    );
+  }
+
+  get images(): Collection<Publisher, Image> {
+    return this.#images ??= hasMany(
+      this as any as Publisher,
+      imageMeta,
+      "images",
+      "publisher",
+      "publisher_id",
+      undefined,
+    );
+  }
+
+  get group(): ManyToOneReference<Publisher, PublisherGroup, undefined> {
+    return this.#group ??= hasOne(this as any as Publisher, publisherGroupMeta, "group", "publishers");
+  }
+
+  get tags(): Collection<Publisher, Tag> {
+    return this.#tags ??= hasManyToMany(
+      this as any as Publisher,
+      "publishers_to_tags",
+      "tags",
+      "publisher_id",
+      tagMeta,
+      "publishers",
+      "tag_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherCodegen.ts
@@ -328,78 +328,67 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
 
   get authors(): Collection<Publisher, Author> {
     const { relations } = this.__orm;
-    if (relations.authors === undefined) {
-      relations.authors = hasMany(
-        this as any as Publisher,
-        authorMeta,
-        "authors",
-        "publisher",
-        "publisher_id",
-        undefined,
-      );
-    }
-    return relations.authors as any;
+    return relations.authors ??= hasMany(
+      this as any as Publisher,
+      authorMeta,
+      "authors",
+      "publisher",
+      "publisher_id",
+      undefined,
+    );
   }
 
   get bookAdvances(): Collection<Publisher, BookAdvance> {
     const { relations } = this.__orm;
-    if (relations.bookAdvances === undefined) {
-      relations.bookAdvances = hasMany(
-        this as any as Publisher,
-        bookAdvanceMeta,
-        "bookAdvances",
-        "publisher",
-        "publisher_id",
-        undefined,
-      );
-    }
-    return relations.bookAdvances as any;
+    return relations.bookAdvances ??= hasMany(
+      this as any as Publisher,
+      bookAdvanceMeta,
+      "bookAdvances",
+      "publisher",
+      "publisher_id",
+      undefined,
+    );
   }
 
   get comments(): Collection<Publisher, Comment> {
     const { relations } = this.__orm;
-    if (relations.comments === undefined) {
-      relations.comments = hasMany(
-        this as any as Publisher,
-        commentMeta,
-        "comments",
-        "parent",
-        "parent_publisher_id",
-        undefined,
-      );
-    }
-    return relations.comments as any;
+    return relations.comments ??= hasMany(
+      this as any as Publisher,
+      commentMeta,
+      "comments",
+      "parent",
+      "parent_publisher_id",
+      undefined,
+    );
   }
 
   get images(): Collection<Publisher, Image> {
     const { relations } = this.__orm;
-    if (relations.images === undefined) {
-      relations.images = hasMany(this as any as Publisher, imageMeta, "images", "publisher", "publisher_id", undefined);
-    }
-    return relations.images as any;
+    return relations.images ??= hasMany(
+      this as any as Publisher,
+      imageMeta,
+      "images",
+      "publisher",
+      "publisher_id",
+      undefined,
+    );
   }
 
   get group(): ManyToOneReference<Publisher, PublisherGroup, undefined> {
     const { relations } = this.__orm;
-    if (relations.group === undefined) {
-      relations.group = hasOne(this as any as Publisher, publisherGroupMeta, "group", "publishers");
-    }
-    return relations.group as any;
+    return relations.group ??= hasOne(this as any as Publisher, publisherGroupMeta, "group", "publishers");
   }
 
   get tags(): Collection<Publisher, Tag> {
     const { relations } = this.__orm;
-    if (relations.tags === undefined) {
-      relations.tags = hasManyToMany(
-        this as any as Publisher,
-        "publishers_to_tags",
-        "tags",
-        "publisher_id",
-        tagMeta,
-        "publishers",
-        "tag_id",
-      );
-    }
-    return relations.tags as any;
+    return relations.tags ??= hasManyToMany(
+      this as any as Publisher,
+      "publishers_to_tags",
+      "tags",
+      "publisher_id",
+      tagMeta,
+      "publishers",
+      "tag_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherCodegen.ts
@@ -178,12 +178,6 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
     optIdsType: PublisherIdsOpts;
     factoryOptsType: Parameters<typeof newPublisher>[1];
   };
-  #authors: Collection<Publisher, Author> | undefined = undefined;
-  #bookAdvances: Collection<Publisher, BookAdvance> | undefined = undefined;
-  #comments: Collection<Publisher, Comment> | undefined = undefined;
-  #images: Collection<Publisher, Image> | undefined = undefined;
-  #group: ManyToOneReference<Publisher, PublisherGroup, undefined> | undefined = undefined;
-  #tags: Collection<Publisher, Tag> | undefined = undefined;
 
   constructor(em: EntityManager, opts: PublisherOpts) {
     if (arguments.length === 4) {
@@ -333,15 +327,27 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
   }
 
   get authors(): Collection<Publisher, Author> {
-    if (this.#authors === undefined) {
-      this.#authors = hasMany(this as any as Publisher, authorMeta, "authors", "publisher", "publisher_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.authors === undefined) {
+      relations.authors = hasMany(
+        this as any as Publisher,
+        authorMeta,
+        "authors",
+        "publisher",
+        "publisher_id",
+        undefined,
+      );
+      if (this.isNewEntity) {
+        relations.authors.initializeForNewEntity?.();
+      }
     }
-    return this.#authors;
+    return relations.authors as any;
   }
 
   get bookAdvances(): Collection<Publisher, BookAdvance> {
-    if (this.#bookAdvances === undefined) {
-      this.#bookAdvances = hasMany(
+    const { relations } = this.__orm;
+    if (relations.bookAdvances === undefined) {
+      relations.bookAdvances = hasMany(
         this as any as Publisher,
         bookAdvanceMeta,
         "bookAdvances",
@@ -349,13 +355,17 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
         "publisher_id",
         undefined,
       );
+      if (this.isNewEntity) {
+        relations.bookAdvances.initializeForNewEntity?.();
+      }
     }
-    return this.#bookAdvances;
+    return relations.bookAdvances as any;
   }
 
   get comments(): Collection<Publisher, Comment> {
-    if (this.#comments === undefined) {
-      this.#comments = hasMany(
+    const { relations } = this.__orm;
+    if (relations.comments === undefined) {
+      relations.comments = hasMany(
         this as any as Publisher,
         commentMeta,
         "comments",
@@ -363,27 +373,39 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
         "parent_publisher_id",
         undefined,
       );
+      if (this.isNewEntity) {
+        relations.comments.initializeForNewEntity?.();
+      }
     }
-    return this.#comments;
+    return relations.comments as any;
   }
 
   get images(): Collection<Publisher, Image> {
-    if (this.#images === undefined) {
-      this.#images = hasMany(this as any as Publisher, imageMeta, "images", "publisher", "publisher_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.images === undefined) {
+      relations.images = hasMany(this as any as Publisher, imageMeta, "images", "publisher", "publisher_id", undefined);
+      if (this.isNewEntity) {
+        relations.images.initializeForNewEntity?.();
+      }
     }
-    return this.#images;
+    return relations.images as any;
   }
 
   get group(): ManyToOneReference<Publisher, PublisherGroup, undefined> {
-    if (this.#group === undefined) {
-      this.#group = hasOne(this as any as Publisher, publisherGroupMeta, "group", "publishers");
+    const { relations } = this.__orm;
+    if (relations.group === undefined) {
+      relations.group = hasOne(this as any as Publisher, publisherGroupMeta, "group", "publishers");
+      if (this.isNewEntity) {
+        relations.group.initializeForNewEntity?.();
+      }
     }
-    return this.#group;
+    return relations.group as any;
   }
 
   get tags(): Collection<Publisher, Tag> {
-    if (this.#tags === undefined) {
-      this.#tags = hasManyToMany(
+    const { relations } = this.__orm;
+    if (relations.tags === undefined) {
+      relations.tags = hasManyToMany(
         this as any as Publisher,
         "publishers_to_tags",
         "tags",
@@ -392,7 +414,10 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
         "publishers",
         "tag_id",
       );
+      if (this.isNewEntity) {
+        relations.tags.initializeForNewEntity?.();
+      }
     }
-    return this.#tags;
+    return relations.tags as any;
   }
 }

--- a/packages/tests/integration/src/entities/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherCodegen.ts
@@ -333,62 +333,66 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
   }
 
   get authors(): Collection<Publisher, Author> {
-    return this.#authors ??= hasMany(
-      this as any as Publisher,
-      authorMeta,
-      "authors",
-      "publisher",
-      "publisher_id",
-      undefined,
-    );
+    if (this.#authors === undefined) {
+      this.#authors = hasMany(this as any as Publisher, authorMeta, "authors", "publisher", "publisher_id", undefined);
+    }
+    return this.#authors;
   }
 
   get bookAdvances(): Collection<Publisher, BookAdvance> {
-    return this.#bookAdvances ??= hasMany(
-      this as any as Publisher,
-      bookAdvanceMeta,
-      "bookAdvances",
-      "publisher",
-      "publisher_id",
-      undefined,
-    );
+    if (this.#bookAdvances === undefined) {
+      this.#bookAdvances = hasMany(
+        this as any as Publisher,
+        bookAdvanceMeta,
+        "bookAdvances",
+        "publisher",
+        "publisher_id",
+        undefined,
+      );
+    }
+    return this.#bookAdvances;
   }
 
   get comments(): Collection<Publisher, Comment> {
-    return this.#comments ??= hasMany(
-      this as any as Publisher,
-      commentMeta,
-      "comments",
-      "parent",
-      "parent_publisher_id",
-      undefined,
-    );
+    if (this.#comments === undefined) {
+      this.#comments = hasMany(
+        this as any as Publisher,
+        commentMeta,
+        "comments",
+        "parent",
+        "parent_publisher_id",
+        undefined,
+      );
+    }
+    return this.#comments;
   }
 
   get images(): Collection<Publisher, Image> {
-    return this.#images ??= hasMany(
-      this as any as Publisher,
-      imageMeta,
-      "images",
-      "publisher",
-      "publisher_id",
-      undefined,
-    );
+    if (this.#images === undefined) {
+      this.#images = hasMany(this as any as Publisher, imageMeta, "images", "publisher", "publisher_id", undefined);
+    }
+    return this.#images;
   }
 
   get group(): ManyToOneReference<Publisher, PublisherGroup, undefined> {
-    return this.#group ??= hasOne(this as any as Publisher, publisherGroupMeta, "group", "publishers");
+    if (this.#group === undefined) {
+      this.#group = hasOne(this as any as Publisher, publisherGroupMeta, "group", "publishers");
+    }
+    return this.#group;
   }
 
   get tags(): Collection<Publisher, Tag> {
-    return this.#tags ??= hasManyToMany(
-      this as any as Publisher,
-      "publishers_to_tags",
-      "tags",
-      "publisher_id",
-      tagMeta,
-      "publishers",
-      "tag_id",
-    );
+    if (this.#tags === undefined) {
+      this.#tags = hasManyToMany(
+        this as any as Publisher,
+        "publishers_to_tags",
+        "tags",
+        "publisher_id",
+        tagMeta,
+        "publishers",
+        "tag_id",
+      );
+    }
+    return this.#tags;
   }
 }

--- a/packages/tests/integration/src/entities/PublisherCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherCodegen.ts
@@ -337,9 +337,6 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
         "publisher_id",
         undefined,
       );
-      if (this.isNewEntity) {
-        relations.authors.initializeForNewEntity?.();
-      }
     }
     return relations.authors as any;
   }
@@ -355,9 +352,6 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
         "publisher_id",
         undefined,
       );
-      if (this.isNewEntity) {
-        relations.bookAdvances.initializeForNewEntity?.();
-      }
     }
     return relations.bookAdvances as any;
   }
@@ -373,9 +367,6 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
         "parent_publisher_id",
         undefined,
       );
-      if (this.isNewEntity) {
-        relations.comments.initializeForNewEntity?.();
-      }
     }
     return relations.comments as any;
   }
@@ -384,9 +375,6 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
     const { relations } = this.__orm;
     if (relations.images === undefined) {
       relations.images = hasMany(this as any as Publisher, imageMeta, "images", "publisher", "publisher_id", undefined);
-      if (this.isNewEntity) {
-        relations.images.initializeForNewEntity?.();
-      }
     }
     return relations.images as any;
   }
@@ -395,9 +383,6 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
     const { relations } = this.__orm;
     if (relations.group === undefined) {
       relations.group = hasOne(this as any as Publisher, publisherGroupMeta, "group", "publishers");
-      if (this.isNewEntity) {
-        relations.group.initializeForNewEntity?.();
-      }
     }
     return relations.group as any;
   }
@@ -414,9 +399,6 @@ export abstract class PublisherCodegen extends BaseEntity<EntityManager, string>
         "publishers",
         "tag_id",
       );
-      if (this.isNewEntity) {
-        relations.tags.initializeForNewEntity?.();
-      }
     }
     return relations.tags as any;
   }

--- a/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
@@ -190,9 +190,6 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
         "group_id",
         undefined,
       );
-      if (this.isNewEntity) {
-        relations.publishers.initializeForNewEntity?.();
-      }
     }
     return relations.publishers as any;
   }
@@ -201,9 +198,6 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
     const { relations } = this.__orm;
     if (relations.critics === undefined) {
       relations.critics = hasLargeMany(this as any as PublisherGroup, criticMeta, "critics", "group", "group_id");
-      if (this.isNewEntity) {
-        relations.critics.initializeForNewEntity?.();
-      }
     }
     return relations.critics as any;
   }

--- a/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
@@ -181,24 +181,24 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
 
   get publishers(): Collection<PublisherGroup, Publisher> {
     const { relations } = this.__orm;
-    if (relations.publishers === undefined) {
-      relations.publishers = hasMany(
-        this as any as PublisherGroup,
-        publisherMeta,
-        "publishers",
-        "group",
-        "group_id",
-        undefined,
-      );
-    }
-    return relations.publishers as any;
+    return relations.publishers ??= hasMany(
+      this as any as PublisherGroup,
+      publisherMeta,
+      "publishers",
+      "group",
+      "group_id",
+      undefined,
+    );
   }
 
   get critics(): LargeCollection<PublisherGroup, Critic> {
     const { relations } = this.__orm;
-    if (relations.critics === undefined) {
-      relations.critics = hasLargeMany(this as any as PublisherGroup, criticMeta, "critics", "group", "group_id");
-    }
-    return relations.critics as any;
+    return relations.critics ??= hasLargeMany(
+      this as any as PublisherGroup,
+      criticMeta,
+      "critics",
+      "group",
+      "group_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
@@ -105,16 +105,8 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
     optIdsType: PublisherGroupIdsOpts;
     factoryOptsType: Parameters<typeof newPublisherGroup>[1];
   };
-
-  readonly publishers: Collection<PublisherGroup, Publisher> = hasMany(
-    publisherMeta,
-    "publishers",
-    "group",
-    "group_id",
-    undefined,
-  );
-
-  readonly critics: LargeCollection<PublisherGroup, Critic> = hasLargeMany(criticMeta, "critics", "group", "group_id");
+  #publishers: Collection<PublisherGroup, Publisher> | undefined = undefined;
+  #critics: LargeCollection<PublisherGroup, Critic> | undefined = undefined;
 
   constructor(em: EntityManager, opts: PublisherGroupOpts) {
     super(em, publisherGroupMeta, PublisherGroupCodegen.defaultValues, opts);
@@ -187,5 +179,20 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
 
   isLoaded<H extends LoadHint<PublisherGroup>>(hint: H): this is Loaded<PublisherGroup, H> {
     return isLoaded(this as any as PublisherGroup, hint);
+  }
+
+  get publishers(): Collection<PublisherGroup, Publisher> {
+    return this.#publishers ??= hasMany(
+      this as any as PublisherGroup,
+      publisherMeta,
+      "publishers",
+      "group",
+      "group_id",
+      undefined,
+    );
+  }
+
+  get critics(): LargeCollection<PublisherGroup, Critic> {
+    return this.#critics ??= hasLargeMany(this as any as PublisherGroup, criticMeta, "critics", "group", "group_id");
   }
 }

--- a/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
@@ -182,17 +182,23 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
   }
 
   get publishers(): Collection<PublisherGroup, Publisher> {
-    return this.#publishers ??= hasMany(
-      this as any as PublisherGroup,
-      publisherMeta,
-      "publishers",
-      "group",
-      "group_id",
-      undefined,
-    );
+    if (this.#publishers === undefined) {
+      this.#publishers = hasMany(
+        this as any as PublisherGroup,
+        publisherMeta,
+        "publishers",
+        "group",
+        "group_id",
+        undefined,
+      );
+    }
+    return this.#publishers;
   }
 
   get critics(): LargeCollection<PublisherGroup, Critic> {
-    return this.#critics ??= hasLargeMany(this as any as PublisherGroup, criticMeta, "critics", "group", "group_id");
+    if (this.#critics === undefined) {
+      this.#critics = hasLargeMany(this as any as PublisherGroup, criticMeta, "critics", "group", "group_id");
+    }
+    return this.#critics;
   }
 }

--- a/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
+++ b/packages/tests/integration/src/entities/PublisherGroupCodegen.ts
@@ -105,8 +105,6 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
     optIdsType: PublisherGroupIdsOpts;
     factoryOptsType: Parameters<typeof newPublisherGroup>[1];
   };
-  #publishers: Collection<PublisherGroup, Publisher> | undefined = undefined;
-  #critics: LargeCollection<PublisherGroup, Critic> | undefined = undefined;
 
   constructor(em: EntityManager, opts: PublisherGroupOpts) {
     super(em, publisherGroupMeta, PublisherGroupCodegen.defaultValues, opts);
@@ -182,8 +180,9 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
   }
 
   get publishers(): Collection<PublisherGroup, Publisher> {
-    if (this.#publishers === undefined) {
-      this.#publishers = hasMany(
+    const { relations } = this.__orm;
+    if (relations.publishers === undefined) {
+      relations.publishers = hasMany(
         this as any as PublisherGroup,
         publisherMeta,
         "publishers",
@@ -191,14 +190,21 @@ export abstract class PublisherGroupCodegen extends BaseEntity<EntityManager, st
         "group_id",
         undefined,
       );
+      if (this.isNewEntity) {
+        relations.publishers.initializeForNewEntity?.();
+      }
     }
-    return this.#publishers;
+    return relations.publishers as any;
   }
 
   get critics(): LargeCollection<PublisherGroup, Critic> {
-    if (this.#critics === undefined) {
-      this.#critics = hasLargeMany(this as any as PublisherGroup, criticMeta, "critics", "group", "group_id");
+    const { relations } = this.__orm;
+    if (relations.critics === undefined) {
+      relations.critics = hasLargeMany(this as any as PublisherGroup, criticMeta, "critics", "group", "group_id");
+      if (this.isNewEntity) {
+        relations.critics.initializeForNewEntity?.();
+      }
     }
-    return this.#critics;
+    return relations.critics as any;
   }
 }

--- a/packages/tests/integration/src/entities/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/TagCodegen.ts
@@ -184,49 +184,40 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
 
   get books(): Collection<Tag, Book> {
     const { relations } = this.__orm;
-    if (relations.books === undefined) {
-      relations.books = hasManyToMany(
-        this as any as Tag,
-        "books_to_tags",
-        "books",
-        "tag_id",
-        bookMeta,
-        "tags",
-        "book_id",
-      );
-    }
-    return relations.books as any;
+    return relations.books ??= hasManyToMany(
+      this as any as Tag,
+      "books_to_tags",
+      "books",
+      "tag_id",
+      bookMeta,
+      "tags",
+      "book_id",
+    );
   }
 
   get publishers(): Collection<Tag, Publisher> {
     const { relations } = this.__orm;
-    if (relations.publishers === undefined) {
-      relations.publishers = hasManyToMany(
-        this as any as Tag,
-        "publishers_to_tags",
-        "publishers",
-        "tag_id",
-        publisherMeta,
-        "tags",
-        "publisher_id",
-      );
-    }
-    return relations.publishers as any;
+    return relations.publishers ??= hasManyToMany(
+      this as any as Tag,
+      "publishers_to_tags",
+      "publishers",
+      "tag_id",
+      publisherMeta,
+      "tags",
+      "publisher_id",
+    );
   }
 
   get authors(): LargeCollection<Tag, Author> {
     const { relations } = this.__orm;
-    if (relations.authors === undefined) {
-      relations.authors = hasLargeManyToMany(
-        this as any as Tag,
-        "authors_to_tags",
-        "authors",
-        "tag_id",
-        authorMeta,
-        "tags",
-        "author_id",
-      );
-    }
-    return relations.authors as any;
+    return relations.authors ??= hasLargeManyToMany(
+      this as any as Tag,
+      "authors_to_tags",
+      "authors",
+      "tag_id",
+      authorMeta,
+      "tags",
+      "author_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/TagCodegen.ts
@@ -113,33 +113,9 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: TagIdsOpts;
     factoryOptsType: Parameters<typeof newTag>[1];
   };
-
-  readonly books: Collection<Tag, Book> = hasManyToMany(
-    "books_to_tags",
-    "books",
-    "tag_id",
-    bookMeta,
-    "tags",
-    "book_id",
-  );
-
-  readonly publishers: Collection<Tag, Publisher> = hasManyToMany(
-    "publishers_to_tags",
-    "publishers",
-    "tag_id",
-    publisherMeta,
-    "tags",
-    "publisher_id",
-  );
-
-  readonly authors: LargeCollection<Tag, Author> = hasLargeManyToMany(
-    "authors_to_tags",
-    "authors",
-    "tag_id",
-    authorMeta,
-    "tags",
-    "author_id",
-  );
+  #books: Collection<Tag, Book> | undefined = undefined;
+  #publishers: Collection<Tag, Publisher> | undefined = undefined;
+  #authors: LargeCollection<Tag, Author> | undefined = undefined;
 
   constructor(em: EntityManager, opts: TagOpts) {
     super(em, tagMeta, TagCodegen.defaultValues, opts);
@@ -207,5 +183,41 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Tag>>(hint: H): this is Loaded<Tag, H> {
     return isLoaded(this as any as Tag, hint);
+  }
+
+  get books(): Collection<Tag, Book> {
+    return this.#books ??= hasManyToMany(
+      this as any as Tag,
+      "books_to_tags",
+      "books",
+      "tag_id",
+      bookMeta,
+      "tags",
+      "book_id",
+    );
+  }
+
+  get publishers(): Collection<Tag, Publisher> {
+    return this.#publishers ??= hasManyToMany(
+      this as any as Tag,
+      "publishers_to_tags",
+      "publishers",
+      "tag_id",
+      publisherMeta,
+      "tags",
+      "publisher_id",
+    );
+  }
+
+  get authors(): LargeCollection<Tag, Author> {
+    return this.#authors ??= hasLargeManyToMany(
+      this as any as Tag,
+      "authors_to_tags",
+      "authors",
+      "tag_id",
+      authorMeta,
+      "tags",
+      "author_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/TagCodegen.ts
@@ -194,9 +194,6 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
         "tags",
         "book_id",
       );
-      if (this.isNewEntity) {
-        relations.books.initializeForNewEntity?.();
-      }
     }
     return relations.books as any;
   }
@@ -213,9 +210,6 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
         "tags",
         "publisher_id",
       );
-      if (this.isNewEntity) {
-        relations.publishers.initializeForNewEntity?.();
-      }
     }
     return relations.publishers as any;
   }
@@ -232,10 +226,6 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
         "tags",
         "author_id",
       );
-
-      if (this.isNewEntity) {
-        relations.authors.initializeForNewEntity?.();
-      }
     }
     return relations.authors as any;
   }

--- a/packages/tests/integration/src/entities/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/TagCodegen.ts
@@ -186,38 +186,40 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get books(): Collection<Tag, Book> {
-    return this.#books ??= hasManyToMany(
-      this as any as Tag,
-      "books_to_tags",
-      "books",
-      "tag_id",
-      bookMeta,
-      "tags",
-      "book_id",
-    );
+    if (this.#books === undefined) {
+      this.#books = hasManyToMany(this as any as Tag, "books_to_tags", "books", "tag_id", bookMeta, "tags", "book_id");
+    }
+    return this.#books;
   }
 
   get publishers(): Collection<Tag, Publisher> {
-    return this.#publishers ??= hasManyToMany(
-      this as any as Tag,
-      "publishers_to_tags",
-      "publishers",
-      "tag_id",
-      publisherMeta,
-      "tags",
-      "publisher_id",
-    );
+    if (this.#publishers === undefined) {
+      this.#publishers = hasManyToMany(
+        this as any as Tag,
+        "publishers_to_tags",
+        "publishers",
+        "tag_id",
+        publisherMeta,
+        "tags",
+        "publisher_id",
+      );
+    }
+    return this.#publishers;
   }
 
   get authors(): LargeCollection<Tag, Author> {
-    return this.#authors ??= hasLargeManyToMany(
-      this as any as Tag,
-      "authors_to_tags",
-      "authors",
-      "tag_id",
-      authorMeta,
-      "tags",
-      "author_id",
-    );
+    if (this.#authors === undefined) {
+      this.#authors = hasLargeManyToMany(
+        this as any as Tag,
+        "authors_to_tags",
+        "authors",
+        "tag_id",
+        authorMeta,
+        "tags",
+        "author_id",
+      );
+    }
+
+    return this.#authors;
   }
 }

--- a/packages/tests/integration/src/entities/TagCodegen.ts
+++ b/packages/tests/integration/src/entities/TagCodegen.ts
@@ -113,9 +113,6 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: TagIdsOpts;
     factoryOptsType: Parameters<typeof newTag>[1];
   };
-  #books: Collection<Tag, Book> | undefined = undefined;
-  #publishers: Collection<Tag, Publisher> | undefined = undefined;
-  #authors: LargeCollection<Tag, Author> | undefined = undefined;
 
   constructor(em: EntityManager, opts: TagOpts) {
     super(em, tagMeta, TagCodegen.defaultValues, opts);
@@ -186,15 +183,28 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get books(): Collection<Tag, Book> {
-    if (this.#books === undefined) {
-      this.#books = hasManyToMany(this as any as Tag, "books_to_tags", "books", "tag_id", bookMeta, "tags", "book_id");
+    const { relations } = this.__orm;
+    if (relations.books === undefined) {
+      relations.books = hasManyToMany(
+        this as any as Tag,
+        "books_to_tags",
+        "books",
+        "tag_id",
+        bookMeta,
+        "tags",
+        "book_id",
+      );
+      if (this.isNewEntity) {
+        relations.books.initializeForNewEntity?.();
+      }
     }
-    return this.#books;
+    return relations.books as any;
   }
 
   get publishers(): Collection<Tag, Publisher> {
-    if (this.#publishers === undefined) {
-      this.#publishers = hasManyToMany(
+    const { relations } = this.__orm;
+    if (relations.publishers === undefined) {
+      relations.publishers = hasManyToMany(
         this as any as Tag,
         "publishers_to_tags",
         "publishers",
@@ -203,13 +213,17 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
         "tags",
         "publisher_id",
       );
+      if (this.isNewEntity) {
+        relations.publishers.initializeForNewEntity?.();
+      }
     }
-    return this.#publishers;
+    return relations.publishers as any;
   }
 
   get authors(): LargeCollection<Tag, Author> {
-    if (this.#authors === undefined) {
-      this.#authors = hasLargeManyToMany(
+    const { relations } = this.__orm;
+    if (relations.authors === undefined) {
+      relations.authors = hasLargeManyToMany(
         this as any as Tag,
         "authors_to_tags",
         "authors",
@@ -218,8 +232,11 @@ export abstract class TagCodegen extends BaseEntity<EntityManager, string> {
         "tags",
         "author_id",
       );
-    }
 
-    return this.#authors;
+      if (this.isNewEntity) {
+        relations.authors.initializeForNewEntity?.();
+      }
+    }
+    return relations.authors as any;
   }
 }

--- a/packages/tests/integration/src/entities/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/UserCodegen.ts
@@ -142,29 +142,9 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: UserIdsOpts;
     factoryOptsType: Parameters<typeof newUser>[1];
   };
-
-  readonly createdComments: Collection<User, Comment> = hasMany(
-    commentMeta,
-    "createdComments",
-    "user",
-    "user_id",
-    undefined,
-  );
-
-  readonly authorManyToOne: ManyToOneReference<User, Author, undefined> = hasOne(
-    authorMeta,
-    "authorManyToOne",
-    "userOneToOne",
-  );
-
-  readonly likedComments: Collection<User, Comment> = hasManyToMany(
-    "users_to_comments",
-    "likedComments",
-    "liked_by_user_id",
-    commentMeta,
-    "likedByUsers",
-    "comment_id",
-  );
+  #createdComments: Collection<User, Comment> | undefined = undefined;
+  #authorManyToOne: ManyToOneReference<User, Author, undefined> | undefined = undefined;
+  #likedComments: Collection<User, Comment> | undefined = undefined;
 
   constructor(em: EntityManager, opts: UserOpts) {
     super(em, userMeta, UserCodegen.defaultValues, opts);
@@ -264,5 +244,32 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<User>>(hint: H): this is Loaded<User, H> {
     return isLoaded(this as any as User, hint);
+  }
+
+  get createdComments(): Collection<User, Comment> {
+    return this.#createdComments ??= hasMany(
+      this as any as User,
+      commentMeta,
+      "createdComments",
+      "user",
+      "user_id",
+      undefined,
+    );
+  }
+
+  get authorManyToOne(): ManyToOneReference<User, Author, undefined> {
+    return this.#authorManyToOne ??= hasOne(this as any as User, authorMeta, "authorManyToOne", "userOneToOne");
+  }
+
+  get likedComments(): Collection<User, Comment> {
+    return this.#likedComments ??= hasManyToMany(
+      this as any as User,
+      "users_to_comments",
+      "likedComments",
+      "liked_by_user_id",
+      commentMeta,
+      "likedByUsers",
+      "comment_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/UserCodegen.ts
@@ -254,9 +254,6 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
         "user_id",
         undefined,
       );
-      if (this.isNewEntity) {
-        relations.createdComments.initializeForNewEntity?.();
-      }
     }
     return relations.createdComments as any;
   }
@@ -265,9 +262,6 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.authorManyToOne === undefined) {
       relations.authorManyToOne = hasOne(this as any as User, authorMeta, "authorManyToOne", "userOneToOne");
-      if (this.isNewEntity) {
-        relations.authorManyToOne.initializeForNewEntity?.();
-      }
     }
     return relations.authorManyToOne as any;
   }
@@ -284,9 +278,6 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
         "likedByUsers",
         "comment_id",
       );
-      if (this.isNewEntity) {
-        relations.likedComments.initializeForNewEntity?.();
-      }
     }
     return relations.likedComments as any;
   }

--- a/packages/tests/integration/src/entities/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/UserCodegen.ts
@@ -142,9 +142,6 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: UserIdsOpts;
     factoryOptsType: Parameters<typeof newUser>[1];
   };
-  #createdComments: Collection<User, Comment> | undefined = undefined;
-  #authorManyToOne: ManyToOneReference<User, Author, undefined> | undefined = undefined;
-  #likedComments: Collection<User, Comment> | undefined = undefined;
 
   constructor(em: EntityManager, opts: UserOpts) {
     super(em, userMeta, UserCodegen.defaultValues, opts);
@@ -247,8 +244,9 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get createdComments(): Collection<User, Comment> {
-    if (this.#createdComments === undefined) {
-      this.#createdComments = hasMany(
+    const { relations } = this.__orm;
+    if (relations.createdComments === undefined) {
+      relations.createdComments = hasMany(
         this as any as User,
         commentMeta,
         "createdComments",
@@ -256,20 +254,28 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
         "user_id",
         undefined,
       );
+      if (this.isNewEntity) {
+        relations.createdComments.initializeForNewEntity?.();
+      }
     }
-    return this.#createdComments;
+    return relations.createdComments as any;
   }
 
   get authorManyToOne(): ManyToOneReference<User, Author, undefined> {
-    if (this.#authorManyToOne === undefined) {
-      this.#authorManyToOne = hasOne(this as any as User, authorMeta, "authorManyToOne", "userOneToOne");
+    const { relations } = this.__orm;
+    if (relations.authorManyToOne === undefined) {
+      relations.authorManyToOne = hasOne(this as any as User, authorMeta, "authorManyToOne", "userOneToOne");
+      if (this.isNewEntity) {
+        relations.authorManyToOne.initializeForNewEntity?.();
+      }
     }
-    return this.#authorManyToOne;
+    return relations.authorManyToOne as any;
   }
 
   get likedComments(): Collection<User, Comment> {
-    if (this.#likedComments === undefined) {
-      this.#likedComments = hasManyToMany(
+    const { relations } = this.__orm;
+    if (relations.likedComments === undefined) {
+      relations.likedComments = hasManyToMany(
         this as any as User,
         "users_to_comments",
         "likedComments",
@@ -278,7 +284,10 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
         "likedByUsers",
         "comment_id",
       );
+      if (this.isNewEntity) {
+        relations.likedComments.initializeForNewEntity?.();
+      }
     }
-    return this.#likedComments;
+    return relations.likedComments as any;
   }
 }

--- a/packages/tests/integration/src/entities/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/UserCodegen.ts
@@ -245,40 +245,31 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
 
   get createdComments(): Collection<User, Comment> {
     const { relations } = this.__orm;
-    if (relations.createdComments === undefined) {
-      relations.createdComments = hasMany(
-        this as any as User,
-        commentMeta,
-        "createdComments",
-        "user",
-        "user_id",
-        undefined,
-      );
-    }
-    return relations.createdComments as any;
+    return relations.createdComments ??= hasMany(
+      this as any as User,
+      commentMeta,
+      "createdComments",
+      "user",
+      "user_id",
+      undefined,
+    );
   }
 
   get authorManyToOne(): ManyToOneReference<User, Author, undefined> {
     const { relations } = this.__orm;
-    if (relations.authorManyToOne === undefined) {
-      relations.authorManyToOne = hasOne(this as any as User, authorMeta, "authorManyToOne", "userOneToOne");
-    }
-    return relations.authorManyToOne as any;
+    return relations.authorManyToOne ??= hasOne(this as any as User, authorMeta, "authorManyToOne", "userOneToOne");
   }
 
   get likedComments(): Collection<User, Comment> {
     const { relations } = this.__orm;
-    if (relations.likedComments === undefined) {
-      relations.likedComments = hasManyToMany(
-        this as any as User,
-        "users_to_comments",
-        "likedComments",
-        "liked_by_user_id",
-        commentMeta,
-        "likedByUsers",
-        "comment_id",
-      );
-    }
-    return relations.likedComments as any;
+    return relations.likedComments ??= hasManyToMany(
+      this as any as User,
+      "users_to_comments",
+      "likedComments",
+      "liked_by_user_id",
+      commentMeta,
+      "likedByUsers",
+      "comment_id",
+    );
   }
 }

--- a/packages/tests/integration/src/entities/UserCodegen.ts
+++ b/packages/tests/integration/src/entities/UserCodegen.ts
@@ -247,29 +247,38 @@ export abstract class UserCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get createdComments(): Collection<User, Comment> {
-    return this.#createdComments ??= hasMany(
-      this as any as User,
-      commentMeta,
-      "createdComments",
-      "user",
-      "user_id",
-      undefined,
-    );
+    if (this.#createdComments === undefined) {
+      this.#createdComments = hasMany(
+        this as any as User,
+        commentMeta,
+        "createdComments",
+        "user",
+        "user_id",
+        undefined,
+      );
+    }
+    return this.#createdComments;
   }
 
   get authorManyToOne(): ManyToOneReference<User, Author, undefined> {
-    return this.#authorManyToOne ??= hasOne(this as any as User, authorMeta, "authorManyToOne", "userOneToOne");
+    if (this.#authorManyToOne === undefined) {
+      this.#authorManyToOne = hasOne(this as any as User, authorMeta, "authorManyToOne", "userOneToOne");
+    }
+    return this.#authorManyToOne;
   }
 
   get likedComments(): Collection<User, Comment> {
-    return this.#likedComments ??= hasManyToMany(
-      this as any as User,
-      "users_to_comments",
-      "likedComments",
-      "liked_by_user_id",
-      commentMeta,
-      "likedByUsers",
-      "comment_id",
-    );
+    if (this.#likedComments === undefined) {
+      this.#likedComments = hasManyToMany(
+        this as any as User,
+        "users_to_comments",
+        "likedComments",
+        "liked_by_user_id",
+        commentMeta,
+        "likedByUsers",
+        "comment_id",
+      );
+    }
+    return this.#likedComments;
   }
 }

--- a/packages/tests/integration/src/getProperties.test.ts
+++ b/packages/tests/integration/src/getProperties.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe("getProperties", () => {
   it("should work", () => {
-    expect(getProperties(bookMeta)).toStrictEqual({
+    expect(getProperties(bookMeta)).toEqual({
       advances: expect.any(OneToManyCollection),
       reviews: expect.any(OneToManyCollection),
       comments: expect.any(OneToManyCollection),

--- a/packages/tests/integration/src/toMatchEntity.test.ts
+++ b/packages/tests/integration/src/toMatchEntity.test.ts
@@ -327,6 +327,16 @@ describe("toMatchEntity", () => {
     });
   });
 
+  it("can match references loaded after flush", async () => {
+    const em = newEntityManager();
+    const a1 = newAuthor(em, {});
+    await em.flush();
+    // This test assumes that no Author rules loaded `comments` during
+    // flush, and so this is the 1st time comments is being accessed
+    expect(Object.keys(a1.__orm.relations)).toEqual(["books", "publisher", "mentor"]);
+    expect(a1).toMatchEntity({ comments: [] });
+  });
+
   it("can match arrays", async () => {
     const em = newEntityManager();
     const a1 = newAuthor(em, { firstName: "a1" });

--- a/packages/tests/number-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/AuthorCodegen.ts
@@ -100,7 +100,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-  #books: Collection<Author, Book> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -182,9 +181,13 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> {
   }
 
   get books(): Collection<Author, Book> {
-    if (this.#books === undefined) {
-      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.books === undefined) {
+      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+      if (this.isNewEntity) {
+        relations.books.initializeForNewEntity?.();
+      }
     }
-    return this.#books;
+    return relations.books as any;
   }
 }

--- a/packages/tests/number-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/AuthorCodegen.ts
@@ -184,9 +184,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> {
     const { relations } = this.__orm;
     if (relations.books === undefined) {
       relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
-      if (this.isNewEntity) {
-        relations.books.initializeForNewEntity?.();
-      }
     }
     return relations.books as any;
   }

--- a/packages/tests/number-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/AuthorCodegen.ts
@@ -182,9 +182,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> {
 
   get books(): Collection<Author, Book> {
     const { relations } = this.__orm;
-    if (relations.books === undefined) {
-      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
-    }
-    return relations.books as any;
+    return relations.books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
   }
 }

--- a/packages/tests/number-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/AuthorCodegen.ts
@@ -100,8 +100,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id", undefined);
+  #books: Collection<Author, Book> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -180,5 +179,9 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> {
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {
     return isLoaded(this as any as Author, hint);
+  }
+
+  get books(): Collection<Author, Book> {
+    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
   }
 }

--- a/packages/tests/number-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/number-ids/src/entities/AuthorCodegen.ts
@@ -182,6 +182,9 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, number> {
   }
 
   get books(): Collection<Author, Book> {
-    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    if (this.#books === undefined) {
+      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    }
+    return this.#books;
   }
 }

--- a/packages/tests/number-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/BookCodegen.ts
@@ -169,6 +169,9 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> {
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
+    if (this.#author === undefined) {
+      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    }
+    return this.#author;
   }
 }

--- a/packages/tests/number-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/BookCodegen.ts
@@ -169,9 +169,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> {
 
   get author(): ManyToOneReference<Book, Author, never> {
     const { relations } = this.__orm;
-    if (relations.author === undefined) {
-      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-    }
-    return relations.author as any;
+    return relations.author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 }

--- a/packages/tests/number-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/BookCodegen.ts
@@ -98,7 +98,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -169,9 +168,13 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> {
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    if (this.#author === undefined) {
-      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    const { relations } = this.__orm;
+    if (relations.author === undefined) {
+      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
+      if (this.isNewEntity) {
+        relations.author.initializeForNewEntity?.();
+      }
     }
-    return this.#author;
+    return relations.author as any;
   }
 }

--- a/packages/tests/number-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/BookCodegen.ts
@@ -98,8 +98,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -167,5 +166,9 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> {
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {
     return isLoaded(this as any as Book, hint);
+  }
+
+  get author(): ManyToOneReference<Book, Author, never> {
+    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 }

--- a/packages/tests/number-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/number-ids/src/entities/BookCodegen.ts
@@ -171,9 +171,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, number> {
     const { relations } = this.__orm;
     if (relations.author === undefined) {
       relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-      if (this.isNewEntity) {
-        relations.author.initializeForNewEntity?.();
-      }
     }
     return relations.author as any;
   }

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -101,7 +101,6 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: ArtistIdsOpts;
     factoryOptsType: Parameters<typeof newArtist>[1];
   };
-  #paintings: Collection<Artist, Painting> | undefined = undefined;
 
   constructor(em: EntityManager, opts: ArtistOpts) {
     super(em, artistMeta, ArtistCodegen.defaultValues, opts);
@@ -183,9 +182,13 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get paintings(): Collection<Artist, Painting> {
-    if (this.#paintings === undefined) {
-      this.#paintings = hasMany(this as any as Artist, paintingMeta, "paintings", "artist", "artistId", undefined);
+    const { relations } = this.__orm;
+    if (relations.paintings === undefined) {
+      relations.paintings = hasMany(this as any as Artist, paintingMeta, "paintings", "artist", "artistId", undefined);
+      if (this.isNewEntity) {
+        relations.paintings.initializeForNewEntity?.();
+      }
     }
-    return this.#paintings;
+    return relations.paintings as any;
   }
 }

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -183,13 +183,9 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get paintings(): Collection<Artist, Painting> {
-    return this.#paintings ??= hasMany(
-      this as any as Artist,
-      paintingMeta,
-      "paintings",
-      "artist",
-      "artistId",
-      undefined,
-    );
+    if (this.#paintings === undefined) {
+      this.#paintings = hasMany(this as any as Artist, paintingMeta, "paintings", "artist", "artistId", undefined);
+    }
+    return this.#paintings;
   }
 }

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -183,9 +183,13 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> {
 
   get paintings(): Collection<Artist, Painting> {
     const { relations } = this.__orm;
-    if (relations.paintings === undefined) {
-      relations.paintings = hasMany(this as any as Artist, paintingMeta, "paintings", "artist", "artistId", undefined);
-    }
-    return relations.paintings as any;
+    return relations.paintings ??= hasMany(
+      this as any as Artist,
+      paintingMeta,
+      "paintings",
+      "artist",
+      "artistId",
+      undefined,
+    );
   }
 }

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -185,9 +185,6 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.paintings === undefined) {
       relations.paintings = hasMany(this as any as Artist, paintingMeta, "paintings", "artist", "artistId", undefined);
-      if (this.isNewEntity) {
-        relations.paintings.initializeForNewEntity?.();
-      }
     }
     return relations.paintings as any;
   }

--- a/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/ArtistCodegen.ts
@@ -101,14 +101,7 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: ArtistIdsOpts;
     factoryOptsType: Parameters<typeof newArtist>[1];
   };
-
-  readonly paintings: Collection<Artist, Painting> = hasMany(
-    paintingMeta,
-    "paintings",
-    "artist",
-    "artistId",
-    undefined,
-  );
+  #paintings: Collection<Artist, Painting> | undefined = undefined;
 
   constructor(em: EntityManager, opts: ArtistOpts) {
     super(em, artistMeta, ArtistCodegen.defaultValues, opts);
@@ -187,5 +180,16 @@ export abstract class ArtistCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Artist>>(hint: H): this is Loaded<Artist, H> {
     return isLoaded(this as any as Artist, hint);
+  }
+
+  get paintings(): Collection<Artist, Painting> {
+    return this.#paintings ??= hasMany(
+      this as any as Artist,
+      paintingMeta,
+      "paintings",
+      "artist",
+      "artistId",
+      undefined,
+    );
   }
 }

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -184,9 +184,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.books === undefined) {
       relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "authorId", undefined);
-      if (this.isNewEntity) {
-        relations.books.initializeForNewEntity?.();
-      }
     }
     return relations.books as any;
   }

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -100,7 +100,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-  #books: Collection<Author, Book> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -182,9 +181,13 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get books(): Collection<Author, Book> {
-    if (this.#books === undefined) {
-      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "authorId", undefined);
+    const { relations } = this.__orm;
+    if (relations.books === undefined) {
+      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "authorId", undefined);
+      if (this.isNewEntity) {
+        relations.books.initializeForNewEntity?.();
+      }
     }
-    return this.#books;
+    return relations.books as any;
   }
 }

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -182,9 +182,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
 
   get books(): Collection<Author, Book> {
     const { relations } = this.__orm;
-    if (relations.books === undefined) {
-      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "authorId", undefined);
-    }
-    return relations.books as any;
+    return relations.books ??= hasMany(this as any as Author, bookMeta, "books", "author", "authorId", undefined);
   }
 }

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -182,6 +182,9 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get books(): Collection<Author, Book> {
-    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "authorId", undefined);
+    if (this.#books === undefined) {
+      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "authorId", undefined);
+    }
+    return this.#books;
   }
 }

--- a/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/AuthorCodegen.ts
@@ -100,8 +100,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "authorId", undefined);
+  #books: Collection<Author, Book> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -180,5 +179,9 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {
     return isLoaded(this as any as Author, hint);
+  }
+
+  get books(): Collection<Author, Book> {
+    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "authorId", undefined);
   }
 }

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -151,6 +151,9 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
+    if (this.#author === undefined) {
+      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    }
+    return this.#author;
   }
 }

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -88,8 +88,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -149,5 +148,9 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {
     return isLoaded(this as any as Book, hint);
+  }
+
+  get author(): ManyToOneReference<Book, Author, never> {
+    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 }

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -88,7 +88,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -151,9 +150,13 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    if (this.#author === undefined) {
-      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    const { relations } = this.__orm;
+    if (relations.author === undefined) {
+      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
+      if (this.isNewEntity) {
+        relations.author.initializeForNewEntity?.();
+      }
     }
-    return this.#author;
+    return relations.author as any;
   }
 }

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -151,9 +151,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
 
   get author(): ManyToOneReference<Book, Author, never> {
     const { relations } = this.__orm;
-    if (relations.author === undefined) {
-      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-    }
-    return relations.author as any;
+    return relations.author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 }

--- a/packages/tests/schema-misc/src/entities/BookCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/BookCodegen.ts
@@ -153,9 +153,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.author === undefined) {
       relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-      if (this.isNewEntity) {
-        relations.author.initializeForNewEntity?.();
-      }
     }
     return relations.author as any;
   }

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -174,9 +174,6 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
     const { relations } = this.__orm;
     if (relations.artist === undefined) {
       relations.artist = hasOne(this as any as Painting, artistMeta, "artist", "paintings");
-      if (this.isNewEntity) {
-        relations.artist.initializeForNewEntity?.();
-      }
     }
     return relations.artist as any;
   }

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -172,9 +172,6 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
 
   get artist(): ManyToOneReference<Painting, Artist, never> {
     const { relations } = this.__orm;
-    if (relations.artist === undefined) {
-      relations.artist = hasOne(this as any as Painting, artistMeta, "artist", "paintings");
-    }
-    return relations.artist as any;
+    return relations.artist ??= hasOne(this as any as Painting, artistMeta, "artist", "paintings");
   }
 }

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -172,6 +172,9 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
   }
 
   get artist(): ManyToOneReference<Painting, Artist, never> {
-    return this.#artist ??= hasOne(this as any as Painting, artistMeta, "artist", "paintings");
+    if (this.#artist === undefined) {
+      this.#artist = hasOne(this as any as Painting, artistMeta, "artist", "paintings");
+    }
+    return this.#artist;
   }
 }

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -98,8 +98,7 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
     optIdsType: PaintingIdsOpts;
     factoryOptsType: Parameters<typeof newPainting>[1];
   };
-
-  readonly artist: ManyToOneReference<Painting, Artist, never> = hasOne(artistMeta, "artist", "paintings");
+  #artist: ManyToOneReference<Painting, Artist, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: PaintingOpts) {
     super(em, paintingMeta, PaintingCodegen.defaultValues, opts);
@@ -170,5 +169,9 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
 
   isLoaded<H extends LoadHint<Painting>>(hint: H): this is Loaded<Painting, H> {
     return isLoaded(this as any as Painting, hint);
+  }
+
+  get artist(): ManyToOneReference<Painting, Artist, never> {
+    return this.#artist ??= hasOne(this as any as Painting, artistMeta, "artist", "paintings");
   }
 }

--- a/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
+++ b/packages/tests/schema-misc/src/entities/PaintingCodegen.ts
@@ -98,7 +98,6 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
     optIdsType: PaintingIdsOpts;
     factoryOptsType: Parameters<typeof newPainting>[1];
   };
-  #artist: ManyToOneReference<Painting, Artist, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: PaintingOpts) {
     super(em, paintingMeta, PaintingCodegen.defaultValues, opts);
@@ -172,9 +171,13 @@ export abstract class PaintingCodegen extends BaseEntity<EntityManager, string> 
   }
 
   get artist(): ManyToOneReference<Painting, Artist, never> {
-    if (this.#artist === undefined) {
-      this.#artist = hasOne(this as any as Painting, artistMeta, "artist", "paintings");
+    const { relations } = this.__orm;
+    if (relations.artist === undefined) {
+      relations.artist = hasOne(this as any as Painting, artistMeta, "artist", "paintings");
+      if (this.isNewEntity) {
+        relations.artist.initializeForNewEntity?.();
+      }
     }
-    return this.#artist;
+    return relations.artist as any;
   }
 }

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -182,6 +182,9 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get books(): Collection<Author, Book> {
-    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    if (this.#books === undefined) {
+      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    }
+    return this.#books;
   }
 }

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -100,7 +100,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-  #books: Collection<Author, Book> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -182,9 +181,13 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get books(): Collection<Author, Book> {
-    if (this.#books === undefined) {
-      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.books === undefined) {
+      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+      if (this.isNewEntity) {
+        relations.books.initializeForNewEntity?.();
+      }
     }
-    return this.#books;
+    return relations.books as any;
   }
 }

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -182,9 +182,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
 
   get books(): Collection<Author, Book> {
     const { relations } = this.__orm;
-    if (relations.books === undefined) {
-      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
-    }
-    return relations.books as any;
+    return relations.books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
   }
 }

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -184,9 +184,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.books === undefined) {
       relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
-      if (this.isNewEntity) {
-        relations.books.initializeForNewEntity?.();
-      }
     }
     return relations.books as any;
   }

--- a/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/AuthorCodegen.ts
@@ -100,8 +100,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id", undefined);
+  #books: Collection<Author, Book> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -180,5 +179,9 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {
     return isLoaded(this as any as Author, hint);
+  }
+
+  get books(): Collection<Author, Book> {
+    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
   }
 }

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -171,9 +171,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.author === undefined) {
       relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-      if (this.isNewEntity) {
-        relations.author.initializeForNewEntity?.();
-      }
     }
     return relations.author as any;
   }

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -98,7 +98,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -169,9 +168,13 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    if (this.#author === undefined) {
-      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    const { relations } = this.__orm;
+    if (relations.author === undefined) {
+      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
+      if (this.isNewEntity) {
+        relations.author.initializeForNewEntity?.();
+      }
     }
-    return this.#author;
+    return relations.author as any;
   }
 }

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -169,6 +169,9 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
+    if (this.#author === undefined) {
+      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    }
+    return this.#author;
   }
 }

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -98,8 +98,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -167,5 +166,9 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {
     return isLoaded(this as any as Book, hint);
+  }
+
+  get author(): ManyToOneReference<Book, Author, never> {
+    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 }

--- a/packages/tests/untagged-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/untagged-ids/src/entities/BookCodegen.ts
@@ -169,9 +169,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
 
   get author(): ManyToOneReference<Book, Author, never> {
     const { relations } = this.__orm;
-    if (relations.author === undefined) {
-      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-    }
-    return relations.author as any;
+    return relations.author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 }

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -182,6 +182,9 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get books(): Collection<Author, Book> {
-    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    if (this.#books === undefined) {
+      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    }
+    return this.#books;
   }
 }

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -100,7 +100,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-  #books: Collection<Author, Book> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -182,9 +181,13 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get books(): Collection<Author, Book> {
-    if (this.#books === undefined) {
-      this.#books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+    const { relations } = this.__orm;
+    if (relations.books === undefined) {
+      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
+      if (this.isNewEntity) {
+        relations.books.initializeForNewEntity?.();
+      }
     }
-    return this.#books;
+    return relations.books as any;
   }
 }

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -182,9 +182,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
 
   get books(): Collection<Author, Book> {
     const { relations } = this.__orm;
-    if (relations.books === undefined) {
-      relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
-    }
-    return relations.books as any;
+    return relations.books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
   }
 }

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -184,9 +184,6 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.books === undefined) {
       relations.books = hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
-      if (this.isNewEntity) {
-        relations.books.initializeForNewEntity?.();
-      }
     }
     return relations.books as any;
   }

--- a/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/AuthorCodegen.ts
@@ -100,8 +100,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: AuthorIdsOpts;
     factoryOptsType: Parameters<typeof newAuthor>[1];
   };
-
-  readonly books: Collection<Author, Book> = hasMany(bookMeta, "books", "author", "author_id", undefined);
+  #books: Collection<Author, Book> | undefined = undefined;
 
   constructor(em: EntityManager, opts: AuthorOpts) {
     super(em, authorMeta, AuthorCodegen.defaultValues, opts);
@@ -180,5 +179,9 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Author>>(hint: H): this is Loaded<Author, H> {
     return isLoaded(this as any as Author, hint);
+  }
+
+  get books(): Collection<Author, Book> {
+    return this.#books ??= hasMany(this as any as Author, bookMeta, "books", "author", "author_id", undefined);
   }
 }

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -171,9 +171,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     const { relations } = this.__orm;
     if (relations.author === undefined) {
       relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-      if (this.isNewEntity) {
-        relations.author.initializeForNewEntity?.();
-      }
     }
     return relations.author as any;
   }

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -98,7 +98,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -169,9 +168,13 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    if (this.#author === undefined) {
-      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    const { relations } = this.__orm;
+    if (relations.author === undefined) {
+      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
+      if (this.isNewEntity) {
+        relations.author.initializeForNewEntity?.();
+      }
     }
-    return this.#author;
+    return relations.author as any;
   }
 }

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -169,6 +169,9 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
   }
 
   get author(): ManyToOneReference<Book, Author, never> {
-    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
+    if (this.#author === undefined) {
+      this.#author = hasOne(this as any as Book, authorMeta, "author", "books");
+    }
+    return this.#author;
   }
 }

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -98,8 +98,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
     optIdsType: BookIdsOpts;
     factoryOptsType: Parameters<typeof newBook>[1];
   };
-
-  readonly author: ManyToOneReference<Book, Author, never> = hasOne(authorMeta, "author", "books");
+  #author: ManyToOneReference<Book, Author, never> | undefined = undefined;
 
   constructor(em: EntityManager, opts: BookOpts) {
     super(em, bookMeta, BookCodegen.defaultValues, opts);
@@ -167,5 +166,9 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
 
   isLoaded<H extends LoadHint<Book>>(hint: H): this is Loaded<Book, H> {
     return isLoaded(this as any as Book, hint);
+  }
+
+  get author(): ManyToOneReference<Book, Author, never> {
+    return this.#author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 }

--- a/packages/tests/uuid-ids/src/entities/BookCodegen.ts
+++ b/packages/tests/uuid-ids/src/entities/BookCodegen.ts
@@ -169,9 +169,6 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> {
 
   get author(): ManyToOneReference<Book, Author, never> {
     const { relations } = this.__orm;
-    if (relations.author === undefined) {
-      relations.author = hasOne(this as any as Book, authorMeta, "author", "books");
-    }
-    return relations.author as any;
+    return relations.author ??= hasOne(this as any as Book, authorMeta, "author", "books");
   }
 }


### PR DESCRIPTION
Fixes #836.

This really cleans up looking at entities in the debugger...except for custom relations. I'd like to try and meta-program those into lazy inits too, but I think anything that is:

```ts
class Foo {
  readonly relation = hasRelation(...);
}
```

Is fundamentally defined as a field on the instance, and can't be intercepted / meta-programmed around.

Coincidentally, this limitation is something that TC39 decorators ran in to, and is being handled by a new `accessor` keyword:

https://github.com/tc39/proposal-grouped-and-auto-accessors

That is a one-liner that auto-getters/setters things. 

I'm like 90% certain that if we started writing:

```ts
class Foo {
  accessor relation = hasRelation(...);
}
```

We could meta-program the Foo.prototype on boot and lazy-ize relation, basically as if the user had written a `@lazy` annotation, but we would do it automatically b/c we recognized the field as a relation (via our fake instance detection).

---

Looks like perf increased ~14% when loading 50k entities in an `em.find`:

![image](https://github.com/stephenh/joist-ts/assets/6401/1ce7a7a8-0b72-47ff-ae91-6cbf0d8329dd)

