### PR TITLE
fix: Fix findOrCreate with undefined.

### DIFF
--- a/packages/tests/integration/src/EntityManager.test.ts
+++ b/packages/tests/integration/src/EntityManager.test.ts
@@ -997,6 +997,20 @@ describe("EntityManager", () => {
     expect(a1.lastName).toBe("l1");
   });
 
+  it("can find existing with findOrCreate with undefined FKs", async () => {
+    await insertPublisher({ name: "p1" });
+    // Given two authors, both with same age, but one has a publisher
+    await insertAuthor({ first_name: "a1", age: 20, publisher_id: 1 });
+    await insertAuthor({ first_name: "a2", age: 20 });
+    const em = newEntityManager();
+    resetQueryCount();
+    // When we findOrCreate for the { age: 20, publisher: undefined } author
+    const a1 = await em.findOrCreate(Author, { age: 20, publisher: undefined }, { firstName: "a3" });
+    expect(numberOfQueries).toBe(1);
+    // Then we got back the existing a2 author
+    expect(a1).toMatchEntity({ firstName: "a2", isNewEntity: false });
+  });
+
   it("findOrCreate still creates dups with different where clauses in a loop", async () => {
     const em = newEntityManager();
     // Given two findOrCreates that are creating two entities


### PR DESCRIPTION
The API for findOrCreate is opts-based, so wants `publisher: undefined`, which matches Joist's opinionated choice of `undefined` to represent empty within the object graph.

But when we call `em.find`, it drops `publisher: undefined` due to a legacy-but-valid desire to match the behavior of `em.findGql` where it's very easy for a resolver implementation that handles "the client didn't include a filter for publisherId" to accidentally include the `publisher` key on the `em.find` call.

I.e. something like:

```
const { publisherId } = filter;
await em.find(..., { publisherId });
```

Is the destructuring/restructuring idiom that looks innocent but will mean the `publisherId` key is always set on the `em.find` call, regardless of being included in the incoming filter.

Anyway, this watches for opts-find-undefined and converts over to null so that the semantics work as expected.