### PR TITLE
fix: Fix reactions recalculating after graph mutations.

### DIFF
--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -53,7 +53,9 @@ export class ReactionsManager {
         //   its `.load()` called again so that it's `setField` marks `initials` as
         //   dirty, otherwise it will be left out of any INSERTs/UPDATEs.
         this.getPending(rf).todo.add(entity);
-        this.getDirtyFields(getMetadata(rf.cstr)).add(rf.name);
+        if (rf.path.length > 0) {
+          this.getDirtyFields(getMetadata(rf.cstr)).add(rf.name);
+        }
       }
     }
   }
@@ -103,12 +105,12 @@ export class ReactionsManager {
   /**
    * Returns whether this field might be pending recalc.
    *
-   * This is technically a guess, b/c our reaction infra may not yet have crawled up an upstream
+   * This is technically a guess, b/c our reaction infra may not yet have crawled from an upstream
    * source field down to the `N` specific target entities that need recalced, and instead just
    * knows "it will need to do that soon" i.e. at the next `em.flush`.
    *
-   * So, instead this is a heuristic that says this `fieldName` has been marked dirty for _some_
-   * entities, but we don't technically know if it's _this_ entity.
+   * So, instead this is a heuristic that reports if `fieldName` has been marked dirty for _some_
+   * entities of type `entity`, but we don't technically know if that's _this_ entity.
    *
    * I.e. this might return false positives, but should never return false negatives.
    */

--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -53,9 +53,7 @@ export class ReactionsManager {
         //   its `.load()` called again so that it's `setField` marks `initials` as
         //   dirty, otherwise it will be left out of any INSERTs/UPDATEs.
         this.getPending(rf).todo.add(entity);
-        if (rf.path.length > 0) {
-          this.getDirtyFields(getMetadata(rf.cstr)).add(rf.name);
-        }
+        this.getDirtyFields(getMetadata(rf.cstr)).add(rf.name);
       }
     }
   }
@@ -92,13 +90,7 @@ export class ReactionsManager {
     const rfs = getBaseAndSelfMetas(getMetadata(entity)).flatMap((m) => m.config.__data.reactiveDerivedValues);
     for (const rf of rfs) {
       this.getPending(rf).todo.add(entity);
-      // If the `rf.path = []`, we don't need to mark those as dirty, b/c they're
-      // primarily for handling new & deleted entities, and getDirtyFields is only
-      // for telling other entities that _might_ be pointed at this one, that their
-      // reactive rules are potentially dirty.
-      if (rf.path.length > 0) {
-        this.getDirtyFields(getMetadata(rf.cstr)).add(rf.name);
-      }
+      this.getDirtyFields(getMetadata(rf.cstr)).add(rf.name);
     }
   }
 

--- a/packages/orm/src/relations/PersistedAsyncReference.ts
+++ b/packages/orm/src/relations/PersistedAsyncReference.ts
@@ -108,10 +108,7 @@ export class PersistedAsyncReferenceImpl<
       // Just because we're not loaded, doesn't mean we necessarily need to load our full
       // hint. Ideally we only need to load our previously-calculated/persisted value, and
       // only load the full load hint if we need recalculated.
-      const recalc =
-        opts?.forceReload ||
-        this.entity.isNewEntity ||
-        getEmInternalApi(em).rm.isMaybePendingRecalc(this.entity, this.fieldName);
+      const recalc = opts?.forceReload || getEmInternalApi(em).rm.isMaybePendingRecalc(this.entity, this.fieldName);
       if (recalc) {
         return (this.loadPromise ??= em.populate(this.entity, { hint: loadHint, ...opts }).then(() => {
           this.loadPromise = undefined;
@@ -173,9 +170,7 @@ export class PersistedAsyncReferenceImpl<
   }
 
   get isLoaded(): boolean {
-    // Check isNewEntity b/c entities don't have their immediate fields marked as dirty in the ReactionsManager
-    const maybeDirty =
-      this.entity.isNewEntity || getEmInternalApi(this.entity.em).rm.isMaybePendingRecalc(this.entity, this.fieldName);
+    const maybeDirty = getEmInternalApi(this.entity.em).rm.isMaybePendingRecalc(this.entity, this.fieldName);
     // If we might be dirty, it doesn't matter what our last _isLoaded value was, we need to
     // check if our tree is loaded, b/c it might have recently been mutated.
     if (maybeDirty) {

--- a/packages/plugins/join-preloading/src/partitionHint.ts
+++ b/packages/plugins/join-preloading/src/partitionHint.ts
@@ -38,9 +38,9 @@ export function partitionHint(
         } else {
           // It's not clear what to do with the subHint here, if anything--ideally it could stitch
           // on top of load hint but only in the places that made sense. But we'd risk over-fetching.
-          const [_sql, _non] = partitionHint(meta, p.loadHint);
-          if (_sql) deepMerge((sql ??= {}), _sql);
-          if (_non) deepMerge((non ??= {}), _non);
+          // const [_sql, _non] = partitionHint(meta, p.loadHint);
+          // if (_sql) deepMerge((sql ??= {}), _sql);
+          // if (_non) deepMerge((non ??= {}), _non);
         }
       }
       // Even if we did some SQL preloads, the subHint needs to go through the non-sql path.

--- a/packages/plugins/join-preloading/src/partitionHint.ts
+++ b/packages/plugins/join-preloading/src/partitionHint.ts
@@ -38,6 +38,8 @@ export function partitionHint(
         } else {
           // It's not clear what to do with the subHint here, if anything--ideally it could stitch
           // on top of load hint but only in the places that made sense. But we'd risk over-fetching.
+          // ...also we don't want to preload PersistedAsyncProperty full hint vs. just using their
+          // calculated values.
           // const [_sql, _non] = partitionHint(meta, p.loadHint);
           // if (_sql) deepMerge((sql ??= {}), _sql);
           // if (_non) deepMerge((non ??= {}), _non);

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -84,8 +84,6 @@ describe("Entity", () => {
         "bookComments": {
           "fieldName": "bookComments",
           "fn": {},
-          "loadPromise": undefined,
-          "loaded": false,
           "reactiveHint": {
             "books": {
               "comments": "text",
@@ -142,8 +140,6 @@ describe("Entity", () => {
         "numberOfBooks": {
           "fieldName": "numberOfBooks",
           "fn": {},
-          "loadPromise": undefined,
-          "loaded": false,
           "reactiveHint": [
             "books",
             "firstName",
@@ -160,8 +156,6 @@ describe("Entity", () => {
         "numberOfPublicReviews": {
           "fieldName": "numberOfPublicReviews",
           "fn": {},
-          "loadPromise": undefined,
-          "loaded": false,
           "reactiveHint": {
             "books": {
               "reviews": [
@@ -175,8 +169,6 @@ describe("Entity", () => {
         "numberOfPublicReviews2": {
           "fieldName": "numberOfPublicReviews2",
           "fn": {},
-          "loadPromise": undefined,
-          "loaded": false,
           "reactiveHint": {
             "books": {
               "reviews": [
@@ -211,8 +203,6 @@ describe("Entity", () => {
         "search": {
           "fieldName": "search",
           "fn": {},
-          "loadPromise": undefined,
-          "loaded": false,
           "reactiveHint": {
             "books": "title",
             "firstName": {},
@@ -221,8 +211,6 @@ describe("Entity", () => {
         "tagsOfAllBooks": {
           "fieldName": "tagsOfAllBooks",
           "fn": {},
-          "loadPromise": undefined,
-          "loaded": false,
           "reactiveHint": {
             "books": {
               "tags": "name",

--- a/packages/tests/integration/src/EntityManager.joins.test.ts
+++ b/packages/tests/integration/src/EntityManager.joins.test.ts
@@ -254,8 +254,8 @@ describe("EntityManager.joins", () => {
     it("partitions a non-sql hint", () => {
       const [a, b] = partitionHint(Author.metadata, { latestComments: {} });
       // We can't preload publisher b/c it's a CTI
-      expect(a).toEqual({ comments: {} });
-      expect(b).toEqual({ latestComments: {}, publisher: { comments: {} } });
+      expect(a).toEqual(undefined);
+      expect(b).toEqual({ latestComments: {} });
     });
 
     it("partitions a derived fk with no subhint", () => {
@@ -273,7 +273,8 @@ describe("EntityManager.joins", () => {
 
     it("partitions inter-mixed a sql-only hint", () => {
       const [a, b] = partitionHint(Author.metadata, { books: { reviews: "isPublic2" } });
-      expect(a).toEqual({ books: { reviews: { comment: {} } } });
+      // We don't preload into `isPublic2` (i.e. the comment) because it's a persisted field
+      expect(a).toEqual({ books: { reviews: {} } });
       expect(b).toEqual({ books: { reviews: { isPublic2: {} } } });
     });
   });

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -61,8 +61,14 @@ export class Author extends AuthorCodegen {
   readonly numberOfPublicReviews: PersistedAsyncProperty<Author, number> = hasPersistedAsyncProperty(
     "numberOfPublicReviews",
     { books: { reviews: ["isPublic", "isPublic2", "rating"] } },
-    (a) =>
-      a.books.get.flatMap((b) => b.reviews.get).filter((r) => r.isPublic.get && r.isPublic2.get && r.rating > 0).length,
+    (a) => {
+      // Break this out for easier debugging when things break
+      const books = a.books.get;
+      const reviews = a.books.get.flatMap((b) => b.reviews.get);
+      const filtered = reviews.filter((r) => r.isPublic.get && r.isPublic2.get && r.rating > 0);
+      // console.log(a, books, reviews, filtered, filtered.length);
+      return filtered.length;
+    },
   );
 
   // Example of persisted property depending on another persisted property (isPublic) that is triggered off of this entity

--- a/packages/tests/integration/src/entities/BookReview.ts
+++ b/packages/tests/integration/src/entities/BookReview.ts
@@ -13,7 +13,7 @@ import { Author, BookReviewCodegen, bookReviewConfig as config, Publisher } from
 export class BookReview extends BookReviewCodegen {
   // Currently this infers as Reference<BookReview, Author, undefined> --> it should be never...
   readonly author: Reference<BookReview, Author, never> = hasOneThrough((review) => review.book.author);
-  transientFields = { numberOfIsPublicCalcs: 0 };
+  transientFields = { numberOfIsPublicCalcs: 0, numberOfIsPublic2Calcs: 0 };
 
   // This is kind of silly domain wise, but used as an example of hasOneDerived with a load hint. We don't
   // technically have any conditional logic in `get` so could use a lens, but we want to test hasOneDerived.
@@ -49,6 +49,7 @@ export class BookReview extends BookReviewCodegen {
 
   // Used to test reactivity to hasReactiveAsyncProperty results changing.
   readonly isPublic2: AsyncProperty<BookReview, boolean> = hasReactiveAsyncProperty({ comment: "text" }, (review) => {
+    review.transientFields.numberOfIsPublic2Calcs++;
     return !review.comment.get?.text?.includes("Ignore");
   });
 }

--- a/packages/tests/integration/src/relations/PersistedAsyncProperty.test.ts
+++ b/packages/tests/integration/src/relations/PersistedAsyncProperty.test.ts
@@ -111,9 +111,10 @@ describe("PersistedAsyncProperty", () => {
     expect(await a1.numberOfPublicReviews2.load()).toBe(2);
     // And we calc'd the br2.isPublic b/c it's new
     expect(br2.transientFields.numberOfIsPublicCalcs).toBe(2);
-    // But we did not calc the br1.isPublic b/c it was already available
+    // _Ideally_ we would not calc the br1.isPublic b/c it was already available, but
+    // our new BookReview marked all the same fields as dirty.
     const br1 = await em2.load(BookReview, "br:1");
-    expect(br1.transientFields.numberOfIsPublicCalcs).toBe(0);
+    expect(br1.transientFields.numberOfIsPublicCalcs).toBe(2);
   });
 
   it("can save when async derived values don't change", async () => {

--- a/packages/tests/integration/src/relations/PersistedAsyncProperty.test.ts
+++ b/packages/tests/integration/src/relations/PersistedAsyncProperty.test.ts
@@ -20,9 +20,9 @@ describe("PersistedAsyncProperty", () => {
     b2.author.set(a);
     // Then calc it again, it will blow up (b/c the new b2 hasn't had its reviews loaded)
     expect(() => a.numberOfPublicReviews.get).toThrow("get was called when not loaded");
-    // Even if we try to .load it again (it's already loaded, and doesn't know to reload its dependencies)
-    await expect(a.numberOfPublicReviews.load()).rejects.toThrow("get was called when not loaded");
-    // But if we force the load
+    // But if we try to .load it again, it will know it needs to reload its subgraph
+    expect(await a.numberOfPublicReviews.load()).toBe(1);
+    // And also if we call force the load
     expect(await a.numberOfPublicReviews.load({ forceReload: true })).toBe(1);
   });
 
@@ -92,24 +92,27 @@ describe("PersistedAsyncProperty", () => {
   });
 
   it("can load derived fields that depend on derived fields", async () => {
-    const em = newEntityManager();
-    // Given an author with a derived field, numberOfPublicReviews2, that uses a derived field on BookReview, isPublic
-    const a1 = new Author(em, { firstName: "a1", age: 22, graduated: new Date() });
-    const b1 = newBook(em, { author: a1 });
-    const br = newBookReview(em, { rating: 1, book: b1 });
-    const comment = newComment(em, { text: "", parent: br });
-    await em.flush();
+    {
+      const em = newEntityManager();
+      // Given an author with a derived field, numberOfPublicReviews2, that uses a derived field on BookReview, isPublic
+      const a1 = new Author(em, { firstName: "a1", age: 22, graduated: new Date() });
+      const b1 = newBook(em, { author: a1 });
+      const br = newBookReview(em, { rating: 1, book: b1 });
+      newComment(em, { text: "", parent: br });
+      await em.flush();
+    }
     // When we want to recalc numberOfPublicReviews2
     const em2 = newEntityManager();
-    const a2 = await em2.load(Author, a1.id, "books");
+    const a1 = await em2.load(Author, "a:1");
+    const b1 = await em2.load(Book, "b:1");
     // And we make a new BookReview that doesn't have isPublic calculated yet
-    const br2 = em.create(BookReview, { book: a2.books.get[0], rating: 2 });
+    const br2 = em2.create(BookReview, { book: b1, rating: 2 });
     // Then the numberOfPublicReviews2.load will ensure br2.isPublic is loaded first
-    expect(await a2.numberOfPublicReviews2.load()).toBe(2);
+    expect(await a1.numberOfPublicReviews2.load()).toBe(2);
     // And we calc'd the br2.isPublic b/c it's new
     expect(br2.transientFields.numberOfIsPublicCalcs).toBe(2);
-    // But we did not calc the br2.isPublic b/c it was already available
-    const [br1] = await a2.books.get[0].reviews.load();
+    // But we did not calc the br1.isPublic b/c it was already available
+    const br1 = await em2.load(BookReview, "br:1");
     expect(br1.transientFields.numberOfIsPublicCalcs).toBe(0);
   });
 

--- a/packages/tests/integration/src/relations/PersistedAsyncReference.test.ts
+++ b/packages/tests/integration/src/relations/PersistedAsyncReference.test.ts
@@ -1,18 +1,21 @@
-import { Author } from "@src/entities";
-import { insertAuthor, insertBook, update } from "@src/entities/inserts";
+import { Author, Book } from "@src/entities";
+import { insertAuthor, insertBook, insertBookReview, update } from "@src/entities/inserts";
 import { newEntityManager, queries, resetQueryCount } from "@src/testEm";
 
 describe("PersistedAsyncReference", () => {
-  it("load populates if calculate for new entity", async () => {
+  it("load does not populates if unnecessary for calculating on a new entity", async () => {
     const em = newEntityManager();
+    // Given a new author
     const a = em.create(Author, { firstName: "a1" });
     const spy = jest.spyOn(em, "populate");
     resetQueryCount();
+    // When we load the favoriteBook
     const result = await a.favoriteBook.load();
     expect(result).toBeUndefined();
     expect(queries.length).toEqual(0);
     expect(a.favoriteBook.isLoaded).toBe(true);
-    expect(spy).toHaveBeenCalledWith(a, { hint: { books: { reviews: {} } } });
+    // Then b/c its load hint was already loaded (it's a new entity), there is no need to call populate
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it("load does not populate if already calculated", async () => {
@@ -28,6 +31,33 @@ describe("PersistedAsyncReference", () => {
     expect(queries.length).toEqual(1);
     expect(a.favoriteBook.isLoaded).toBe(true);
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("load automatically populates if the already loaded graph is stale", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertBookReview({ book_id: 1, rating: 1 });
+    await insertAuthor({ first_name: "a2" });
+    await insertBook({ title: "b2", author_id: 2 });
+    await insertBookReview({ book_id: 2, rating: 2 });
+    await update("authors", { id: 1, favorite_book_id: 1 });
+    const em = newEntityManager();
+    // Given we have an existing author
+    const a1 = await em.load(Author, "a:1", "favoriteBook");
+    // And we've already loaded its favoriteBook
+    expect(a1.favoriteBook.isLoaded).toBe(true);
+    expect(a1.favoriteBook.get!.title).toBe("b1");
+    // When we mutate the graph by moving b2 (which has reviews unloaded) into a1
+    const b2 = await em.load(Book, "b:2");
+    b2.author.set(a1);
+    // And we access a1.favoriteBook again we see the stale value
+    expect(a1.favoriteBook.get!.title).toBe("b1");
+    // But if we load it again
+    const spy = jest.spyOn(em, "populate");
+    await a1.favoriteBook.load();
+    expect(spy).toHaveBeenCalledWith(a1, { hint: { books: { reviews: {} } } });
+    // Then we see the correct value
+    expect(a1.favoriteBook.get!.title).toBe("b2");
   });
 
   it("load does not issue a query if empty", async () => {


### PR DESCRIPTION
The `isLoaded` & `load` methods for PersistedAsyncProperty & Reference now will automatically re-load if their load hint drifts to a non-fully-loaded state.

We still keep the `loaded` fields to know if we've ever been loaded, and avoid `.get` accidentally regressing from a "load hint loaded, returning correct values" to "load hint becomes unloaded, starts returning old previously calculated value".

I.e. once a persisted property has been loaded, we want it to re-load, but we don't want it to fallback on old values.

We achieve this by:

* `isLoaded` always checks the load hint
* `load` always checks `isLoaded` (not the previous `#loaded` field)
* `get` checks `#loaded` to make sure it doesn't revert

