### PR TITLE
fix: Really check if relations are loaded for CustomCollection and CustomReference

### DIFF
--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -114,7 +114,6 @@ describe("Entity", () => {
           "undefined": null,
         },
         "latestComment": {
-          "_isLoaded": false,
           "loadPromise": undefined,
           "opts": {
             "get": {},
@@ -185,7 +184,6 @@ describe("Entity", () => {
           },
         },
         "reviewedBooks": {
-          "_isLoaded": false,
           "loadPromise": undefined,
           "opts": {
             "add": {},
@@ -197,7 +195,6 @@ describe("Entity", () => {
           },
         },
         "reviews": {
-          "_isLoaded": false,
           "loadPromise": undefined,
           "opts": {
             "get": {},

--- a/packages/tests/integration/src/entities/Image.ts
+++ b/packages/tests/integration/src/entities/Image.ts
@@ -15,6 +15,7 @@ export class Image extends ImageCodegen {
       // TODO should validate other matches ImageType
       image.ownerRef.set(other as any);
     },
+    isLoaded: () => this.ownerRef.isLoaded,
   });
 
   private get ownerRef() {

--- a/packages/tests/integration/src/entities/Publisher.ts
+++ b/packages/tests/integration/src/entities/Publisher.ts
@@ -1,4 +1,4 @@
-import { cannotBeUpdated, Collection, CustomCollection, getEm, Loaded } from "joist-orm";
+import { cannotBeUpdated, Collection, CustomCollection, getEm, isLoaded, Loaded } from "joist-orm";
 import { publisherConfig as config, Image, ImageType, ImageTypes, PublisherCodegen } from "./entities";
 
 const allImagesHint = { images: [], authors: { image: [], books: "image" } } as const;
@@ -36,6 +36,7 @@ export abstract class Publisher extends PublisherCodegen {
         getEm(entity).delete(value);
       }
     },
+    isLoaded: () => isLoaded(this, allImagesHint as any),
   });
 }
 

--- a/packages/tests/integration/src/relations/hasManyDerived.test.ts
+++ b/packages/tests/integration/src/relations/hasManyDerived.test.ts
@@ -111,4 +111,25 @@ describe("hasManyDerived", () => {
     // Then it still works
     expect(a.reviewedBooks.get).toBeDefined();
   });
+
+  it("re-evaluates whether the relation is loaded on changes to the graph", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2" });
+    await insertBook({ title: "b1", author_id: 1 });
+    await insertBook({ title: "b2", author_id: 2 });
+    await insertBookReview({ rating: 5, book_id: 1 });
+
+    const em = newEntityManager();
+    // When I populate reviewedBooks
+    const author = await em.load(Author, "1", "reviewedBooks");
+    // Then it is loaded
+    expect(author.reviewedBooks.isLoaded).toEqual(true);
+
+    // When I add a book to the author which does not have it's reviews loaded
+    const b2 = await em.load(Book, "2");
+    author.books.add(b2);
+
+    // Then the collection is no longer loaded
+    expect(author.reviewedBooks.isLoaded).toEqual(false);
+  });
 });

--- a/packages/tests/integration/src/relations/hasOneDerived.test.ts
+++ b/packages/tests/integration/src/relations/hasOneDerived.test.ts
@@ -1,4 +1,4 @@
-import { BookReview, newBookReview } from "@src/entities";
+import { Author, Book, BookReview, newBookReview } from "@src/entities";
 import { insertAuthor, insertBook, insertBookReview, insertPublisher } from "@src/entities/inserts";
 
 import { newEntityManager } from "@src/testEm";
@@ -23,8 +23,8 @@ describe("hasOneDerived", () => {
     await insertBookReview({ rating: 5, book_id: 1 });
 
     const em = newEntityManager();
-    const p1 = await em.load(BookReview, "1", "publisher");
-    expect(p1.publisher.get?.name).toEqual("p1");
+    const br1 = await em.load(BookReview, "1", "publisher");
+    expect(br1.publisher.get?.name).toEqual("p1");
   });
 
   it("in tests can be called before and after flush", async () => {
@@ -37,5 +37,32 @@ describe("hasOneDerived", () => {
     await em.flush();
     // Then it still works
     expect(br.publisher.get).toBeUndefined();
+  });
+
+  it("re-evaluates whether the relation is loaded on changes to the graph", async () => {
+    await insertPublisher({ id: 1, name: "p1" });
+    await insertPublisher({ id: 2, name: "p2" });
+    await insertAuthor({ first_name: "a", publisher_id: 1 });
+    await insertAuthor({ first_name: "b", publisher_id: 2 });
+    await insertBook({ title: "t", author_id: 1 });
+    await insertBookReview({ rating: 5, book_id: 1 });
+
+    const em = newEntityManager();
+    const br1 = await em.load(BookReview, "1", "publisher");
+    expect(br1.publisher.get?.name).toEqual("p1");
+    expect(br1.publisher.isLoaded).toEqual(true);
+
+    // And when we change the object graph so that the publisher relation is no longer loaded
+    const b1 = await em.load(Book, "1");
+    const a2 = await em.load(Author, "2");
+    b1.author.set(a2);
+
+    // Then the author's publisher is not loaded
+    expect(a2.publisher.isLoaded).toEqual(false);
+    // Therefore the relation is no longer loaded
+    expect(br1.publisher.isLoaded).toEqual(false);
+
+    // And I can re-load the relation to get the new value
+    expect(await br1.publisher.load()).toMatchEntity({ name: "p2" });
   });
 });


### PR DESCRIPTION
Removing some more instances of cached `_isLoaded: boolean` fields becoming stale due to graph changes and actually checking instead.