### PR TITLE
feat: Add AllEnumDetails to graphql codegen

### DIFF
--- a/packages/graphql-codegen/src/generateEnumsGraphql.ts
+++ b/packages/graphql-codegen/src/generateEnumsGraphql.ts
@@ -23,10 +23,15 @@ export async function generateEnumsGraphql(enums: EnumMetadata): Promise<Codegen
         .join(" ")} }`;
       return [enumDecl, "", detailDecl, ""];
     })
-    .flat()
-    .join("\n");
+    .flat();
 
-  const formatted = await formatGraphQL(contents);
+  const allEnumDetailsResult = `type AllEnumDetails {
+      ${Object.values(enums)
+        .map(({ name }) => `${camelCase(name)}: [${name}Detail!]!`)
+        .join("\n")} 
+    }`;
+
+  const formatted = await formatGraphQL([...contents, allEnumDetailsResult].join("\n"));
 
   return { name: "../../schema/enums.graphql", overwrite: true, contents: formatted };
 }


### PR DESCRIPTION
Adds a combined `AllEnumDetails` type to the `enums.graphl` codegen to make it easier to create a query resolver that can return the "details" of any enum

```graphql
type AllEnumDetails {
  enumFoo: [FooDetail!]! 
  enumBar: [BarDetail!]! 
}
```