### PR TITLE
feat: Use the latest pg-types for a timestamp perf fix.

### DIFF
--- a/hydrate-perf.mkd
+++ b/hydrate-perf.mkd
@@ -82,3 +82,33 @@ em.find    348.38 ms/iter (315.17 ms … 414.92 ms) 361.46 ms 414.92 ms 414.92 m
 em.find    184.01 ms/iter  (177.4 ms … 209.01 ms) 184.36 ms 209.01 ms 209.01 ms
 ```
 
+## Use the latest `postgres-date`
+
+Improves authors & books by 50ms.
+
+```
+benchmark        time (avg)             (min … max)       p75       p99      p995
+--------------------------------------------------- -----------------------------
+• loading 50k authors
+--------------------------------------------------- -----------------------------
+postgres.js  157.46 ms/iter (148.25 ms … 180.78 ms) 167.12 ms 180.78 ms 180.78 ms
+knex          99.49 ms/iter  (90.93 ms … 123.83 ms) 100.75 ms 123.83 ms 123.83 ms
+em.find       308.2 ms/iter  (272.56 ms … 385.5 ms) 313.18 ms  385.5 ms  385.5 ms
+
+summary for loading 50k authors
+  knex
+   1.58x faster than postgres.js
+   3.1x faster than em.find
+
+• loading 50k books
+--------------------------------------------------- -----------------------------
+postgres.js   68.64 ms/iter  (60.65 ms … 100.78 ms)  70.78 ms 100.78 ms 100.78 ms
+knex          69.55 ms/iter   (65.91 ms … 89.27 ms)  70.12 ms  89.27 ms  89.27 ms
+em.find       131.2 ms/iter (126.33 ms … 158.74 ms) 131.11 ms 158.74 ms 158.74 ms
+
+summary for loading 50k books
+  postgres.js
+   1.01x faster than knex
+   1.91x faster than em.find
+```
+

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -24,7 +24,8 @@
     "joist-utils": "workspace:*",
     "knex": "^3.1.0",
     "object-hash": "^3.0.0",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "pg-types": "^4.0.1"
   },
   "devDependencies": {
     "@swc/core": "^1.3.101",

--- a/packages/utils/src/connection.ts
+++ b/packages/utils/src/connection.ts
@@ -1,5 +1,6 @@
 import { ConnectionConfig as PgConnectionConfig } from "pg";
 import { parse } from "pg-connection-string";
+import { setupLatestPgTypes } from "./setupLatestPgTypes";
 
 type DatabaseUrlEnv = { DATABASE_URL: string };
 type DbSettingsEnv = { DB_USER: string; DB_PASSWORD: string; DB_HOST: string; DB_DATABASE: string; DB_PORT: string };
@@ -32,6 +33,7 @@ export type ConnectionConfig = Omit<PgConnectionConfig, "password" | "types" | "
  * ts-app-env, you can pass in a specific `env` variable.
  */
 export function newPgConnectionConfig(env?: ConnectionEnv): ConnectionConfig {
+  setupLatestPgTypes();
   if (process.env.DATABASE_URL || (env && "DATABASE_URL" in env)) {
     const url = process.env.DATABASE_URL ?? (env as DatabaseUrlEnv).DATABASE_URL;
     // It'd be great if `parse` returned ConnectionConfig directly

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export { ConnectionConfig, newPgConnectionConfig } from "./connection";
 export { isPlainObject } from "./is-plain-object";
+export { setupLatestPgTypes } from "./setupLatestPgTypes";
 
 export function fail(message?: string): never {
   throw new Error(message || "Failed");

--- a/packages/utils/src/setupLatestPgTypes.ts
+++ b/packages/utils/src/setupLatestPgTypes.ts
@@ -1,0 +1,10 @@
+import { types } from "pg";
+import { builtins, getTypeParser } from "pg-types";
+
+export function setupLatestPgTypes(): void {
+  // Object.entries(builtins).forEach(([name, oid]) => {
+  //   console.log("Setting up pg type", name, oid);
+  //   types.setTypeParser(oid as any, getTypeParser(oid as any));
+  // });
+  types.setTypeParser(types.builtins.TIMESTAMPTZ, getTypeParser(builtins.TIMESTAMPTZ));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10636,6 +10636,7 @@ __metadata:
     knex: ^3.1.0
     object-hash: ^3.0.0
     pg: ^8.11.3
+    pg-types: ^4.0.1
     prettier: ^3.1.1
     prettier-plugin-organize-imports: ^3.2.4
     ts-node-dev: ^2.0.0
@@ -12640,7 +12641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"obuf@npm:^1.0.0, obuf@npm:^1.1.2":
+"obuf@npm:^1.0.0, obuf@npm:^1.1.2, obuf@npm:~1.1.2":
   version: 1.1.2
   resolution: "obuf@npm:1.1.2"
   checksum: 41a2ba310e7b6f6c3b905af82c275bf8854896e2e4c5752966d64cbcd2f599cfffd5932006bcf3b8b419dfdacebb3a3912d5d94e10f1d0acab59876c8757f27f
@@ -13214,6 +13215,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-numeric@npm:1.0.2":
+  version: 1.0.2
+  resolution: "pg-numeric@npm:1.0.2"
+  checksum: 8899f8200caa1744439a8778a9eb3ceefb599d893e40a09eef84ee0d4c151319fd416634a6c0fc7b7db4ac268710042da5be700b80ef0de716fe089b8652c84f
+  languageName: node
+  linkType: hard
+
 "pg-pool@npm:^3.6.1":
   version: 3.6.1
   resolution: "pg-pool@npm:3.6.1"
@@ -13257,6 +13265,21 @@ __metadata:
     postgres-date: ~1.0.4
     postgres-interval: ^1.1.0
   checksum: bf4ec3f594743442857fb3a8dfe5d2478a04c98f96a0a47365014557cbc0b4b0cee01462c79adca863b93befbf88f876299b75b72c665b5fb84a2c94fbd10316
+  languageName: node
+  linkType: hard
+
+"pg-types@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "pg-types@npm:4.0.1"
+  dependencies:
+    pg-int8: 1.0.1
+    pg-numeric: 1.0.2
+    postgres-array: ~3.0.1
+    postgres-bytea: ~3.0.0
+    postgres-date: ~2.0.1
+    postgres-interval: ^3.0.0
+    postgres-range: ^1.1.1
+  checksum: 05258ef2f27a75f1bf4e243f36bb749f85148339d3be818147bcc4aebe019ad7589a6869150713140250d81e5a46ec25dc6e0a031ea77e23db5ca232a0d7a3dc
   languageName: node
   linkType: hard
 
@@ -13815,10 +13838,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postgres-array@npm:~3.0.1":
+  version: 3.0.2
+  resolution: "postgres-array@npm:3.0.2"
+  checksum: 5955f9dffeb6fa960c1a0b04fd4b2ba16813ddb636934ad26f902e4d76a91c0b743dcc6edc4cffc52deba7d547505e0020adea027c1d50a774f989cf955420d1
+  languageName: node
+  linkType: hard
+
 "postgres-bytea@npm:~1.0.0":
   version: 1.0.0
   resolution: "postgres-bytea@npm:1.0.0"
   checksum: d844ae4ca7a941b70e45cac1261a73ee8ed39d72d3d74ab1d645248185a1b7f0ac91a3c63d6159441020f4e1f7fe64689ac56536a307b31cef361e5187335090
+  languageName: node
+  linkType: hard
+
+"postgres-bytea@npm:~3.0.0":
+  version: 3.0.0
+  resolution: "postgres-bytea@npm:3.0.0"
+  dependencies:
+    obuf: ~1.1.2
+  checksum: 5f917a003fcaa0df7f285e1c37108ad474ce91193466b9bd4bcaecef2cdea98ca069c00aa6a8dbe6d2e7192336cadc3c9b36ae48d1555a299521918e00e2936b
   languageName: node
   linkType: hard
 
@@ -13829,12 +13868,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postgres-date@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "postgres-date@npm:2.0.1"
+  checksum: 0304bf8641a01412e4f5c3a374604e2e3dbc9dbee71d30df12fe60b32560c5674f887c2d15bafa2996f3b618b617398e7605f0e3669db43f31e614dfe69f8de7
+  languageName: node
+  linkType: hard
+
 "postgres-interval@npm:^1.1.0":
   version: 1.2.0
   resolution: "postgres-interval@npm:1.2.0"
   dependencies:
     xtend: ^4.0.0
   checksum: 746b71f93805ae33b03528e429dc624706d1f9b20ee81bf743263efb6a0cd79ae02a642a8a480dbc0f09547b4315ab7df6ce5ec0be77ed700bac42730f5c76b2
+  languageName: node
+  linkType: hard
+
+"postgres-interval@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "postgres-interval@npm:3.0.0"
+  checksum: c7a1cf006de97de663b6b8c4d2b167aa9909a238c4866a94b15d303762f5ac884ff4796cd6e2111b7f0a91302b83c570453aa8506fd005b5a5d5dfa87441bebc
+  languageName: node
+  linkType: hard
+
+"postgres-range@npm:^1.1.1":
+  version: 1.1.3
+  resolution: "postgres-range@npm:1.1.3"
+  checksum: bf7e194a18c490d02bda0bd02035a8da454d8fd2b22c55d3d03f185c038b2a6f52d0804417d8090864afefc2b7ed664b2d12c2454a4a0f545dcbbb86488fbdf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Before `parseDate` was ~40% of the time:

![image](https://github.com/stephenh/joist-ts/assets/6401/20e6b587-ddc2-48a3-a4bd-13573815dd43)

Afterwards it's ~25%

![image](https://github.com/stephenh/joist-ts/assets/6401/4ac7312f-67d0-4baa-b9db-ad3092b31471)
