### PR TITLE
fix: Change m2m.get ensureNotDeleted to ignore pending.

### DIFF
--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -164,7 +164,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   }
 
   private doGet(): U[] {
-    ensureNotDeleted(this.entity);
+    ensureNotDeleted(this.entity, "pending");
     if (this.loaded === undefined) {
       // This should only be callable in the type system if we've already resolved this to an instance
       throw new Error("get was called when not loaded");


### PR DESCRIPTION
This matches how our other relation `get`s work.