### PR TITLE
feat: Add em.recalc, simplify em.touch.

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1370,8 +1370,17 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
   }
 
   /**
-   * Recalculates the reactive fields for an entity, i.e. in case the values have
-   * drifted from underlying data.
+   * Recalculates the reactive fields for an entity, and any downstream reactive fields that depend on them.
+   *
+   * You shouldn't need to call this unless the derived fields have drifted from the underlying data, which
+   * should only happen if:
+   *
+   * - The underlying data was changed by a raw SQL query, or
+   * - You've changed the field's business logic and want to update the database to the latest value.
+   *
+   * You can also trigger a recalc for specific fields by calling `.load()` on the property, i.e.
+   * `author.numberOfBooks.load()`. This `recalc` method is just a helper method to call `load` for
+   * all derived fields on the given entity/entities.
    */
   public recalc(entity: EntityW): Promise<void>;
   public recalc(entities: EntityW[]): Promise<void>;

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1,8 +1,8 @@
 import DataLoader, { BatchLoadFn, Options } from "dataloader";
-import { getField, setField } from "./fields";
 import { Knex } from "knex";
 import { getOrmField } from "./BaseEntity";
 import { setAsyncDefaults } from "./defaults";
+import { getField, setField } from "./fields";
 // We alias `Entity => EntityW` to denote "Entity wide" i.e. the non-narrowed Entity
 import { Entity, EntityOrmField, Entity as EntityW, IdType, isEntity } from "./Entity";
 import { FlushLock } from "./FlushLock";
@@ -1089,11 +1089,6 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
     this.#fl.startLock();
 
     await this.#fl.allowWrites(async () => {
-      // Recalc any touched entities
-      const touched = this.entities.filter((e) => getOrmField(e).isTouched);
-      if (touched.length > 0) {
-        await recalcTouchedEntities(touched);
-      }
       // Cascade deletes now that we're async (i.e. to keep `em.delete` synchronous).
       // Also do this before calling `recalcPendingDerivedValues` to avoid recalculating
       // fields on entities that will be deleted (and probably have unset/invalid FKs
@@ -1365,13 +1360,29 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
    *
    * This will:
    *
-   * - Run `beforeUpdate` and `beforeFlush` hooks,
-   * - Bump the entities `updated_at` timestamp,
-   * - Recalc all async derived fields stored on the entity, and
-   * - Rerun all simple & reactive rules on the entity.
+   * - Bump the entity's `updated_at` timestamp (if available),
+   * - Run `beforeUpdate` and `beforeFlush` hooks.
    */
-  public touch(entity: EntityW) {
-    getOrmField(entity).isTouched = true;
+  public touch(entity: EntityW): void;
+  public touch(entities: EntityW[]): void;
+  public touch(entityOrEntities: EntityW | EntityW[]): void {
+    for (const entity of toArray(entityOrEntities)) getOrmField(entity).isTouched = true;
+  }
+
+  /**
+   * Recalculates the reactive fields for an entity, i.e. in case the values have
+   * drifted from underlying data.
+   */
+  public recalc(entity: EntityW): Promise<void>;
+  public recalc(entities: EntityW[]): Promise<void>;
+  public async recalc(entityOrEntities: EntityW | EntityW[]): Promise<void> {
+    const relations = toArray(entityOrEntities).flatMap((entity) =>
+      Object.values(getMetadata(entity).allFields)
+        .filter((f) => "derived" in f && f.derived === "async")
+        .map((field) => (entity as any)[field.fieldName]),
+    );
+    await Promise.all(relations.map((r: any) => r.load()));
+    await this.#rm.recalcPendingDerivedValues();
   }
 
   public beforeTransaction(fn: HookFn) {
@@ -1501,16 +1512,6 @@ export class TooManyError extends Error {
   }
 }
 
-/** Force recalc all async fields on entities that were `em.touch`-d. */
-async function recalcTouchedEntities(touched: Entity[]): Promise<void> {
-  const relations = touched.flatMap((entity) =>
-    Object.values(getMetadata(entity).allFields)
-      .filter((f) => "derived" in f && f.derived === "async")
-      .map((field) => (entity as any)[field.fieldName]),
-  );
-  await Promise.all(relations.map((r: any) => r.load()));
-}
-
 /**
  * For the entities currently in `todos`, find any reactive validation rules that point
  * from the currently-changed entities back to each rule's originally-defined-in entity,
@@ -1582,26 +1583,6 @@ async function validateReactiveRules(
   });
 
   await Promise.all([...p1, ...p2]);
-
-  // Also re-validate anything that is touched
-  for (const todo of Object.values(todos)) {
-    // Get the dummy reactive rules that point to the owning entity itself, which are usually triggered on new
-    const rules = getBaseAndSelfMetas(todo.metadata)
-      .flatMap((m) => m.config.__data.reactiveRules)
-      .filter((r) => r.path.length === 0);
-    for (const entity of todo.updates) {
-      if (getOrmField(entity).isTouched) {
-        for (const rule of rules) {
-          let entities = fns.get(rule.fn);
-          if (!entities) {
-            entities = new Set();
-            fns.set(rule.fn, entities);
-          }
-          entities.add(entity);
-        }
-      }
-    }
-  }
 
   // Now that we've found the fn+entities to run, run them and collect any errors
   const p3 = [...fns.entries()].flatMap(([fn, entities]) =>

--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1382,6 +1382,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW> {
         .map((field) => (entity as any)[field.fieldName]),
     );
     await Promise.all(relations.map((r: any) => r.load()));
+    // `.load()` recalculated the immediate relations, go ahead and recalc any downstream fields
     await this.#rm.recalcPendingDerivedValues();
   }
 

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -233,6 +233,7 @@ describe("Entity", () => {
           "beforeUpdateRan": false,
           "bookCommentsCalcInvoked": 0,
           "deleteDuringFlush": false,
+          "firstIsNotLastNameRuleInvoked": 0,
           "graduatedRuleInvoked": 0,
           "mentorRuleInvoked": 0,
           "numberOfBooksCalcInvoked": 0,

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -118,6 +118,7 @@ export class Author extends AuthorCodegen {
     afterCommitIsNewEntity: false,
     afterCommitIsDeletedEntity: false,
     setGraduatedInFlush: false,
+    firstIsNotLastNameRuleInvoked: 0,
     mentorRuleInvoked: 0,
     ageRuleInvoked: 0,
     numberOfBooksCalcInvoked: 0,
@@ -252,7 +253,9 @@ export class Author extends AuthorCodegen {
 config.cascadeDelete("books");
 config.cascadeDelete("image");
 
+// Example of a simple rule that runs on every flush
 config.addRule((a) => {
+  a.transientFields.firstIsNotLastNameRuleInvoked++;
   if (a.firstName && a.firstName === a.lastName) {
     return "firstName and lastName must be different";
   }

--- a/packages/tests/integration/src/relations/PersistedAsyncProperty.test.ts
+++ b/packages/tests/integration/src/relations/PersistedAsyncProperty.test.ts
@@ -87,6 +87,12 @@ describe("PersistedAsyncProperty", () => {
     // Then the value is updated on both the book review AND its dependent field on the author
     expect(br2.isTest.get).toEqual(true);
     expect(a2.numberOfPublicReviews2.get).toEqual(0);
+
+    // And when we flush, both entities were committed
+    const entities = await em2.flush();
+    expect(entities).toMatchEntity([a2, br2]);
+    // Then the author's hooks ran as expected
+    expect(a2.transientFields.beforeFlushRan).toBe(true);
   });
 
   it("can load derived fields that depend on derived fields", async () => {

--- a/packages/tests/integration/src/relations/PersistedAsyncProperty.test.ts
+++ b/packages/tests/integration/src/relations/PersistedAsyncProperty.test.ts
@@ -58,7 +58,7 @@ describe("PersistedAsyncProperty", () => {
     expect(rows[0].number_of_books).toEqual(1);
   });
 
-  it("has async derived values automatically updated when dependency touched and updated", async () => {
+  it("has async derived values automatically updated when dependency recalculated", async () => {
     const em = newEntityManager();
     // Given an author with a book that has a review that should be public
     const a1 = new Author(em, { firstName: "a1", age: 22, graduated: new Date() });
@@ -69,7 +69,7 @@ describe("PersistedAsyncProperty", () => {
     expect(a1.numberOfPublicReviews2.get).toEqual(1);
     expect(br.isTest.get).toEqual(false);
 
-    // And the comment is set to be Test, but not calculuted
+    // And the comment is set to be Test, but not calculated
     await knex.raw(`UPDATE comments SET text = 'Test' WHERE id = ${comment.idUntagged}`);
 
     // When the objects are loaded into a new Entity Manager
@@ -82,8 +82,7 @@ describe("PersistedAsyncProperty", () => {
     expect(br2.isTest.get).toEqual(false);
 
     // And when the book review object is touched and flushed to have its fields recalculated
-    em2.touch(br2);
-    await em2.flush();
+    await em2.recalc(br2);
 
     // Then the value is updated on both the book review AND its dependent field on the author
     expect(br2.isTest.get).toEqual(true);
@@ -133,7 +132,7 @@ describe("PersistedAsyncProperty", () => {
     expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(3);
   });
 
-  it("can force async derived values to recalc on touch", async () => {
+  it("can force async derived values to recalc", async () => {
     const em = newEntityManager();
     // Given an author with a book
     const a1 = newAuthor(em, { firstName: "a1" });
@@ -141,8 +140,7 @@ describe("PersistedAsyncProperty", () => {
     expect(a1.numberOfBooks.get).toEqual(0);
     expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(2);
     // When we touch the author
-    em.touch(a1);
-    await em.flush();
+    await em.recalc(a1);
     // Then the derived value was recalculated
     expect(a1.transientFields.numberOfBooksCalcInvoked).toBe(3);
     // Even though it didn't technically change


### PR DESCRIPTION
Previously, `em.touch` did four things:

1. Bump updatedAt (if available)
2. Run hooks
3. Recalc all reactive derived fields
4. Revalidate all reactive rules

We have an issue in production where we're using em.touch to bump updatedAt's up a tree (i.e. child changes, bump parent) for history purposes.

However, the parent has an unrelated validation rule that validly fails, i.e. the parent entity was valid in the past, but unrelated changes have made one of its rules become invalid (because we purposefully side-stepped the rule's reactivity).

(Specifically, the parent entity is a PRPC that now has an invalid lot configuration, because new option dependencies/constraints had been added; which is fine, but the configuration should only be fixed the next time the users change/update the config, and not part of the unrelated flow that just happens to be bumping the parent.)

In addition to this specific production issue, we've already been wanting to split up `em.touch` to add a `em.recalc` that specifically recalculates fields and _doesn't_ bump `updatedAt` unless any of the fields actually changed.

And for `#4`, trigger revalidate on all reactive rules, we currently don't have an active use case for this; we're fine with the reactive rules running organically as em.touch touches updatedAt or em.recalc changes derived fields.

So, this PR:

* Changes `em.touch` to only bump `updatedAt` + run hooks
* Adds a new `em.touch` that only recalculates reactive fields (plus any downstream reactive fields if/as necessary)

This is a large/breaking change to the semantics of `em.touch`, but we think it's warranted due as it more intuitively matches what "touch" entails + also matches the Rails equivalent of "touch".

Fixes #932 