### PR TITLE
fix: Fix m2m over reactivity

### DIFF
--- a/packages/orm/src/ReactionsManager.ts
+++ b/packages/orm/src/ReactionsManager.ts
@@ -54,6 +54,8 @@ export class ReactionsManager {
         //   dirty, otherwise it will be left out of any INSERTs/UPDATEs.
         this.getPending(rf).todo.add(entity);
         this.getDirtyFields(getMetadata(rf.cstr)).add(rf.name);
+        // Keep for future debugging...
+        // console.log(`${entity}.${fieldName} changed, queuing ${rf.name} walk from ${entity} -> ${rf.path}`);
       }
     }
   }
@@ -134,10 +136,13 @@ export class ReactionsManager {
           }
           for (const doing of todo) pending.done.add(doing);
           // Walk back from the source to any downstream fields
-          return (await followReverseHint(todo, rf.path))
+          const relations = (await followReverseHint(todo, rf.path))
             .filter((entity) => !entity.isDeletedEntity)
             .filter((e) => e instanceof rf.cstr)
             .map((entity) => (entity as any)[rf.name]);
+          // Keep for future debugging...
+          // console.log(`Recalc-ing ${todo} -> ${rf.path} -> ${rf.cstr.name}.${rf.name} for found ${relations.length}`);
+          return relations;
         }),
       );
       // Multiple reactions could have pointed back to the same reactive field, so

--- a/packages/orm/src/relations/ManyToManyCollection.ts
+++ b/packages/orm/src/relations/ManyToManyCollection.ts
@@ -42,9 +42,9 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   implements Collection<T, U>
 {
   readonly #fieldName: keyof T & string;
-  private loaded: U[] | undefined;
-  private addedBeforeLoaded: U[] | undefined;
-  private removedBeforeLoaded: U[] | undefined;
+  #loaded: U[] | undefined;
+  #addedBeforeLoaded: U[] | undefined;
+  #removedBeforeLoaded: U[] | undefined;
 
   constructor(
     public joinTableName: string,
@@ -63,7 +63,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
     super(entity);
     this.#fieldName = fieldName;
     if (isOrWasNew(entity)) {
-      this.loaded = [];
+      this.#loaded = [];
     }
   }
 
@@ -76,20 +76,20 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
 
   async load(opts: { withDeleted?: boolean; forceReload?: boolean } = {}): Promise<ReadonlyArray<U>> {
     ensureNotDeleted(this.entity, "pending");
-    if (this.loaded === undefined || (opts.forceReload && !this.entity.isNewEntity)) {
+    if (this.#loaded === undefined || (opts.forceReload && !this.entity.isNewEntity)) {
       const key = `${this.columnName}=${this.entity.id}`;
-      this.loaded = this.getPreloaded() ?? (await manyToManyDataLoader(this.entity.em, this).load(key));
+      this.#loaded = this.getPreloaded() ?? (await manyToManyDataLoader(this.entity.em, this).load(key));
       this.maybeApplyAddedAndRemovedBeforeLoaded();
     }
-    return this.filterDeleted(this.loaded!, opts) as ReadonlyArray<U>;
+    return this.filterDeleted(this.#loaded!, opts) as ReadonlyArray<U>;
   }
 
   async find(id: IdOf<U>): Promise<U | undefined> {
     ensureNotDeleted(this.entity, "pending");
-    if (this.loaded !== undefined) {
-      return this.loaded.find((u) => u.id === id);
+    if (this.#loaded !== undefined) {
+      return this.#loaded.find((u) => u.id === id);
     } else {
-      const added = this.addedBeforeLoaded?.find((u) => u.id === id);
+      const added = this.#addedBeforeLoaded?.find((u) => u.id === id);
       if (added) {
         return added;
       }
@@ -103,10 +103,10 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
 
   async includes(other: U): Promise<boolean> {
     ensureNotDeleted(this.entity, "pending");
-    if (this.loaded !== undefined) {
-      return this.loaded.includes(other);
+    if (this.#loaded !== undefined) {
+      return this.#loaded.includes(other);
     } else {
-      if (this.addedBeforeLoaded?.includes(other)) {
+      if (this.#addedBeforeLoaded?.includes(other)) {
         return true;
       } else if (other.isNewEntity) {
         return false;
@@ -120,12 +120,12 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   add(other: U, percolated = false): void {
     ensureNotDeleted(this.entity);
 
-    if (this.loaded !== undefined) {
-      if (this.loaded.includes(other)) return;
-      this.loaded.push(other);
+    if (this.#loaded !== undefined) {
+      if (this.#loaded.includes(other)) return;
+      this.#loaded.push(other);
     } else {
-      if (this.removedBeforeLoaded) remove(this.removedBeforeLoaded, other);
-      if (!(this.addedBeforeLoaded ??= []).includes(other)) this.addedBeforeLoaded.push(other);
+      if (this.#removedBeforeLoaded) remove(this.#removedBeforeLoaded, other);
+      if (!(this.#addedBeforeLoaded ??= []).includes(other)) this.#addedBeforeLoaded.push(other);
     }
 
     if (!percolated) {
@@ -142,16 +142,16 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
       (other[this.otherFieldName] as any as ManyToManyCollection<U, T>).remove(this.entity, true);
     }
 
-    if (this.loaded !== undefined) {
-      remove(this.loaded, other);
+    if (this.#loaded !== undefined) {
+      remove(this.#loaded, other);
     } else {
-      maybeRemove(this.addedBeforeLoaded, other);
-      maybeAdd((this.removedBeforeLoaded ??= []), other);
+      maybeRemove(this.#addedBeforeLoaded, other);
+      maybeAdd((this.#removedBeforeLoaded ??= []), other);
     }
   }
 
   get isLoaded(): boolean {
-    return this.loaded !== undefined;
+    return this.#loaded !== undefined;
   }
 
   get isPreloaded(): boolean {
@@ -159,17 +159,17 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   }
 
   preload(): void {
-    this.loaded = this.getPreloaded();
+    this.#loaded = this.getPreloaded();
     this.maybeApplyAddedAndRemovedBeforeLoaded();
   }
 
   private doGet(): U[] {
     ensureNotDeleted(this.entity, "pending");
-    if (this.loaded === undefined) {
+    if (this.#loaded === undefined) {
       // This should only be callable in the type system if we've already resolved this to an instance
       throw new Error("get was called when not loaded");
     }
-    return this.loaded;
+    return this.#loaded;
   }
 
   get getWithDeleted(): U[] {
@@ -182,11 +182,11 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
 
   set(values: U[]): void {
     ensureNotDeleted(this.entity);
-    if (this.loaded === undefined) {
+    if (this.#loaded === undefined) {
       throw new Error("set was called when not loaded");
     }
     // Make a copy for safe iteration
-    const loaded = [...this.loaded];
+    const loaded = [...this.#loaded];
     // Remove old values
     for (const other of loaded) {
       if (!values.includes(other)) this.remove(other);
@@ -199,10 +199,10 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
 
   removeAll(): void {
     ensureNotDeleted(this.entity);
-    if (this.loaded === undefined) {
+    if (this.#loaded === undefined) {
       throw new Error("removeAll was called when not loaded");
     }
-    for (const other of [...this.loaded]) {
+    for (const other of [...this.#loaded]) {
       this.remove(other);
     }
   }
@@ -210,7 +210,7 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   // impl details
 
   setFromOpts(others: U[]): void {
-    this.loaded = [];
+    this.#loaded = [];
     others.forEach((o) => this.add(o));
   }
 
@@ -228,23 +228,28 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
       const m2m = other[this.otherFieldName] as any as ManyToManyCollection<U, T>;
       m2m.remove(this.entity);
     });
-    this.loaded = [];
+    this.#loaded = [];
   }
 
   private maybeApplyAddedAndRemovedBeforeLoaded(): void {
-    if (this.loaded) {
-      // this.loaded.unshift(...this.addedBeforeLoaded);
-      // this.addedBeforeLoaded = [];
-      this.removedBeforeLoaded?.forEach((other) => {
-        remove(this.loaded!, other);
-        getEmInternalApi(this.entity.em).joinRows(this).addRemove(this, this.entity, other);
+    if (this.#loaded) {
+      this.#addedBeforeLoaded?.forEach((e) => {
+        if (!this.#loaded?.includes(e)) {
+          // Push on the end to better match the db order of "newer things come last"
+          this.#loaded?.unshift(e);
+          getEmInternalApi(this.entity.em).joinRows(this).addNew(this, this.entity, e);
+        }
       });
-      this.removedBeforeLoaded = [];
+      this.#removedBeforeLoaded?.forEach((e) => {
+        remove(this.#loaded!, e);
+        getEmInternalApi(this.entity.em).joinRows(this).addRemove(this, this.entity, e);
+      });
+      this.#removedBeforeLoaded = undefined;
     }
   }
 
   current(opts?: { withDeleted?: boolean }): U[] {
-    return this.filterDeleted(this.loaded ?? this.addedBeforeLoaded ?? [], opts);
+    return this.filterDeleted(this.#loaded ?? this.#addedBeforeLoaded ?? [], opts);
   }
 
   public get meta(): EntityMetadata {

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -63,5 +63,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.143.0"
+  "version": "1.143.1"
 }

--- a/packages/tests/integration/joist-config.json
+++ b/packages/tests/integration/joist-config.json
@@ -63,5 +63,5 @@
     }
   },
   "entitiesDirectory": "./src/entities",
-  "version": "1.143.1"
+  "version": "1.143.2"
 }

--- a/packages/tests/integration/src/EntityManager.reactiveRules.test.tsx
+++ b/packages/tests/integration/src/EntityManager.reactiveRules.test.tsx
@@ -120,7 +120,7 @@ describe("EntityManager.reactiveRules", () => {
       ]);
     });
 
-    it.withCtx("does not over calc on change", async ({ em }) => {
+    it.withCtx("does not trigger over reactivity on change", async ({ em }) => {
       // Given two authors that have books
       await insertAuthor({ first_name: "a1" });
       await insertAuthor({ first_name: "a2" });

--- a/packages/tests/integration/src/reactiveHints.test.ts
+++ b/packages/tests/integration/src/reactiveHints.test.ts
@@ -61,7 +61,7 @@ describe("reactiveHints", () => {
   it("can do child m2m with primitive field names", () => {
     expect(reverseReactiveHint(Book, Book, { tags: "name" })).toEqual([
       { entity: Book, fields: ["tags"], path: [] },
-      { entity: Tag, fields: ["books", "name"], path: ["books"] },
+      { entity: Tag, fields: ["name"], path: ["books"] },
     ]);
   });
 
@@ -69,7 +69,7 @@ describe("reactiveHints", () => {
     expect(reverseReactiveHint(Author, Author, { books: { tags: "name" } })).toEqual([
       { entity: Author, fields: [], path: [] },
       { entity: Book, fields: ["author", "tags"], path: ["author"] },
-      { entity: Tag, fields: ["books", "name"], path: ["books", "author"] },
+      { entity: Tag, fields: ["name"], path: ["books", "author"] },
     ]);
   });
 

--- a/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
@@ -91,6 +91,17 @@ describe("ManyToManyCollection", () => {
     expect(rows[0]).toEqual(expect.objectContaining({ id: 1, book_id: 2, tag_id: 3 }));
   });
 
+  it("can add an existing tag to an existing book and then load", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ id: 2, title: "b1", author_id: 1 });
+    await insertTag({ id: 3, name: `t1` });
+    const em = newEntityManager();
+    const book = await em.load(Book, "2");
+    const tag = await em.load(Tag, "3");
+    book.tags.add(tag);
+    expect(await book.tags.load()).toMatchEntity([tag]);
+  });
+
   it("can add a new tag tag to a new book", async () => {
     const em = newEntityManager();
     const book = newBook(em);
@@ -231,8 +242,7 @@ describe("ManyToManyCollection", () => {
 
     book.tags.add(tag);
     expect(tag.books.get).toContain(book);
-    expect((await book.tags.load()).length).toBe(1);
-
+    expect((await book.tags.load()).length).toBe(2);
     await em.flush();
 
     expect(await countOfBookToTags()).toEqual(2);

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.143.0"
+  "version": "1.143.1"
 }

--- a/packages/tests/number-ids/joist-config.json
+++ b/packages/tests/number-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "number",
-  "version": "1.143.1"
+  "version": "1.143.2"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.143.1"
+  "version": "1.143.2"
 }

--- a/packages/tests/schema-misc/joist-config.json
+++ b/packages/tests/schema-misc/joist-config.json
@@ -15,5 +15,5 @@
     "createdAt": { "names": ["created_at", "createdAt"], "required": false },
     "updatedAt": { "names": ["updated_at", "updatedAt"], "required": false }
   },
-  "version": "1.143.0"
+  "version": "1.143.1"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.143.0"
+  "version": "1.143.1"
 }

--- a/packages/tests/untagged-ids/joist-config.json
+++ b/packages/tests/untagged-ids/joist-config.json
@@ -4,5 +4,5 @@
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
   "idType": "untagged-string",
-  "version": "1.143.1"
+  "version": "1.143.2"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.143.1"
+  "version": "1.143.2"
 }

--- a/packages/tests/uuid-ids/joist-config.json
+++ b/packages/tests/uuid-ids/joist-config.json
@@ -3,5 +3,5 @@
   "contextType": "Context@src/context",
   "entities": { "Author": { "tag": "a" }, "Book": { "tag": "b" } },
   "entitiesDirectory": "./src/entities",
-  "version": "1.143.0"
+  "version": "1.143.1"
 }


### PR DESCRIPTION
If we had:

* Books <- m2m -> Tags
* Author.tagsOfAllBooks watching `books: "tags"`
* And `a1 / b1.tags = [t1]` was an existing b1/tag
* When we added `b2.tags.add(1)` this correctly recalc'd `b2 -> a2`, `a2.tagsOfAllBooks`
* But it also walked from `t1.books.authors` and found `a1` and `a2`

This was unnecessary, because b1.tags hadn't changed.

