### PR TITLE
fix: Implement not null checks on polymorphic references.

### DIFF
--- a/packages/orm/src/QueryParser.ts
+++ b/packages/orm/src/QueryParser.ts
@@ -238,6 +238,17 @@ export function parseFindQuery(
                   cond: f,
                 });
               });
+            } else if (f.kind === "not-null") {
+              const conditions = field.components.map((comp) => {
+                const column = field.serde.columns.find((c) => c.columnName === comp.columnName)!;
+                return {
+                  alias: fa,
+                  column: comp.columnName,
+                  dbType: column.dbType,
+                  cond: { kind: "not-null" },
+                };
+              }) satisfies ColumnCondition[];
+              inlineExpressions.push({ op: "or", conditions });
             } else if (f.kind === "in") {
               // Split up the ids by constructor
               const idsByConstructor = groupBy(f.value, (id) => getConstructorFromTaggedId(id as string).name);

--- a/packages/tests/integration/src/entities/inserts.ts
+++ b/packages/tests/integration/src/entities/inserts.ts
@@ -71,7 +71,15 @@ export function insertComment(row: {
   return testDriver.insert("comments", row);
 }
 
-export function insertUser(row: { id?: number; name: string; email?: string; password?: string; author_id?: number }) {
+export function insertUser(row: {
+  id?: number;
+  name: string;
+  email?: string;
+  password?: string;
+  author_id?: number;
+  favorite_publisher_small_id?: number;
+  favorite_publisher_large_id?: number;
+}) {
   return testDriver.insert("users", {
     email: `${row.name}@example.com`,
     password: "password",


### PR DESCRIPTION
Originally the QueryParser/poly handling code could only do ANDs, which was fine for "IS NULL" checks, but couldn't also do "OR"s.

A recent-ish refactoring of QueryParser added inlineExpressions (optional ORs), in addition to the inlineConditions (ANDs), so this is easy/able to implement now.