### PR TITLE
fix: nin any -> all operator in `buildKnexQuery`

### DIFF
--- a/packages/orm/src/drivers/buildKnexQuery.ts
+++ b/packages/orm/src/drivers/buildKnexQuery.ts
@@ -122,7 +122,7 @@ function buildCondition(cc: ColumnCondition): [string, any[]] {
     case "in":
       return [`${columnName} = any(?)`, [cond.value]];
     case "nin":
-      return [`${columnName} != any(?)`, [cond.value]];
+      return [`${columnName} != all(?)`, [cond.value]];
     case "between":
       return [`${columnName} between ? and ?`, cond.value];
     default:


### PR DESCRIPTION
Fixes the `nin` condition within `buildKnexQuery` to use `all()` rather than `any()` which for `nin` entirely permissive.

This is inline with findDataLoader's `makeOp`: https://github.com/stephenh/joist-ts/blob/8960c68ae54cbe0f9d5907ad4aac5520d8383fa5/packages/orm/src/dataloaders/findDataLoader.ts#L271
