### PR TITLE
fix: Avoid failing on cross-schema triggers.

### DIFF
--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -95,8 +95,10 @@ async function maybeGenerateFlushFunctions(config: Config, client: Client, pgCon
 }
 
 async function loadSchemaMetadata(config: Config, client: Client): Promise<DbMetadata> {
-  // Assume other schemas are things like cyanaudit/graphile-worker, that we don't want entity for
-  const db = await pgStructure(client, { includeSchemas: "public" });
+  // Here we load all schemas, to avoid pg-structure failing on cross-schema foreign keys
+  // like our cyanaudit triggers (https://github.com/ozum/pg-structure/issues/85), and then
+  // later filter them non-public schema tables out.
+  const db = await pgStructure(client);
   const enums = await loadEnumMetadata(db, client, config);
   const pgEnums = await loadPgEnumMetadata(db, client, config);
   const entities = db.tables

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -175,5 +175,9 @@ export function uncapitalize(s: string): string {
 }
 
 function isIgnored(config: Config, t: Table): boolean {
-  return (config.ignoredTables || ["migrations", "pgmigrations"]).includes(t.name);
+  return (config.ignoredTables || ["migrations", "pgmigrations"]).includes(t.name) || !shouldIncludeSchema(t);
+}
+
+function shouldIncludeSchema(t: Table): boolean {
+  return t.schema.name === "public";
 }


### PR DESCRIPTION
The pg-structure bumps requires us to load all schemas, so that our cyanaudit triggers don't blow up the pg-structure load metadata step.