### PR TITLE
feat: Add preventEqualsOnEntities method for Jest.

### DIFF
--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,14 +1,25 @@
-import { BaseEntity } from "joist-orm";
+import { BaseEntity, Entity } from "joist-orm";
 import { MatchedEntity } from "./toMatchEntity";
+
 export { Context } from "./context";
+export { preventEqualsOnEntities } from "./preventEqualsOnEntities";
 export { ContextFn, makeRun, makeRunEach, newContext, run, runEach } from "./run";
 export { seed } from "./seed";
+export { toBeEntities } from "./toBeEntities";
+export { toBeEntity } from "./toBeEntity";
 export { toMatchEntity } from "./toMatchEntity";
 
 declare global {
   namespace jest {
     interface Matchers<R, T = {}> {
+      /** A `toMatchObject`-like matcher that will correctly diff Joist entities against an object literal structure. */
       toMatchEntity(expected: MatchedEntity<T>): CustomMatcherResult;
+
+      /** A `toEqual`-like matcher that will correctly diff a Joist. */
+      toBeEntity(expected: Entity): CustomMatcherResult;
+
+      /** A `toEqual`-like matcher that will correctly diff multiple Joist entities. */
+      toBeEntities(expected: Entity[]): CustomMatcherResult;
     }
   }
 }

--- a/packages/test-utils/src/preventEqualsOnEntities.ts
+++ b/packages/test-utils/src/preventEqualsOnEntities.ts
@@ -1,0 +1,8 @@
+import { BaseEntity } from "joist-orm";
+
+export function preventEqualsOnEntities(a: unknown, b: unknown): boolean | undefined {
+  if (a instanceof BaseEntity || b instanceof BaseEntity) {
+    throw new Error("Use toBeEntity, toBeEntities, or toMatchEntity for asserting against entities");
+  }
+  return undefined;
+}

--- a/packages/test-utils/src/toBeEntities.ts
+++ b/packages/test-utils/src/toBeEntities.ts
@@ -1,0 +1,13 @@
+import CustomMatcherResult = jest.CustomMatcherResult;
+import { Entity } from "joist-orm";
+import { toMatchEntity } from "./toMatchEntity";
+
+/**
+ * Provides a `toBe` / `toEqual` matcher that correctly diffs Joist entities.
+ *
+ * In particular, when `toEqual` assertions fail, even with custom equality testers, the
+ * Jest diff output for entities is huge and unhelpful.
+ */
+export function toBeEntities(this: any, actual: Entity[], expected: Entity[]): CustomMatcherResult {
+  return toMatchEntity.call(this, actual, expected);
+}

--- a/packages/test-utils/src/toBeEntity.ts
+++ b/packages/test-utils/src/toBeEntity.ts
@@ -1,0 +1,13 @@
+import CustomMatcherResult = jest.CustomMatcherResult;
+import { Entity } from "joist-orm";
+import { toMatchEntity } from "./toMatchEntity";
+
+/**
+ * Provides a `toBe` / `toEqual` matcher that correctly diffs Joist entities.
+ *
+ * In particular, when `toEqual` assertions fail, even with custom equality testers, the
+ * Jest diff output for entities is huge and unhelpful.
+ */
+export function toBeEntity(this: any, actual: Entity, expected: Entity): CustomMatcherResult {
+  return toMatchEntity.call(this, actual, expected);
+}

--- a/packages/tests/integration/src/setupDbTests.ts
+++ b/packages/tests/integration/src/setupDbTests.ts
@@ -1,11 +1,11 @@
 import { expect } from "@jest/globals";
 import { resetQueryCount, setApiCallMock, testDriver } from "@src/testEm";
-import { areEntitiesEqual, toMatchEntity } from "joist-test-utils";
+import { preventEqualsOnEntities, toBeEntities, toBeEntity, toMatchEntity } from "joist-test-utils";
 
 export const makeApiCall = jest.fn();
 
-expect.extend({ toMatchEntity });
-expect.addEqualityTesters([areEntitiesEqual]);
+expect.extend({ toMatchEntity, toBeEntity, toBeEntities });
+expect.addEqualityTesters([preventEqualsOnEntities]);
 
 beforeEach(async () => {
   setApiCallMock(makeApiCall);

--- a/packages/tests/integration/src/toMatchEntity.test.ts
+++ b/packages/tests/integration/src/toMatchEntity.test.ts
@@ -25,6 +25,7 @@ describe("toMatchEntity", () => {
     const b1 = newBook(em);
     await em.flush();
     expect(b1).toMatchEntity(b1);
+    expect(b1).toBeEntity(b1);
   });
 
   it("can match entity that is undefined", async () => {
@@ -352,6 +353,7 @@ describe("toMatchEntity", () => {
     expect(res).toMatchEntity([{ author1: a1 }] as readonly { author1: DeepNew<Author> }[]);
     expect(res as readonly { author1: DeepNew<Author> }[]).toMatchEntity([{ author1: a1 }]);
     expect([a1, a2]).toMatchEntity([a1, a2]);
+    expect([a1, a2]).toBeEntities([a1, a2]);
     expect(() => expect([a1, a2]).toMatchEntity([a2, a1])).toThrowErrorMatchingInlineSnapshot(`
       expect(received).toMatchObject(expected)
 
@@ -399,5 +401,13 @@ describe("toMatchEntity", () => {
       - ]
       + Array []
     `);
+  });
+
+  it("breaks toEqual being called with entities", async () => {
+    const em = newEntityManager();
+    const p1 = newAuthor(em, { firstName: "Author 1" });
+    expect(() => {
+      expect(p1).toEqual(p1);
+    }).toThrow("Use toBeEntity, toBeEntities, or toMatchEntity for asserting against entities");
   });
 });


### PR DESCRIPTION
Using toEquals with entities can cause issues b/c:

* The equality does a deep comparison of the entities & ends up diffing the entire EntityManager/ConnectionPool
* If equality fails, the toEquals diff similarily prints the entire entity + EntityManager + ConnectionPool

While it's possible to add custom equality matchers, to recognize the entities and do a custom equals check, it's not possible to, if the entities are _not_ equal, provide a custom diff output.

Because of this, we've created our own toMatchEntity, but it's hard to remember to use it, so this prompts the prompt by just breaking toEquals on entities all together.