### PR TITLE
fix: Move setBooted to end of configureMetadata

### DIFF
--- a/packages/orm/src/configure.ts
+++ b/packages/orm/src/configure.ts
@@ -18,13 +18,13 @@ const typeToMetaMap = new Map<string, EntityMetadata>();
 
 /** Performs our boot-time initialization, i.e. hooking up reactivity. */
 export function configureMetadata(metas: EntityMetadata[]): void {
-  setBooted();
   populateConstructorMaps(metas);
   setImmutableFields(metas);
   hookUpBaseTypeAndSubTypes(metas);
   reverseIndexReactivity(metas);
   populatePolyComponentFields(metas);
   fireAfterMetadatas(metas);
+  setBooted();
 }
 
 function fireAfterMetadatas(metas: EntityMetadata[]): void {


### PR DESCRIPTION
Moves `setBooted` to the end of `configureMetadata` since `fireAfterMetadatas` needs to be called before it.