### PR TITLE
docs: fix astro highlighting warning

### DIFF
--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -41,7 +41,7 @@ docker compose up -d db
 
 The `docker-compose.yml` exposes the `sample_app` database on port `5342`, so it is accessible with an environment variable of:
 
-```env
+```ini
 DATABASE_URL=postgres://sample_user:local@localhost:5432/sample_app
 ```
 


### PR DESCRIPTION
> 12:21:15 [WARN] [astro-expressive-code] Error while highlighting code block using language "env" in document "/Users/blimmer/code/homebound/joist-orm/docs/src/content/docs/getting-started/installation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.

Before:

<img width="1620" height="436" alt="Screenshot 2025-09-04 at 12 22 42" src="https://github.com/user-attachments/assets/93b952e3-a8f5-4a4a-9b8c-9a75a1b9b785" />

After:

<img width="1616" height="434" alt="Screenshot 2025-09-04 at 12 22 54" src="https://github.com/user-attachments/assets/7678a499-e451-48c9-9649-47be83d2a180" />
