### PR TITLE
fix: Don't set opts for derived fields.

### DIFF
--- a/packages/orm/src/newTestInstance.ts
+++ b/packages/orm/src/newTestInstance.ts
@@ -426,7 +426,7 @@ function applyUse(optsMaybeNew: object, use: UseMap, metadata: EntityMetadata): 
     .filter((f) => !(f.fieldName in opts))
     .forEach((f) => {
       // And set them to the current `use` entity for their type, if it exists
-      if ((isManyToOneField(f) || isOneToOneField(f)) && use.has(f.otherMetadata().cstr)) {
+      if (((isManyToOneField(f) && !f.derived) || isOneToOneField(f)) && use.has(f.otherMetadata().cstr)) {
         const def = use.get(f.otherMetadata().cstr)!;
         // Only pass explicit/user-defined `use` entities, so that factories can "fan out" if they want,
         // and not see other factory-created entities look like user-specific values.

--- a/packages/orm/src/relations/ReactiveReference.ts
+++ b/packages/orm/src/relations/ReactiveReference.ts
@@ -334,7 +334,7 @@ export class ReactiveReferenceImpl<
   }
 
   setFromOpts(_: U | IdOf<U> | N): void {
-    throw new Error("ReactiveReferences cannot be set via opts");
+    throw new Error(`ReactiveReference ${this.entity}.${this.fieldName} cannot be set via opts`);
   }
 
   maybeCascadeDelete(): void {


### PR DESCRIPTION
If a test used the `use` feature like:

```
const projectItem = newProjectItem(em, {
  commitmentLineItems: [{}],
  use: [tradePartner],
});
```

We were passing `tradePartner` into for m2o fields that were ReactiveReferences and so would cause a "RR cannot be set opts" error.