### PR TITLE
fix: use Object.hasOwn to check if a class has had relations moved

### DIFF
--- a/packages/orm/src/newEntity.ts
+++ b/packages/orm/src/newEntity.ts
@@ -18,7 +18,7 @@ const lazySymbol = Symbol("lazy");
  * let any `this.books` accesses resolve to the getters we've installed on the prototype.
  */
 export function newEntity<T extends Entity>(em: EntityManager, cstr: EntityConstructor<T>, isNew: boolean): T {
-  if (!cstr.hasOwnProperty(lazySymbol)) {
+  if (!Object.hasOwn(cstr, lazySymbol)) {
     moveRelationsToGetters(cstr);
     (cstr as any)[lazySymbol] = true;
   }


### PR DESCRIPTION
The symbol is inherited by subclasses, so if a base class is instantiated first then all subclasses will have it defined and will never get their relations/fields moved