### PR TITLE
fix: Add appendStack to em.populate

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -1324,15 +1324,33 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       const [preload, non] = this.#preloader.partitionHint(meta, hintOpt);
       if (preload) {
         const loader = populateDataLoader(this, meta, preload, "preload", opts);
-        await Promise.all(list.map((entity) => loader.load({ entity, hint: preload })));
+        await Promise.all(
+          list.map((entity) =>
+            loader.load({ entity, hint: preload }).catch(function populate(err: any) {
+              throw appendStack(err, new Error());
+            }),
+          ),
+        );
       }
       if (non) {
         const loader = populateDataLoader(this, meta, non, "intermixed", opts);
-        await Promise.all(list.map((entity) => loader.load({ entity, hint: non })));
+        await Promise.all(
+          list.map((entity) =>
+            loader.load({ entity, hint: non }).catch(function populate(err: any) {
+              throw appendStack(err, new Error());
+            }),
+          ),
+        );
       }
     } else {
       const loader = populateDataLoader(this, meta, hintOpt, "intermixed", opts);
-      await Promise.all(list.map((entity) => loader.load({ entity, hint: hintOpt })));
+      await Promise.all(
+        list.map((entity) =>
+          loader.load({ entity, hint: hintOpt }).catch(function populate(err: any) {
+            throw appendStack(err, new Error());
+          }),
+        ),
+      );
     }
 
     return fn ? fn(entityOrList as any) : (entityOrList as any);


### PR DESCRIPTION
I couldn't easily reproduce in a `EntityManager.populate.test` but these "oh its Location calling this"

```
    at async Promise.all (index 0)
    at async EntityManager.populate (node_modules/joist-orm/src/EntityManager.ts:1347:7)
    at async Location.generateDesignPackageAltConfigs (src/entities/Location.ts:189:15)
    at async copyPlanPackageTlis (src/jobs/copyTemplateItems/copyPlanPackageToDesignPackage.ts:78:31)
    at async Promise.all (index 0)
    at async copyPlanPackageToDesignPackage (src/jobs/copyTemplateItems/copyPlanPackageToDesignPackage.ts:34:3)
    at async <anonymous> (node_modules/joist-orm/src/EntityManager.ts:1371:22)
    at async <anonymous> (node_modules/joist-orm/src/drivers/PostgresDriver.ts:90:24)
```

Were missing without this change.