### PR TITLE
fix: Remove ensureLoaded from m2o.isTaggedMaybe.

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -3,5 +3,3 @@ procs:
     shell: "yarn db"
   build:
     shell: "yarn build -w"
-  shell:
-    shell: "$SHELL"

--- a/packages/orm/src/relations/ManyToOneReference.ts
+++ b/packages/orm/src/relations/ManyToOneReference.ts
@@ -214,7 +214,8 @@ export class ManyToOneReferenceImpl<T extends Entity, U extends Entity, N extend
 
   /** Returns the tagged id of the current value, or undefined if unset or a new entity. */
   get idTaggedMaybe(): TaggedId | undefined {
-    ensureNotDeleted(this.entity, "pending");
+    // Skip the deleted check so that `isPreloaded` doesn't blow up during em.refreshes/populates
+    // ensureNotDeleted(this.entity, "pending");
     return maybeResolveReferenceToId(this.current());
   }
 


### PR DESCRIPTION
Otherwise in ~esoteric cases, am `em.refresh()` when an entity had been deleted would go CustomReference.load -> em.populate -> m2o.isPreloaded -> m2o.maybeFindEntity -> m2o.idTaggedMaybe and blow b/c the entity was deleted.