### PR TITLE
fix: Fix findOrCreate lowered values used for em.create.

### DIFF
--- a/packages/tests/integration/src/EntityManager.findOrCreate.test.ts
+++ b/packages/tests/integration/src/EntityManager.findOrCreate.test.ts
@@ -350,6 +350,12 @@ describe("EntityManager.findOrCreate", () => {
     const a2 = await em.findOrCreate(Author, { firstName: "a1", lastName: "" }, {});
     expect(a2).toMatchEntity(a1);
   });
+
+  it("uses trimmed but not lowered value", async () => {
+    const em = newEntityManager();
+    const t1 = await em.findOrCreate(Tag, { name: " First " }, {});
+    expect(t1.name).toBe("First");
+  });
 });
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
Fixes a regression from the previous "trim values" PR.