### PR TITLE
fix: expose lastNow for tests that do manual time management

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -2799,7 +2799,12 @@ function maybeBumpUpdatedAt(todos: Record<string, Todo>, now: Date): void {
   }
 }
 
-let lastNow = new Date();
+let lastNow = undefined as Date | undefined;
+
+// exposed so tests that do their own time management can override lastNow to get correct updatedAt values
+export function setLastNow(now: Date | undefined) {
+  lastNow = now;
+}
 
 function getNow(): Date {
   let now = new Date();
@@ -2808,7 +2813,7 @@ function getNow(): Date {
   // with exactly the same `updated_at`, the `updated_at` SQL trigger fallback will think "the caller
   // didn't self-manage `updated_at`" and so bump it for them. Which is fine, but now
   // Joist doesn't know about the bumped time, and the 2nd `UPDATE` will fail.
-  if (lastNow.getTime() === now.getTime() || now.getTime() < lastNow.getTime()) {
+  if (lastNow && (lastNow.getTime() === now.getTime() || now.getTime() < lastNow.getTime())) {
     now = new Date(lastNow.getTime() + 1);
   }
   lastNow = now;


### PR DESCRIPTION
The current `lastNow` implementation makes it so joist does not respect frozen time when bumping `updatedAt` during an `UPDATE`.  `lastNow` is seeded as the current system time at boot.  Any frozen test date in the past will be overridden since `lastNow` is after them. In tests with `UPDATE`s,  `updatedAt` will be set sequentially in 1 ms increments from boot time across each test that is run.  This effectively makes testing against `updatedAt` impossible.

This PR fixes the behavior by:
* Allowing `lastNow` to be undefined, in which case its assumed that no flushes have been performed yet and thus whatever `new Date()` returns is correct
* Exposing a `setLastNow` so that tests doing manual time management can reset this behavior before they run