### PR TITLE
feat: Support o2m fields in touchOnChange.

### DIFF
--- a/packages/tests/integration/src/entities/Book.ts
+++ b/packages/tests/integration/src/entities/Book.ts
@@ -4,6 +4,7 @@ import { Author, BookCodegen, bookReviewBeforeFlushRan, bookConfig as config } f
 export class Book extends BookCodegen {
   transientFields = {
     rulesInvoked: 0,
+    hooksInvoked: 0,
     firstNameRuleInvoked: 0,
     favoriteColorsRuleInvoked: 0,
     reviewsRuleInvoked: 0,
@@ -122,11 +123,17 @@ config.addReaction("notes", (b) => {
 // Example of a trigger for a many-to-many field
 config.touchOnChange("tags");
 
+// Example of a trigger for a one-to-many field
+config.touchOnChange("reviews");
+
 config.beforeFlush((book) => {
   // Arbitrary logic to show this hook fired, the relevant logic here is the `book.changes.fields.includes("tags")`
   if (book.changes.fields.includes("tags") && book.title.includes("To be changed by hook")) {
     book.title = "Tags Changed";
   }
+  // For testing touchOnChange(reviews); we can't use changes.fields.includes("reviews") because we want
+  // any review change (i.e. ratings changing) to trigger this, not just adding/removing reviews.
+  book.transientFields.hooksInvoked++;
 });
 
 // For testing cross-entity hook ordering


### PR DESCRIPTION
I had noticed a week or so ago that `config.touchOnChange`:

1. Only worked for m2m relations, but
2. Did not fail if called with o2m relations

B/c we had a relation that was m2m, but we promoted the m2m table to a real entity, so the relation name stayed the same, but it went from a m2m to a o2m, and we forgot to update the `touchOnChange` call -- it just become a noop.

I'd thought that teaching `touchOnChange` about o2m relations would be a good way to round out the feature, and provide a replacement for our `touchParentOnChange`, but ran into:

- The m2m `touchOnChange` only triggers on m2m adds/removes, it doesn't actually trigger on "the content of a 'child' changes"
- My initial o2m `touchOnChange` impl does trigger on either "a child is added/removed" or "a child has any field changed" (like `touchParentOnChange`)

But I don't like these differing semantics. Options to resolve this are:

1. Make `touchOnChange` for both m2m and o2m fire on "child is added/removed/changed"
   * Pro: Consistent
   * Pro: Replaces touchParentOnChange
   * Con: Likely overkill for m2m use cases, b/c m2m relations aren't really "parent/child"
2. Use an opt flag to `touchOnChange` like `{ addedRemove: true; change: true }` or `{ on: "collection-change" | "any-change" }`
   * Pro: Flexible
   * Con: I can't think of a good API
   * Con: Probably overkill
3. Deprecate/remove `touchOnChange` all together b/c `addReaction` exists now and is likely the better API for the job anyway

Currently leaning towards 3 -- I think if `addReaction` had already existed, we would not have added the `config.touchOnChange` hack for m2ms -- so might as well remove it now, and simplify our API/impl surface area.