### PR TITLE
fix: o(n^2) on clone complexity

### DIFF
--- a/packages/orm/src/EntityManager.ts
+++ b/packages/orm/src/EntityManager.ts
@@ -947,7 +947,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
       return [entity, clone] as const;
     });
-    const entityToClone = new Map(clones);
+    const entityToClone: Map<EntityW, EntityW> = new Map(clones);
 
     // 3. Now mutate the m2o relations. We focus on only m2o's because they "own" the field/column,
     // and will drive percolation to keep the other-side o2m & o2o updated.
@@ -961,7 +961,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
           // What's the existing entity? Have we cloned it?
           const existingIdOrEntity = getField(clone, fieldName);
           // Use O(1) lookup via #entitiesById Map instead of O(N) .find() scan
-          const existing = this.findExistingInstance(existingIdOrEntity) as Entity;
+          const existing = isEntity(existingIdOrEntity) ? existingIdOrEntity : this.getEntity(existingIdOrEntity);
           // If we didn't find a loaded entity for this value, assume that it a) itself is not being cloned,
           // and b) we don't need to bother telling it about the newly cloned entity
           if (existing) {


### PR DESCRIPTION
When cloning a large number of entities, em.clone has O(n²) complexity due to [this line](https://github.com/joist-orm/joist-orm/blob/main/packages/orm/src/EntityManager.ts#L963):

```ts
const existing = this.entities.find((e) => sameEntity(e, existingIdOrEntity));
```

This performs a linear scan through all entities for each clone operation. Since there's already a Map (#entitiesById) that provides O(1) lookup via findExistingInstance(), we can use that instead.