### PR TITLE
feat: Track internal / trusted calls

### DIFF
--- a/packages/orm/src/fields.ts
+++ b/packages/orm/src/fields.ts
@@ -15,8 +15,8 @@ import { fail } from "./utils";
  */
 export function getField(entity: Entity, fieldName: string): any {
   const { em } = entity;
-  // Need to know if we're an "internal" call (from hooks, RFs)...
-  getEmInternalApi(em).pluginManager.beforeGetField(entity, fieldName);
+  const api = getEmInternalApi(em);
+  api.pluginManager.beforeGetField(entity, fieldName);
   // We may not have converted the database column value into domain values yet
   const { data, row } = getInstanceData(entity);
   if (fieldName in data) {
@@ -61,6 +61,7 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
   const api = getEmInternalApi(em);
   const { rm, pluginManager, indexManager, fieldLogger, isLoadedCache } = api;
 
+  // If we're flushing, only allow writes from hooks
   api.checkWritesAllowed();
 
   // Tell any `#isLoaded` or `#value` caches that they might be stale

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -120,6 +120,7 @@ export {
 export { setRuntimeConfig, type RuntimeConfig } from "./runtimeConfig";
 export * from "./serde";
 export * from "./temporalMappers";
+export { isInTrustedContext } from "./trusted";
 export * from "./typeMap";
 export { buildUnnestCte } from "./unnest";
 export { DeepPartialOrNull, updatePartial, upsert } from "./upsert";

--- a/packages/orm/src/trusted.ts
+++ b/packages/orm/src/trusted.ts
@@ -1,0 +1,13 @@
+import { AsyncLocalStorage } from "async_hooks";
+
+const trustedContext = new AsyncLocalStorage<boolean>();
+
+/** Returns true if we're inside a trusted context (reactive field recalculation or validation). */
+export function isInTrustedContext(): boolean {
+  return trustedContext.getStore() === true;
+}
+
+/** Runs the given function within a trusted context. */
+export function runInTrustedContext<T>(fn: () => T): T {
+  return trustedContext.run(true, fn);
+}


### PR DESCRIPTION
I'm prototyping a plugin that does auth, and we need to know:

- did the user call this code i.e. is it being put on the wire, or
- did our "trusted code" (a hook or reactive field) do this `getField` or `setField`?

This will let the auth plugin ignore trusted code.

We probably also need to handle:

- `hasManyThrough` / `hasDerived`s -- should they be considered their own fields
- `hasAsyncMethods` -- also their own fields/actions?
