### PR TITLE
fix: Support null in findOrCreate.

### DIFF
--- a/.idea/runConfigurations/_template__of_Jest2.xml
+++ b/.idea/runConfigurations/_template__of_Jest2.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="JavaScriptTestRunnerJest">
+    <node-interpreter value="project" />
+    <node-options value="--experimental-vm-modules" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/core/src/IndexManager.ts
+++ b/packages/core/src/IndexManager.ts
@@ -8,7 +8,7 @@ type FieldName = string;
 type EntityTag = string;
 
 // The test reproducing a n^2 with n=500 went from 100ms to 50ms if indexed
-const indexThreshold = 500;
+export const indexThreshold = 500;
 
 /**
  * IndexManager provides field-based indexing for entity queries to avoid O(n) linear scans of `em.entities`.
@@ -172,6 +172,8 @@ class FieldIndex {
       }
       return matchId ?? matchInstance;
     }
+    // Treat null and undefined as equivalent for unset relations
+    if (value === null) value = undefined;
     return this.#valueToEntities.get(value);
   }
 

--- a/packages/core/src/dataloaders/findOrCreateDataLoader.ts
+++ b/packages/core/src/dataloaders/findOrCreateDataLoader.ts
@@ -138,7 +138,8 @@ export function entityMatches<T extends Entity>(entity: T, opts: Partial<OptsOf<
           // Otherwise use ids
           return sameEntity(relation.id as any, value as any);
         } else {
-          return value === undefined;
+          // Relation is not set, match if value is null-ish (null or undefined)
+          return value === undefined || value === null;
         }
       default:
         throw new Error(`Unsupported field ${fieldName}`);

--- a/packages/tests/integration/src/EntityManager.findOrCreate.test.ts
+++ b/packages/tests/integration/src/EntityManager.findOrCreate.test.ts
@@ -34,6 +34,24 @@ describe("EntityManager.findOrCreate", () => {
     await em.findOrCreate(Author, { publisher: undefined }, { firstName: "a2" });
   });
 
+  it("can find by null unloaded m2o field with findOrCreate", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    const a1 = await em.load(Author, "a:1");
+    // Using null instead of undefined should also find the existing author
+    const a2 = await em.findOrCreate(Author, { publisher: null }, { firstName: "a2" });
+    expect(a2).toMatchEntity(a1);
+  });
+
+  it("can find in-memory entity by null m2o field with findOrCreate", async () => {
+    const em = newEntityManager();
+    // Create an author with no publisher
+    const a1 = em.create(Author, { firstName: "a1" });
+    // Using null should find the in-memory entity
+    const a2 = await em.findOrCreate(Author, { publisher: null }, { firstName: "a2" });
+    expect(a2).toMatchEntity(a1);
+  });
+
   it("can create with findOrCreate", async () => {
     const em = newEntityManager();
     em.create(Author, { firstName: "a1" });


### PR DESCRIPTION
I'd attempted to assert "everyone should just pass undefined to findOrCreate" but it's admittedly unintuitive b/c `find` prunes `undefined`, which leads to thinking "surely `findOrCreate` will prune as well ... so I should use `null`".

So this PR teaches `findOrCreate` to support `null` or `undefined`.

There is still admittedly some ambiguity b/c users might think "surely `findOrCreate` prunes like `find` does" -- which it does not.

Maybe I made the wrong decision here, and `findOrCreate` should actually prune, but that would be a large breaking change 