### PR TITLE
fix: Fix stale preload cache causing dropped entities.

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1704,9 +1704,10 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         }
         mutatedCollections.clear();
 
-        // Reset the find caches b/c data will have changed in the db
+        // Reset the find/preload caches b/c data will have changed in the db
         this.#dataloaders = {};
         this.#batchLoaders = {};
+        this.#preloadedRelations = new Map();
         this.#rm.clear();
       }
 


### PR DESCRIPTION
When em.recalc (or any populate with forceReload: true) ran on an entity whose o2m collection had entities loaded, those entities could be silently dropped.

The sequence:

- 1. Entity a created and flushed (no children yet)
- 2. Child b1 added to a.books (not yet flushed)
- 3. A populate runs (via recalc), which queries the DB and caches [] in the preload cache for a.books (since b1 isn't in the DB yet). The #added set preserves b1 during this applyLoad.
- 4. em.flush() — persists b1 to DB, and calls resetAddedRemoved() which clears #added.
- 5. A second populate with forceReload: true runs.
  - The stale preload cache still has [] from step 3.
  - The isPreloaded check at populateBatchLoader.ts:123 returns true, calling preload() → applyLoad([]).
  - With #added now empty (cleared in step 4), b1 is dropped from the collection.

Root Cause:

The #preloadedRelations cache in EntityManager was not cleared during em.flush().