### PR TITLE
feat: Use EXISTS for collection joins

### DIFF
--- a/docs/src/content/docs/features/queries-find.md
+++ b/docs/src/content/docs/features/queries-find.md
@@ -176,6 +176,39 @@ The aliases use method calls to create conditions (i.e. `.eq(1)`), which is a di
 - `gte(1)`
 - `gte(1)`
 
+## Collection Filters: `EXISTS` vs. `LEFT JOIN`
+
+For collection relations (`one-to-many` and `many-to-many`), Joist usually renders filters as `EXISTS` subqueries instead of `LEFT JOIN`s. This avoids row explosion when querying multiple collections:
+
+```ts
+await em.find(Author, {
+  books: { title: "b1" },
+  comments: { text: "c1" },
+});
+```
+
+```sql
+WHERE EXISTS (SELECT 1 FROM books b WHERE b.author_id = a.id AND b.title = 'b1')
+  AND EXISTS (SELECT 1 FROM comments c WHERE c.parent_author_id = a.id AND c.text = 'c1')
+```
+
+Some alias conditions, especially `OR`s that mix collection aliases with outer aliases, require all aliases to be in the same SQL scope. In those cases Joist falls back to `LEFT JOIN`s.
+
+Because multiple collection `LEFT JOIN`s can create large intermediate row fanouts, Joist rejects them by default before join pruning. If you have verified the query is intentional and safe, opt in with `allowMultipleLeftJoins`:
+
+```ts
+const [a, b, c] = aliases(Author, Book, Comment);
+
+await em.find(
+  Author,
+  { as: a, books: { as: b }, comments: { as: c } },
+  {
+    conditions: { or: [b.title.eq("b1"), c.text.eq("c1")] },
+    allowMultipleLeftJoins: true,
+  },
+);
+```
+
 ## Condition & Join Pruning
 
 Find queries have special treatment of `undefined`, to facilitate constructing complex queries:

--- a/packages/core/src/ConditionBuilder.ts
+++ b/packages/core/src/ConditionBuilder.ts
@@ -10,7 +10,7 @@ import {
   skipCondition,
 } from "./QueryParser";
 import { Column } from "./serde";
-import { assertNever, partition } from "./utils";
+import { partition } from "./utils";
 
 type PartialSome<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
@@ -87,82 +87,21 @@ export class ConditionBuilder {
     }
   }
 
-  /** Combines our collected `conditions` & `expressions` into a single `ParsedExpressionFilter`. */
+  /** Combines our collected `conditions` and `expressions` into a single `ParsedExpressionFilter`. */
   toExpressionFilter(): ParsedExpressionFilter | undefined {
     const { expressions, conditions } = this;
-    if (conditions.length === 0 && expressions.length === 1) {
+    const allSimple: ParsedExpressionCondition[] = [...conditions];
+    if (allSimple.length === 0 && expressions.length === 1) {
       // If no inline conditions, and just 1 opt expression, just use that
       return expressions[0];
     } else if (expressions.length === 1 && expressions[0].op === "and") {
       // Merge the 1 `AND` expression with the other simple conditions
-      return { kind: "exp", op: "and", conditions: [...conditions, ...expressions[0].conditions] };
-    } else if (conditions.length > 0 || expressions.length > 0) {
+      return { kind: "exp", op: "and", conditions: [...allSimple, ...expressions[0].conditions] };
+    } else if (allSimple.length > 0 || expressions.length > 0) {
       // Combine the conditions within the `em.find` join literal & the `conditions` as ANDs
-      return { kind: "exp", op: "and", conditions: [...conditions, ...expressions] };
+      return { kind: "exp", op: "and", conditions: [...allSimple, ...expressions] };
     }
     return undefined;
-  }
-
-  /**
-   * Finds `child.column.eq(...)` complex conditions that need pushed down into each lateral join.
-   *
-   * Once we find something like `{ column: "first_name", cond: { eq: "a1" } }`, we return it to the
-   * caller (for injection into the lateral join's `SELECT` clause), and replace it with a boolean
-   * expression that is basically "did any of my children match this condition?".
-   *
-   * We also assume that `findAndRewrite` is only called on the top-level/user-facing `ParsedFindQuery`,
-   * and not any intermediate `CteJoinTable` queries (which are allowed to have their own
-   * `ConditionBuilder`s for building their internal query, but it's not exposed to the user,
-   * so won't have any truly-complex conditions that should need rewritten).
-   *
-   * @param topLevelLateralJoin the outermost lateral join alias, as that will be the only alias
-   *   that is visible to the rewritten condition, i.e. `_alias._whatever_condition_`.
-   * @param alias the alias being "hidden" in a lateral join, and so its columns/data won't be
-   *   available for the top-level condition to directly AND/OR against.
-   */
-  findAndRewrite(topLevelLateralJoin: string, alias: string): { cond: ColumnCondition; as: string }[] {
-    let j = 0;
-    const found: { cond: ColumnCondition; as: string }[] = [];
-    const todo: ParsedExpressionCondition[][] = [this.conditions];
-    for (const exp of this.expressions) todo.push(exp.conditions);
-    while (todo.length > 0) {
-      const array = todo.pop()!;
-      array.forEach((cond, i) => {
-        if (cond.kind === "column") {
-          // Use startsWith to look for `_b0` / `_s0` base/subtype conditions
-          if (cond.alias === alias || cond.alias.startsWith(`${alias}_`)) {
-            if (cond.column === "_") return; // Hack to skip rewriting `alias._ > 0`
-            const as = `_${alias}_${cond.column}_${j++}`;
-            array[i] = {
-              kind: "raw",
-              aliases: [topLevelLateralJoin],
-              condition: `${topLevelLateralJoin}.${as}`,
-              bindings: [],
-              pruneable: false,
-              ...{ rewritten: true },
-            } satisfies RawCondition;
-            found.push({ cond, as });
-          }
-        } else if (cond.kind === "exp") {
-          todo.push(cond.conditions);
-        } else if (cond.kind === "raw") {
-          // what would we do here?
-          if (cond.aliases.includes(alias)) {
-            // Look for a hacky hint that this is our own already-rewritten query; this is likely
-            // because `findAndRewrite` is mutating condition expressions that get passed into
-            // `parseFindQuery` multiple times, i.e. while batching/dataloading.
-            //
-            // ...although in theory parseExpression should already be making a copy of any user-facing
-            // `em.find` conditions. :thinking:
-            if ("rewritten" in cond) return;
-            throw new Error("Joist doesn't support raw conditions in lateral joins yet");
-          }
-        } else {
-          assertNever(cond);
-        }
-      });
-    }
-    return found;
   }
 }
 

--- a/packages/core/src/EntityFilter.ts
+++ b/packages/core/src/EntityFilter.ts
@@ -12,6 +12,7 @@ export type FilterAndSettings<T extends Entity> = {
   limit?: number;
   offset?: number;
   softDeletes?: "exclude" | "include";
+  allowMultipleLeftJoins?: boolean;
 };
 
 export type OrderBy = "ASC" | "DESC";

--- a/packages/core/src/EntityGraphQLFilter.ts
+++ b/packages/core/src/EntityGraphQLFilter.ts
@@ -13,6 +13,7 @@ export type GraphQLFilterAndSettings<T extends Entity> = {
   limit?: number | null;
   offset?: number | null;
   softDeletes?: "exclude" | "include";
+  allowMultipleLeftJoins?: boolean;
 };
 
 /**

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -58,6 +58,7 @@ import {
   Lens,
   loadLens,
   OneToManyCollection,
+  optimizeCollectionJoins,
   ParsedFindQuery,
   parseFindQuery,
   PartialOrNull,
@@ -127,6 +128,7 @@ export interface FindFilterOptions<T extends Entity> {
   conditions?: ExpressionFilter;
   orderBy?: OrderOf<T> | OrderOf<T>[];
   softDeletes?: "include" | "exclude";
+  allowMultipleLeftJoins?: boolean;
 }
 
 /**
@@ -149,6 +151,7 @@ export interface FindGqlPaginatedFilterOptions<T extends Entity> extends FindFil
 export interface FindCountFilterOptions<T extends Entity> {
   conditions?: ExpressionFilter;
   softDeletes?: "include" | "exclude";
+  allowMultipleLeftJoins?: boolean;
 }
 
 /**
@@ -494,7 +497,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     const { populate, limit, offset, ...rest } = options || {};
     const meta = getMetadata(type);
     const query = parseFindQuery(meta, where, rest);
-    const rows = await this.executeFind(meta, "findPaginated", query, { limit, offset, checkLimit: false });
+    const rows = await this.executeFind(meta, "findPaginated", query, { ...rest, limit, offset, checkLimit: false });
     const result = this.hydrate(type, rows);
     if (populate) {
       await this.populate(result, populate);
@@ -502,15 +505,24 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     return result;
   }
 
+  /** Runs the post-parse find pipeline: plugins mutate the logical AST, then Joist optimizes/prunes before SQL. */
   private async executeFind(
     meta: EntityMetadata,
     operation: FindOperation,
     parsed: ParsedFindQuery,
-    settings: { limit?: number; offset?: number; checkLimit?: boolean },
+    settings: {
+      limit?: number;
+      offset?: number;
+      checkLimit?: boolean;
+      allowMultipleLeftJoins?: boolean;
+      pruneJoins?: boolean;
+      keepAliases?: string[];
+    },
   ) {
     const { checkLimit, ...driverSettings } = settings;
     const { pluginManager } = getEmInternalApi(this);
     pluginManager.beforeFind(meta, operation, parsed, driverSettings);
+    optimizeCollectionJoins(parsed, settings);
     const rows = await this.driver.executeFind(this, parsed, driverSettings);
     // Check by default unless explicitly disabled or the caller removed the LIMIT via `limit: undefined`
     const shouldCheck = checkLimit ?? !("limit" in settings && settings.limit === undefined);

--- a/packages/core/src/PluginManager.ts
+++ b/packages/core/src/PluginManager.ts
@@ -32,7 +32,13 @@ interface PluginMethods {
     meta: EntityMetadata,
     operation: FindOperation,
     query: ParsedFindQuery,
-    settings: { limit?: number; offset?: number },
+    settings: {
+      limit?: number;
+      offset?: number;
+      allowMultipleLeftJoins?: boolean;
+      pruneJoins?: boolean;
+      keepAliases?: string[];
+    },
   ): void;
   /**
    * Called after a find operation has been executed with the raw database rows.
@@ -142,7 +148,13 @@ export class PluginManager implements Required<PluginMethods> {
     meta: EntityMetadata,
     operation: FindOperation,
     query: ParsedFindQuery,
-    settings: { limit?: number; offset?: number },
+    settings: {
+      limit?: number;
+      offset?: number;
+      allowMultipleLeftJoins?: boolean;
+      pruneJoins?: boolean;
+      keepAliases?: string[];
+    },
   ): void {}
   afterFind(meta: EntityMetadata, operation: FindOperation, rows: any[]) {}
   afterWrite(entityTodos: Record<string, Todo>, joinRowTodos: Record<string, JoinRowTodo>): void {}

--- a/packages/core/src/QueryParser.collectionJoins.ts
+++ b/packages/core/src/QueryParser.collectionJoins.ts
@@ -1,0 +1,254 @@
+import {
+  type ExistsCondition,
+  type JoinTable,
+  maybeAddIdNotNulls,
+  parseAlias,
+  type ParsedExpressionCondition,
+  type ParsedExpressionFilter,
+  type ParsedFindQuery,
+  type PrimaryTable,
+  type RawCondition,
+} from "./QueryParser";
+import { pruneUnusedJoins } from "./QueryParser.pruning";
+import { assertNever } from "./utils";
+
+/**
+ * Rewrites eligible logical collection LEFT JOINs into EXISTS after plugins have mutated the AST.
+ *
+ * QueryParser intentionally leaves collection filters as ordinary joins so `beforeFind` plugins see
+ * stabler/simpler input than "sometimes JOINs / sometimes EXISTS".
+ *
+ * This pass runs after plugins and before SQL rendering:
+ *
+ * 1. `rewriteCollectionJoins` finds top-level collection joins and moves conditions that reference only
+ *    that subtree into a correlated EXISTS subquery. I.e. `{ books: { title: "b1" } }` becomes
+ *    `EXISTS (SELECT 1 FROM books b WHERE a.id = b.author_id AND b.title = 'b1')`.
+ * 2. The same helper recurses into the generated subquery, so nested collections become nested EXISTS clauses.
+ *    I.e. `{ books: { reviews: { rating: 5 } } }` becomes EXISTS(books WHERE EXISTS(reviews)).
+ * 3. Conditions that cannot be safely moved stay as LEFT JOINs. I.e. `OR(b.title = 'x', a.first_name = 'x')`
+ *    needs both aliases in one SQL scope, so `b` remains a join instead of becoming an EXISTS.
+ * 4. Remaining fanout LEFT JOIN roots are rejected unless `allowMultipleLeftJoins` is set,
+ *    because they can produce cross-product row explosions.
+ * 5. Finally, `maybeAddIdNotNulls` and `pruneUnusedJoins` clean up the joins that remain.
+ */
+export function optimizeCollectionJoins(
+  query: ParsedFindQuery,
+  opts: { allowMultipleLeftJoins?: boolean; pruneJoins?: boolean; keepAliases?: string[] } = {},
+): void {
+  const { allowMultipleLeftJoins = false, pruneJoins = true, keepAliases = [] } = opts;
+  for (const table of query.tables) {
+    // I.e. batched find/count queries wrap the real query in a LATERAL subquery; optimize that inner query too,
+    // but let the outer query decide final pruning so it can keep the lateral alias itself.
+    if (table.join === "lateral") optimizeCollectionJoins(table.query, { ...opts, pruneJoins: false });
+  }
+  rewriteCollectionJoins(query);
+
+  // I.e. after rewriting `{ books: { title: "b1" }, comments: { text: "c1" } }`, there should be no fanout LEFT
+  // JOIN roots left. If an OR forced both joins to stay, require an explicit opt-in because rows can multiply.
+  const fanoutLeftJoinAliases = query.tables
+    .filter((t) => t.join === "outer" && t.collection?.rootAlias === t.alias)
+    .map((t) => t.alias);
+  if (!allowMultipleLeftJoins && fanoutLeftJoinAliases.length > 1) {
+    throw new Error(
+      `em.find would issue multiple LEFT JOINs across collection relations (${fanoutLeftJoinAliases.join(
+        ", ",
+      )}); pass allowMultipleLeftJoins: true if this fanout is intentional`,
+    );
+  }
+
+  if (query.tables.some((t) => t.join === "outer")) {
+    // I.e. preserve legacy LEFT JOIN null semantics for any joins that could not become EXISTS.
+    maybeAddIdNotNulls(query);
+  }
+  if (pruneJoins) {
+    // I.e. remove logical collection joins that were replaced by EXISTS and any joins only needed before plugin edits.
+    pruneUnusedJoins(query, keepAliases);
+  }
+}
+
+/**
+ * Rewrites root-level collection join subtrees into EXISTS when their conditions are locally scoped.
+ *
+ * I.e. for `authors a -> books b -> book_reviews br`, `b` is the collection root and `br` is part of its subtree.
+ */
+function rewriteCollectionJoins(query: ParsedFindQuery): void {
+  // I.e. if `books b` is nested under another collection root, the parent pass should absorb it; don't rewrite it here.
+  const collectionAliases = new Set(
+    query.tables
+      .filter((t): t is JoinTable => t.join === "inner" || t.join === "outer")
+      .flatMap((t) => (t.collection ? [t.alias] : [])),
+  );
+  const roots = query.tables.filter(
+    (t) =>
+      (t.join === "inner" || t.join === "outer") &&
+      t.collection?.rootAlias === t.alias &&
+      !collectionAliases.has(t.collection.parentAlias),
+  ) as JoinTable[];
+
+  for (const root of roots) {
+    // I.e. for root `b`, this gathers `b`, `br`, and any other joins whose `col1` depends on that subtree.
+    const subtreeAliases = collectJoinSubtreeAliases(query, root.alias);
+    // I.e. move `b.title = 'x'` and `(br.rating = 5 OR br.rating = 4)`, but not `b.title = 'x' OR a.first_name = 'x'`.
+    const moved = query.condition ? removeLocallyScopedConditions(query.condition, subtreeAliases) : [];
+    const subqueryTables = query.tables.filter((t) => subtreeAliases.has(t.alias));
+    const hasOnlyAntiJoin = moved.length === 1 && isAliasIdNull(moved[0], root.alias);
+    if (moved.length === 0 && !hasOnlyAntiJoin) continue;
+    if (!hasOnlyAntiJoin && !moved.some(isRealCondition)) {
+      // I.e. only soft-delete/STI conditions moved; put them back so we don't create an EXISTS that changes nothing.
+      query.condition ??= { kind: "exp", op: "and", conditions: [] };
+      query.condition.conditions.push(...moved);
+      continue;
+    }
+    if (moved.length > 0 && moved.some((c) => isAliasIdNull(c, root.alias)) && !hasOnlyAntiJoin) {
+      // I.e. `b.id IS NULL AND b.title = 'x'` is not a pure anti-join; leave it as a LEFT JOIN for SQL semantics.
+      query.condition ??= { kind: "exp", op: "and", conditions: [] };
+      query.condition.conditions.push(...moved);
+      continue;
+    }
+
+    const correlation: RawCondition = {
+      kind: "raw",
+      aliases: [root.alias],
+      condition: `${root.col1} = ${root.col2}`,
+      bindings: [],
+      pruneable: false,
+    };
+    // I.e. a pure `b.id IS NULL` anti-join becomes `NOT EXISTS (SELECT 1 FROM books b WHERE a.id = b.author_id)`.
+    const conditions = hasOnlyAntiJoin ? [correlation] : [correlation, ...moved];
+    const subquery: ParsedFindQuery = {
+      selects: ["1"],
+      tables: subqueryTables.map((t) => {
+        // I.e. the collection root becomes the subquery's FROM table; children remain joins off that root.
+        if (t.alias === root.alias) return { join: "primary", alias: t.alias, table: t.table } satisfies PrimaryTable;
+        // I.e. by this point every moved condition is locally scoped and positive, like `br.rating = 5`; pure
+        // `br.id IS NULL` anti-joins are handled as NOT EXISTS at their own root, and mixed/null-sensitive cases stay
+        // as outer joins. So inside this EXISTS, child rows must exist to satisfy the moved filters, and INNER JOIN is
+        // equivalent to LEFT JOIN + WHERE child condition.
+        if (t.join === "inner" || t.join === "outer") return { ...t, join: "inner" as const };
+        return t;
+      }),
+      condition: { kind: "exp", op: "and", conditions },
+      orderBys: [],
+    };
+    // I.e. nested `books.reviews` first creates an EXISTS for books, then this recursive call creates EXISTS for reviews.
+    rewriteCollectionJoins(subquery);
+    const exists: ExistsCondition = {
+      kind: "exists",
+      negate: hasOnlyAntiJoin,
+      correlation,
+      joinColumns: { col1: root.col1, col2: root.col2 },
+      subquery,
+      outerAliases: [root.collection!.parentAlias],
+    };
+    query.condition ??= { kind: "exp", op: "and", conditions: [] };
+    query.condition.conditions.push(exists);
+    // I.e. after adding EXISTS, remove `books b` and its children from the outer FROM list.
+    query.tables = query.tables.filter((t) => !subtreeAliases.has(t.alias));
+  }
+  removeEmptyExpressions(query.condition);
+}
+
+/** Collects a collection root and all joins that depend on it, i.e. `b -> br -> c`. */
+function collectJoinSubtreeAliases(query: ParsedFindQuery, rootAlias: string): Set<string> {
+  const aliases = new Set([rootAlias]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const table of query.tables) {
+      if (table.join !== "inner" && table.join !== "outer") continue;
+      // I.e. `book_reviews br ON b.id = br.book_id` depends on `b`, so `br` belongs in the `b` subtree.
+      if (!aliases.has(table.alias) && aliases.has(parseAlias(table.col1))) {
+        aliases.add(table.alias);
+        changed = true;
+      }
+    }
+  }
+  return aliases;
+}
+
+/**
+ * Removes AND-safe conditions whose aliases all live inside one collection subtree.
+ *
+ * I.e. in `a.age = 1 AND b.title = 'x'`, only `b.title = 'x'` moves. In `b.title = 'x' OR br.rating = 5`,
+ * the whole OR moves only if every alias is inside the same subtree.
+ */
+function removeLocallyScopedConditions(exp: ParsedExpressionFilter, aliases: Set<string>): ParsedExpressionCondition[] {
+  if (exp.op === "or") {
+    // I.e. OR cannot be split across scopes; either move the whole OR into the EXISTS, or leave it outside.
+    if (!conditionReferencesOnlyAliases(exp, aliases)) return [];
+    const moved = { ...exp, conditions: [...exp.conditions] } satisfies ParsedExpressionFilter;
+    exp.conditions = [];
+    return [moved];
+  }
+  const moved: ParsedExpressionCondition[] = [];
+  for (let i = exp.conditions.length - 1; i >= 0; i--) {
+    const condition = exp.conditions[i];
+    if (condition.kind === "exp" && condition.op === "and") {
+      // I.e. flatten nested AND movement so `a AND (b AND br)` can still move `b` and `br` into the EXISTS.
+      moved.push(...removeLocallyScopedConditions(condition, aliases));
+      if (condition.conditions.length === 0) exp.conditions.splice(i, 1);
+    } else if (conditionReferencesOnlyAliases(condition, aliases)) {
+      // I.e. move `b.title = 'x'` out of the parent AND and into the collection EXISTS.
+      moved.unshift(condition);
+      exp.conditions.splice(i, 1);
+    }
+  }
+  return moved;
+}
+
+/** Returns true when a condition references at least one alias and all aliases are in `aliases`, i.e. only `b`/`br`. */
+function conditionReferencesOnlyAliases(condition: ParsedExpressionCondition, aliases: Set<string>): boolean {
+  const found = new Set<string>();
+  collectAllAliases(condition, found);
+  return found.size > 0 && [...found].every((alias) => aliases.has(alias));
+}
+
+/** Returns true for `alias.id IS NULL`, i.e. the parse shape for `{ books: { id: null } }`. */
+function isAliasIdNull(condition: ParsedExpressionCondition, alias: string): boolean {
+  return (
+    condition.kind === "column" &&
+    condition.alias === alias &&
+    condition.column === "id" &&
+    condition.cond.kind === "is-null"
+  );
+}
+
+/** Removes empty expression wrappers left behind by condition movement, i.e. `AND []` after all children moved. */
+function removeEmptyExpressions(exp: ParsedExpressionFilter | undefined): void {
+  if (!exp) return;
+  for (let i = exp.conditions.length - 1; i >= 0; i--) {
+    const condition = exp.conditions[i];
+    if (condition.kind === "exp") {
+      removeEmptyExpressions(condition);
+      if (condition.conditions.length === 0) exp.conditions.splice(i, 1);
+    }
+  }
+}
+
+/** Returns true if a condition must be preserved to maintain query semantics, i.e. user filters vs soft-delete filters. */
+function isRealCondition(condition: ParsedExpressionCondition): boolean {
+  if (condition.kind === "column" || condition.kind === "raw") {
+    return !condition.pruneable;
+  } else if (condition.kind === "exists") {
+    return true;
+  } else if (condition.kind === "exp") {
+    return condition.conditions.some(isRealCondition);
+  } else {
+    assertNever(condition);
+  }
+}
+
+/** Collects all aliases referenced by a condition, including inside nested expressions, i.e. `b` and `a` in an OR. */
+function collectAllAliases(cond: ParsedExpressionCondition, out: Set<string>): void {
+  if (cond.kind === "column") {
+    out.add(cond.alias);
+  } else if (cond.kind === "raw") {
+    for (const a of cond.aliases) out.add(a);
+  } else if (cond.kind === "exp") {
+    for (const c of cond.conditions) collectAllAliases(c, out);
+  } else if (cond.kind === "exists") {
+    // I.e. an EXISTS subquery is already a scoped unit; outer movement decisions should not inspect its internals.
+  } else {
+    assertNever(cond);
+  }
+}

--- a/packages/core/src/QueryParser.pruning.test.ts
+++ b/packages/core/src/QueryParser.pruning.test.ts
@@ -1,0 +1,34 @@
+import { selectReferencesAlias } from "./QueryParser.pruning";
+
+describe("QueryParser.pruning", () => {
+  describe("selectReferencesAlias", () => {
+    it("finds simple select references", () => {
+      expect(selectReferencesAlias("a.*", "a")).toBe(true);
+      expect(selectReferencesAlias("a.id as id", "a")).toBe(true);
+    });
+
+    it("finds quoted select references", () => {
+      expect(selectReferencesAlias('"a".*', "a")).toBe(true);
+      expect(selectReferencesAlias('"book".id as __source_id', "book")).toBe(true);
+    });
+
+    it("finds aliases inside generated CTI expressions", () => {
+      expect(selectReferencesAlias("COALESCE(p_s0.shared_column, p_s1.shared_column) as shared_column", "p_s0")).toBe(
+        true,
+      );
+      expect(
+        selectReferencesAlias("CASE WHEN p_s0.id IS NOT NULL THEN 'LargePublisher' ELSE '_' END as __class", "p_s0"),
+      ).toBe(true);
+    });
+
+    it("does not match alias prefixes", () => {
+      expect(selectReferencesAlias("p_s0.*", "p")).toBe(false);
+      expect(selectReferencesAlias("book_m2m.id", "book")).toBe(false);
+    });
+
+    it("does not match aliases inside longer identifiers", () => {
+      expect(selectReferencesAlias("foo.a.id", "a")).toBe(false);
+      expect(selectReferencesAlias('foo_"a".id', "a")).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/QueryParser.pruning.ts
+++ b/packages/core/src/QueryParser.pruning.ts
@@ -1,4 +1,11 @@
-import { ColumnCondition, ParsedExpressionFilter, ParsedFindQuery, RawCondition, parseAlias } from "./QueryParser";
+import {
+  ColumnCondition,
+  ExistsCondition,
+  ParsedExpressionFilter,
+  ParsedFindQuery,
+  RawCondition,
+  parseAlias,
+} from "./QueryParser";
 import { assertNever } from "./utils";
 
 // Remove any joins that are not used in the select or conditions
@@ -14,36 +21,47 @@ export function pruneUnusedJoins(parsed: ParsedFindQuery, keepAliases: string[])
       // Recurse into lateral joins...
       todo.push(...t.query.tables);
     } else if (t.join === "cross") {
-      // Doesn't have any conditions
-    } else if (t.join !== "primary") {
-      dt.addAlias(t.alias, [parseAlias(t.col1)]);
+      dt.markRequired(t.alias);
+    } else if (t.join === "primary") {
+      dt.markRequired(t.alias);
+    } else if (parsed.ctes?.some((cte) => cte.alias === t.table)) {
+      dt.markRequired(t.alias);
+    } else {
+      dt.addAlias(
+        t.alias,
+        [parseAlias(t.col1), parseAlias(t.col2)].filter((alias) => alias !== t.alias),
+      );
     }
   }
 
   // Mark all terminal usages
   parsed.selects.forEach((s) => {
     if (typeof s === "string") {
-      if (!s.includes("count(")) dt.markRequired(parseAlias(s));
-    } else {
+      markSelectAliases(dt, parsed, s);
+    } else if ("aliases" in s) {
       for (const a of s.aliases) dt.markRequired(a);
     }
   });
   parsed.orderBys.forEach((o) => dt.markRequired(o.alias));
   keepAliases.forEach((a) => dt.markRequired(a));
   // Look recursively into CTE & lateral join conditions
-  const todo2 = [parsed];
+  const todo2 = [{ query: parsed, filterPruneable: true }];
   while (todo2.length > 0) {
-    const query = todo2.pop()!;
-    deepFindConditions(query.condition, true).forEach((c) => {
+    const { query, filterPruneable } = todo2.pop()!;
+    deepFindConditions(query.condition, filterPruneable).forEach((c) => {
       if (c.kind === "column") {
         dt.markRequired(c.alias);
       } else if (c.kind === "raw") {
         for (const alias of c.aliases) dt.markRequired(alias);
+      } else if (c.kind === "exists") {
+        for (const alias of c.outerAliases) dt.markRequired(alias);
       } else {
         assertNever(c);
       }
     });
-    todo2.push(...query.tables.filter((t) => t.join === "lateral").map((t) => t.query));
+    todo2.push(
+      ...query.tables.filter((t) => t.join === "lateral").map((t) => ({ query: t.query, filterPruneable: false })),
+    );
   }
 
   // Now remove any unused joins
@@ -68,13 +86,50 @@ export function pruneUnusedJoins(parsed: ParsedFindQuery, keepAliases: string[])
   }
 }
 
+/** Marks aliases used by select strings, including generated CTI expressions like `COALESCE(st0.col, st1.col)`. */
+function markSelectAliases(dt: DependencyTracker, parsed: ParsedFindQuery, select: string): void {
+  for (const table of parsed.tables) {
+    if (selectReferencesAlias(select, table.alias)) {
+      dt.markRequired(table.alias);
+    }
+  }
+}
+
+/** Returns true if a raw select expression references `alias.column`. */
+export function selectReferencesAlias(select: string, alias: string): boolean {
+  // Most selects are simple `a.*`, but CTI adds expressions like
+  // `COALESCE(p_s0.shared_column, p_s1.shared_column) as shared_column`.
+  // Those expressions must keep the subtype joins, but `parseAlias` only sees
+  // the leading function name. Instead of parsing SQL, scan for the only alias
+  // forms Joist generates in selects: `alias.column` and `"alias".column`.
+  return selectReferencesCandidate(select, `${alias}.`) || selectReferencesCandidate(select, `"${alias}".`);
+}
+
+/** Returns true when `candidate` is present at a SQL identifier boundary. */
+function selectReferencesCandidate(select: string, candidate: string): boolean {
+  let index = select.indexOf(candidate);
+  while (index !== -1) {
+    // Avoid treating `foo.a.id` as a reference to `a`; Joist-generated aliases
+    // appear at the start of an expression or after punctuation/whitespace.
+    const previous = select[index - 1];
+    if (index === 0 || (previous !== "." && !isSqlIdentifierChar(previous))) return true;
+    index = select.indexOf(candidate, index + candidate.length);
+  }
+  return false;
+}
+
+/** Returns true for characters that can be part of an unquoted SQL identifier. */
+function isSqlIdentifierChar(char: string): boolean {
+  return /[A-Za-z0-9_]/.test(char);
+}
+
 /** Pulls out a flat list of all `ColumnCondition`s from a `ParsedExpressionFilter` tree. */
 export function deepFindConditions(
   condition: ParsedExpressionFilter | undefined,
   filterPruneable: boolean,
-): (ColumnCondition | RawCondition)[] {
+): (ColumnCondition | RawCondition | ExistsCondition)[] {
   const todo = condition ? [condition] : [];
-  const result: (ColumnCondition | RawCondition)[] = [];
+  const result: (ColumnCondition | RawCondition | ExistsCondition)[] = [];
   while (todo.length !== 0) {
     const cc = todo.pop()!;
     for (const c of cc.conditions) {
@@ -82,6 +137,8 @@ export function deepFindConditions(
         todo.push(c);
       } else if (c.kind === "column" || c.kind === "raw") {
         if (!filterPruneable || !c.pruneable) result.push(c);
+      } else if (c.kind === "exists") {
+        result.push(c);
       } else {
         assertNever(c);
       }

--- a/packages/core/src/QueryParser.ts
+++ b/packages/core/src/QueryParser.ts
@@ -2,7 +2,7 @@ import { groupBy, isPlainObject } from "joist-utils";
 import { getAliasMgmt, getMaybeCtiAlias, isAlias } from "./Aliases";
 import { Entity, isEntity } from "./Entity";
 import { ExpressionFilter, OrderBy, ValueFilter } from "./EntityFilter";
-import { EntityMetadata, getBaseMeta } from "./EntityMetadata";
+import { getBaseMeta, type EntityMetadata } from "./EntityMetadata";
 import { pruneUnusedJoins } from "./QueryParser.pruning";
 import { visitConditions } from "./QueryVisitor";
 import { getMetadataForTable } from "./configure";
@@ -25,7 +25,7 @@ export interface ParsedExpressionFilter {
 }
 
 /** A condition or nested condition in a `ParsedExpressionFilter`. */
-export type ParsedExpressionCondition = ParsedExpressionFilter | ColumnCondition | RawCondition;
+export type ParsedExpressionCondition = ParsedExpressionFilter | ColumnCondition | RawCondition | ExistsCondition;
 
 export interface ColumnCondition {
   kind: "column";
@@ -53,6 +53,21 @@ export interface RawCondition {
   pruneable: boolean;
 }
 
+/** An EXISTS or NOT EXISTS subquery condition. */
+export interface ExistsCondition {
+  kind: "exists";
+  /** When true, renders as NOT EXISTS. */
+  negate: boolean;
+  /** The outer-to-inner predicate that correlates the subquery with its parent query. */
+  correlation: RawCondition;
+  /** The join columns to use if this EXISTS must be unwrapped back into an outer join. */
+  joinColumns: { col1: string; col2: string };
+  /** The subquery: SELECT 1 FROM child WHERE correlation AND filter. */
+  subquery: ParsedFindQuery;
+  /** Outer aliases referenced by the correlation predicate, for join pruning. */
+  outerAliases: string[];
+}
+
 /** A marker condition for alias methods to indicate they should be skipped/pruned. */
 export const skipCondition: ColumnCondition = {
   kind: "column",
@@ -75,6 +90,35 @@ export interface JoinTable {
   col1: string;
   col2: string;
   distinct?: boolean;
+  /**
+   * Metadata used by `optimizeCollectionJoins` to rewrite collection joins into EXISTS.
+   *
+   * I.e. for `Author.books.reviews`:
+   * ```sql
+   * authors a
+   * LEFT JOIN books b ON a.id = b.author_id
+   * LEFT JOIN book_reviews br ON b.id = br.book_id
+   * ```
+   * `books b` has `parentAlias: "a"` and `rootAlias: "b"`, while `book_reviews br` has
+   * `parentAlias: "b"` and `rootAlias: "br"`.
+   *
+   * I.e. for `Author.tags`, the m2m join table is the collection root:
+   * ```sql
+   * authors a
+   * LEFT JOIN authors_to_tags att ON a.id = att.author_id
+   * LEFT JOIN tags t ON att.tag_id = t.id
+   * ```
+   * `authors_to_tags att` has `alias: "att"` and `rootAlias: "att"`, while `tags t` has `alias: "t"`
+   * but still has `rootAlias: "att"` because it belongs to the m2m subtree rooted at the join table.
+   */
+  collection?: {
+    /** The collection relation type, i.e. `o2m` for `Author.books`, or `m2m` for `Author.tags`. */
+    kind: "o2m" | "m2m";
+    /** The alias that owns this collection path, i.e. `a` for `Author.books`, or `att` for `Author.tags -> tags`. */
+    parentAlias: string;
+    /** The top-level alias in this collection subtree, i.e. `b` for `Author.books.reviews`, or `att` for `Author.tags`. */
+    rootAlias: string;
+  };
 }
 
 /**
@@ -152,7 +196,7 @@ export interface ParsedGroupBy {
   column: string;
 }
 
-type ParsedSelect = string | ParsedSelectWithBindings;
+export type ParsedSelect = string | ParsedSelectWithBindings;
 type ParsedSelectWithBindings = { sql: string; bindings: any[]; aliases: string[] };
 
 /** The result of parsing an `em.find` filter. */
@@ -160,8 +204,6 @@ export interface ParsedFindQuery {
   selects: ParsedSelect[];
   /** The primary table plus any joins. */
   tables: ParsedTable[];
-  /** Any cross lateral joins, where the `joins: string[]` has the full join as raw SQL; currently only for preloading. */
-  lateralJoins?: { joins: string[]; bindings: any[] };
   /** The query's conditions. */
   condition?: ParsedExpressionFilter;
   /** Extremely optional group bys; we generally don't support adhoc/aggregate queries, but the auto-batching infra uses these. */
@@ -172,7 +214,12 @@ export interface ParsedFindQuery {
   ctes?: ParsedCteClause[];
 }
 
-/** Parses an `em.find` filter into a `ParsedFindQuery` AST for simpler execution. */
+/**
+ * Parses an `em.find` filter into a logical `ParsedFindQuery` AST, leaving optimization/pruning to callers.
+ *
+ * The main execution flow is:
+ * parseFindQuery -> beforeFind plugins -> optimizeCollectionJoins -> pruneUnusedJoins -> execute SQL.
+ */
 export function parseFindQuery(
   meta: EntityMetadata,
   filter: any,
@@ -182,17 +229,18 @@ export function parseFindQuery(
     pruneJoins?: boolean;
     keepAliases?: string[];
     softDeletes?: "include" | "exclude";
+    allowMultipleLeftJoins?: boolean;
   } = {},
 ): ParsedFindQuery {
   const selects: string[] = [];
   const tables: ParsedTable[] = [];
   const orderBys: ParsedOrderBy[] = [];
-  const query = { selects, tables, orderBys };
+  const query: ParsedFindQuery = { selects, tables, orderBys };
   const {
     orderBy = undefined,
     conditions: optsExpression = undefined,
     softDeletes = "exclude",
-    pruneJoins = true,
+    pruneJoins = false,
     keepAliases = [],
   } = opts;
   const cb = new ConditionBuilder();
@@ -205,7 +253,7 @@ export function parseFindQuery(
     return i === 0 ? abbrev : `${abbrev}${i}`;
   }
 
-  function maybeAddNotSoftDeleted(meta: EntityMetadata, alias: string): void {
+  function addSoftDeleteCondition(meta: EntityMetadata, alias: string): void {
     if (filterSoftDeletes(meta, softDeletes)) {
       const column = meta.allFields[getBaseMeta(meta).timestampFields!.deletedAt!].serde?.columns[0]!;
       cb.addSimpleCondition({
@@ -236,7 +284,7 @@ export function parseFindQuery(
 
     if (join === "primary") {
       tables.push({ alias, table: meta.tableName, join });
-      addTablePerClassJoinsAndClassTag(query, meta, alias, true);
+      addTablePerClassJoinsAndClassTag({ selects, tables, orderBys }, meta, alias, true);
     } else if (meta.inheritanceType === "cti" && fieldName && !(fieldName in meta.fields)) {
       // For cti, our meta might be a subtype while the FK is actually on the base table.  This should only be the case
       // when the fk is on another table (e.g. o2o/o2m).  In these cases, we'll be passed a field name and can verify if
@@ -265,14 +313,14 @@ export function parseFindQuery(
     } else {
       tables.push({ alias, table: meta.tableName, join, col1, col2 });
       // Maybe only do this if we're the primary, or have a field that needs it?
-      addTablePerClassJoinsAndClassTag(query, meta, alias, false);
+      addTablePerClassJoinsAndClassTag({ selects, tables, orderBys }, meta, alias, false);
     }
 
     if (needsStiDiscriminator(meta)) {
       addStiSubtypeFilter(cb, meta, alias);
     }
 
-    maybeAddNotSoftDeleted(meta, alias);
+    addSoftDeleteCondition(meta, alias);
 
     // The user's locally declared aliases, i.e. `const [a, b] = aliases(Author, Book)`,
     // aren't guaranteed to line up with the aliases we've assigned internally, like `a`
@@ -409,19 +457,20 @@ export function parseFindQuery(
             field.otherFieldName,
           );
         } else if (field.kind === "o2m") {
-          const a = getAlias(field.otherMetadata().tableName);
-          const otherField = field.otherMetadata().allFields[field.otherFieldName];
+          const otherMeta = field.otherMetadata();
+          const otherField = otherMeta.allFields[field.otherFieldName];
           let otherColumn = otherField.serde!.columns[0].columnName;
-          // If the other field is a poly, we need to find the right column
           if (otherField.kind === "poly") {
-            // For a subcomponent that matches field's metadata
             const otherComponent =
               otherField.components.find((c) => c.otherMetadata() === meta) ??
               fail(`No poly component found for ${otherField.fieldName}`);
             otherColumn = otherComponent.columnName;
           }
+          const isCtiBaseFk =
+            otherMeta.inheritanceType === "cti" && field.otherFieldName && !(field.otherFieldName in otherMeta.fields);
+          const a = getAlias(otherMeta.tableName);
           addTable(
-            field.otherMetadata(),
+            otherMeta,
             a,
             "outer",
             kqDot(alias, "id"),
@@ -429,55 +478,50 @@ export function parseFindQuery(
             (ef.subFilter as any)[key],
             field.otherFieldName,
           );
+          if (!isCtiBaseFk) {
+            const table = tables.find((t) => t.alias === a);
+            if (table && (table.join === "inner" || table.join === "outer")) {
+              table.collection = { parentAlias: alias, rootAlias: a, kind: "o2m" };
+            }
+          }
         } else if (field.kind === "m2m") {
-          // Always join into the m2m table
+          const sub = (ef.subFilter as any)[key];
+          const f = parseEntityFilter(field.otherMetadata(), sub);
+          if (!f && !isAlias(sub)) return;
+
           const ja = getAlias(field.joinTableName);
           tables.push({
-            alias: ja,
             join: "outer",
+            alias: ja,
             table: field.joinTableName,
             col1: kqDot(alias, "id"),
             col2: kqDot(ja, field.columnNames[0]),
+            collection: { parentAlias: alias, rootAlias: ja, kind: "m2m" },
           });
-          // But conditionally join into the alias table
-          const sub = (ef.subFilter as any)[key];
-          if (isAlias(sub)) {
+
+          if (isAlias(sub) || f?.kind === "join" || filterSoftDeletes(field.otherMetadata(), softDeletes)) {
             const a = getAlias(field.otherMetadata().tableName);
             addTable(field.otherMetadata(), a, "outer", kqDot(ja, field.columnNames[1]), kqDot(a, "id"), sub);
-          }
-          const f = parseEntityFilter(field.otherMetadata(), sub);
-          // Probe the filter and see if it's just an id, if so we can avoid the join
-          if (!f) {
-            // skip
-          } else if (f.kind === "join" || filterSoftDeletes(field.otherMetadata(), softDeletes)) {
-            const a = getAlias(field.otherMetadata().tableName);
-            addTable(
-              field.otherMetadata(),
-              a,
-              "outer",
-              kqDot(ja, field.columnNames[1]),
-              kqDot(a, "id"),
-              (ef.subFilter as any)[key],
-            );
-          } else {
-            const meta = field.otherMetadata();
-            // We normally don't have `columns` for m2m fields, b/c they don't go through normal serde
-            // codepaths, so make one up to leverage the existing `mapToDb` function.
+            const table = tables.find((t) => t.alias === a);
+            if (table && (table.join === "inner" || table.join === "outer")) {
+              table.collection = { parentAlias: ja, rootAlias: ja, kind: "m2m" };
+            }
+          } else if (f) {
+            const otherMeta = field.otherMetadata();
             const column: any = {
               columnName: field.columnNames[1],
-              dbType: meta.idDbType,
+              dbType: otherMeta.idDbType,
               mapToDb(value: any) {
-                // Check for `typeof value === number` in case this is a new entity, and we've been given the nilIdValue
                 return value === null || isNilIdValue(value)
                   ? value
-                  : keyToNumber(meta, maybeResolveReferenceToId(value));
+                  : keyToNumber(otherMeta, maybeResolveReferenceToId(value));
               },
             };
             cb.addSimpleCondition({
               kind: "column",
               alias: ja,
               column: field.columnNames[1],
-              dbType: meta.idDbType,
+              dbType: otherMeta.idDbType,
               cond: mapToDb(column, f),
             });
           }
@@ -577,7 +621,7 @@ export function parseFindQuery(
  * to do an `OR` across two different children (which queries both children being
  * OUTER JOINs, and detecting that case seemed complicated).
  */
-function maybeAddIdNotNulls(query: ParsedFindQuery): void {
+export function maybeAddIdNotNulls(query: ParsedFindQuery): void {
   visitConditions(query, {
     visitCond(c: ColumnCondition) {
       // Check `c.prunable` to make sure we don't catch our injected `deleted_at is null` conditions

--- a/packages/core/src/dataloaders/findCountDataLoader.ts
+++ b/packages/core/src/dataloaders/findCountDataLoader.ts
@@ -44,7 +44,7 @@ export function findCountDataLoader<T extends Entity>(
         const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
         query.selects = [`count(distinct ${kq(primary.alias)}.id) as count`];
         query.orderBys = [];
-        const rows = await em["executeFind"](meta, findCountOperation, query, { checkLimit: false });
+        const rows = await em["executeFind"](meta, findCountOperation, query, { ...options, checkLimit: false });
         return [Number(rows[0].count)];
       }
 
@@ -81,7 +81,7 @@ export function findCountDataLoader<T extends Entity>(
         orderBys: [],
       };
 
-      const rows = await em["executeFind"](meta, findCountOperation, query2, { checkLimit: false });
+      const rows = await em["executeFind"](meta, findCountOperation, query2, { ...options, checkLimit: false });
 
       // Make an empty array for each batched query, per the dataloader contract
       const results = queries.map(() => 0);

--- a/packages/core/src/dataloaders/findIdsDataLoader.ts
+++ b/packages/core/src/dataloaders/findIdsDataLoader.ts
@@ -46,7 +46,7 @@ export function findIdsDataLoader<T extends Entity>(
         query.selects = [`${kq(primary.alias)}.id as id`];
         query.orderBys = [{ alias: primary.alias, column: "id", order: "ASC" }];
         // explicitly pass limit: undefined to avoid executeFind applying the default entityLimit
-        const rows = await em["executeFind"](meta, findIdsOperation, query, { limit: undefined });
+        const rows = await em["executeFind"](meta, findIdsOperation, query, { ...options, limit: undefined });
         return [rows.map((row: any) => keyToTaggedId(meta, row.id)!)];
       }
 
@@ -83,7 +83,7 @@ export function findIdsDataLoader<T extends Entity>(
       };
 
       // explicitly pass limit: undefined to avoid executeFind applying the default entityLimit
-      const rows = await em["executeFind"](meta, findIdsOperation, query2, { limit: undefined });
+      const rows = await em["executeFind"](meta, findIdsOperation, query2, { ...options, limit: undefined });
 
       // Make an empty array for each batched query, per the dataloader contract
       const results: string[][] = queries.map(() => []);

--- a/packages/core/src/drivers/buildRawQuery.ts
+++ b/packages/core/src/drivers/buildRawQuery.ts
@@ -57,12 +57,14 @@ export function buildRawQuery(
   }
 
   sql += "SELECT ";
+  const subqueryRenderer = (q: ParsedFindQuery) => buildRawQuery(q, {});
+
   parsed.selects.forEach((s, i) => {
     const maybeDistinct = i === 0 && needsDistinct ? buildDistinctOn(parsed, primary) : "";
     const maybeComma = i === parsed.selects.length - 1 ? "" : ", ";
     if (typeof s === "string") {
       sql += maybeDistinct + s + maybeComma;
-    } else {
+    } else if ("sql" in s) {
       sql += maybeDistinct + s.sql + maybeComma;
       bindings.push(...s.bindings);
     }
@@ -98,7 +100,7 @@ export function buildRawQuery(
   }
 
   if (parsed.condition) {
-    const where = buildWhereClause(parsed.condition, true);
+    const where = buildWhereClause(parsed.condition, true, subqueryRenderer);
     if (where) {
       sql += " WHERE " + where[0];
       bindings.push(...where[1]);

--- a/packages/core/src/drivers/buildUtils.ts
+++ b/packages/core/src/drivers/buildUtils.ts
@@ -1,20 +1,35 @@
 import { opToFn } from "../EntityGraphQLFilter";
 import { isDefined } from "../EntityManager";
-import { ColumnCondition, ParsedExpressionFilter, RawCondition } from "../QueryParser";
+import {
+  type ColumnCondition,
+  type ExistsCondition,
+  type ParsedExpressionFilter,
+  type ParsedFindQuery,
+  type RawCondition,
+} from "../QueryParser";
 import { kqDot } from "../keywords";
-import { assertNever } from "../utils";
+import { assertNever, fail } from "../utils";
+
+/** Renders a ParsedFindQuery subquery to SQL — passed in to avoid circular imports with buildRawQuery. */
+export type SubqueryRenderer = (q: ParsedFindQuery) => { sql: string; bindings: readonly any[] };
 
 /** Returns a tuple of `["cond AND (cond OR cond)", bindings]`. */
-export function buildWhereClause(exp: ParsedExpressionFilter, topLevel = false): [string, any[]] | undefined {
+export function buildWhereClause(
+  exp: ParsedExpressionFilter,
+  topLevel = false,
+  renderSubquery?: SubqueryRenderer,
+): [string, any[]] | undefined {
   const tuples = exp.conditions
     .map((c) => {
       return c.kind === "exp"
-        ? buildWhereClause(c)
+        ? buildWhereClause(c, false, renderSubquery)
         : c.kind === "column"
           ? buildCondition(c)
           : c.kind === "raw"
             ? buildRawCondition(c)
-            : fail(`Invalid condition ${c}`);
+            : c.kind === "exists"
+              ? buildExistsCondition(c, renderSubquery)
+              : fail(`Invalid condition ${c}`);
     })
     .filter(isDefined);
   // If we don't have any conditions to combine, just return undefined;
@@ -74,4 +89,11 @@ function buildCondition(cc: ColumnCondition): [string, any[]] {
     default:
       assertNever(cond);
   }
+}
+
+function buildExistsCondition(c: ExistsCondition, renderSubquery?: SubqueryRenderer): [string, any[]] {
+  if (!renderSubquery) throw new Error("EXISTS condition requires a subquery renderer");
+  const { sql, bindings } = renderSubquery(c.subquery);
+  const prefix = c.negate ? "NOT EXISTS" : "EXISTS";
+  return [`${prefix} (${sql})`, [...bindings]];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export { JoinRow, JoinRowOperation, ManyToManyLike } from "./JoinRows";
 export * from "./PendingChanges";
 export { Plugin } from "./PluginManager";
 export * from "./QueryParser";
+export * from "./QueryParser.collectionJoins";
 export { visitConditions } from "./QueryVisitor";
 export { JoinRowTodo, Todo } from "./Todo";
 export * from "./changes";

--- a/packages/knex/src/buildKnexQuery.ts
+++ b/packages/knex/src/buildKnexQuery.ts
@@ -25,7 +25,7 @@ export function buildKnexQuery(
     const maybeDistinct = i === 0 && needsDistinct ? "distinct " : "";
     if (typeof s === "string") {
       query.select(knex.raw(`${maybeDistinct}${s}`));
-    } else {
+    } else if ("sql" in s) {
       query.select(knex.raw(`${maybeDistinct}${s.sql}`, s.bindings));
     }
   });
@@ -54,7 +54,11 @@ export function buildKnexQuery(
   });
 
   if (parsed.condition) {
-    const where = internals.buildWhereClause(parsed.condition, true);
+    const subqueryRenderer = (q: ParsedFindQuery) => {
+      const { sql, bindings } = buildKnexQuery(knex, q, {}).toSQL();
+      return { sql, bindings };
+    };
+    const where = internals.buildWhereClause(parsed.condition, true, subqueryRenderer);
     if (where) {
       const [sql, bindings] = where;
       query.whereRaw(sql, bindings);

--- a/packages/knex/src/index.ts
+++ b/packages/knex/src/index.ts
@@ -1,4 +1,11 @@
-import { Entity, FilterAndSettings, getMetadata, MaybeAbstractEntityConstructor, parseFindQuery } from "joist-core";
+import {
+  Entity,
+  FilterAndSettings,
+  getMetadata,
+  MaybeAbstractEntityConstructor,
+  optimizeCollectionJoins,
+  parseFindQuery,
+} from "joist-core";
 import { knex as baseCreateKnex, Knex } from "knex";
 import pg from "pg";
 import { buildKnexQuery } from "./buildKnexQuery";
@@ -24,6 +31,8 @@ import { buildKnexQuery } from "./buildKnexQuery";
  *   against the `QueryBuilder` directly.
  * @param filter[pruneJoins] Disables removing any unused joins, i.e. because you plan on adding your
  *   own joins/conditions against the `QueryBuilder` directly.
+ * @param filter[allowMultipleLeftJoins] Allows multiple fanout LEFT JOINs when Joist cannot express
+ *   an alias condition as EXISTS.
  */
 export function buildQuery<T extends Entity>(
   knex: Knex,
@@ -31,6 +40,7 @@ export function buildQuery<T extends Entity>(
   filter: FilterAndSettings<T> & {
     pruneJoins?: boolean;
     keepAliases?: string[];
+    allowMultipleLeftJoins?: boolean;
   },
 ): Knex.QueryBuilder<{}, unknown[]> {
   const meta = getMetadata(type);
@@ -42,9 +52,16 @@ export function buildQuery<T extends Entity>(
     offset,
     pruneJoins = true,
     keepAliases = [],
+    allowMultipleLeftJoins = false,
     softDeletes = "exclude",
   } = filter;
-  const parsed = parseFindQuery(meta, where, { conditions, orderBy, pruneJoins, keepAliases, softDeletes });
+  const parsed = parseFindQuery(meta, where, {
+    conditions,
+    orderBy,
+    keepAliases,
+    softDeletes,
+  });
+  optimizeCollectionJoins(parsed, { allowMultipleLeftJoins, pruneJoins, keepAliases });
   return buildKnexQuery(knex, parsed, { limit, offset });
 }
 

--- a/packages/tests/integration/src/EntityManager.ctiQueries.test.ts
+++ b/packages/tests/integration/src/EntityManager.ctiQueries.test.ts
@@ -104,7 +104,7 @@ describe("EntityManager.ctiQueries", () => {
     const where = { publisherLargePublisher: { country: "US" } } satisfies AuthorFilter;
     const authors = await em.find(Author, where);
     expect(authors.length).toBe(1);
-    expect(parseFindQuery(am, where, { softDeletes: "include" })).toMatchObject({
+    expect(parseFindQuery(am, where, { softDeletes: "include", pruneJoins: true })).toMatchObject({
       selects: [`a.*`],
       tables: [
         { alias: "a", table: "authors", join: "primary" },

--- a/packages/tests/integration/src/EntityManager.lateralJoins.test.ts
+++ b/packages/tests/integration/src/EntityManager.lateralJoins.test.ts
@@ -1,0 +1,1269 @@
+import {
+  insertAuthor,
+  insertAuthorToTag,
+  insertBook,
+  insertBookAdvance,
+  insertBookReview,
+  insertComment,
+  insertPublisher,
+  insertTag,
+} from "@src/entities/inserts";
+import { knex, newEntityManager, queries, resetQueryCount } from "@src/testEm";
+import { aliases, getMetadata, ParsedExpressionCondition, ParsedFindQuery, parseFindQuery, Plugin } from "joist-orm";
+import { AdvanceStatus, Author, Book, Tag } from "./entities";
+
+const am = getMetadata(Author);
+
+const opts = { softDeletes: "include" } as const;
+
+describe("EntityManager.lateralJoins", () => {
+  // -----------------------------------------------------------------------
+  // These "approach" tests use pure SQL to demonstrate the before/after of the
+  // EXISTS rewrite. Each test first runs the naive multi-JOIN query that
+  // produces a cross-product, then runs the equivalent EXISTS subquery
+  // that avoids the cross-product, and asserts both return the same
+  // correct results. This helps maintainers understand the high-level SQL
+  // transformation without needing to understand the Joist query parser.
+  // -----------------------------------------------------------------------
+  describe("approach", () => {
+    it("two o2m collections: JOIN cross-product vs EXISTS", async () => {
+      // a1 has book "b1" and comment "c1" — should match
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      // a2 has book "b2" but no matching comment — should not match
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b2", author_id: 2 });
+
+      // Before: naive multi-JOIN produces a cross-product, needs DISTINCT
+      const { rows: before } = await knex.raw(`
+        SELECT DISTINCT a.id, a.first_name
+        FROM authors a
+        LEFT JOIN books b ON a.id = b.author_id
+        LEFT JOIN comments c ON a.id = c.parent_author_id
+        WHERE b.title = 'b1' AND c.text = 'c1'
+        ORDER BY a.id
+      `);
+      expect(before).toMatchObject([{ first_name: "a1" }]);
+
+      // After: EXISTS — one row per parent, no DISTINCT needed
+      const { rows: after } = await knex.raw(`
+        SELECT a.id, a.first_name
+        FROM authors a
+        WHERE EXISTS (
+          SELECT 1 FROM books b WHERE b.author_id = a.id AND b.title = 'b1'
+        )
+        AND EXISTS (
+          SELECT 1 FROM comments c WHERE c.parent_author_id = a.id AND c.text = 'c1'
+        )
+        ORDER BY a.id
+      `);
+      expect(after).toMatchObject([{ first_name: "a1" }]);
+    });
+
+    it("m2m + o2m: junction table inside EXISTS", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertTag({ name: "t1" });
+      await insertAuthorToTag({ author_id: 1, tag_id: 1 });
+      await insertBook({ title: "b1", author_id: 1 });
+      // a2 has tag but wrong book
+      await insertAuthor({ first_name: "a2" });
+      await insertAuthorToTag({ author_id: 2, tag_id: 1 });
+      await insertBook({ title: "b2", author_id: 2 });
+
+      // Before: three JOINs, DISTINCT to dedup
+      const { rows: before } = await knex.raw(`
+        SELECT DISTINCT a.id, a.first_name
+        FROM authors a
+        LEFT JOIN authors_to_tags att ON a.id = att.author_id
+        LEFT JOIN tags t ON att.tag_id = t.id
+        LEFT JOIN books b ON a.id = b.author_id
+        WHERE t.name = 't1' AND b.title = 'b1'
+        ORDER BY a.id
+      `);
+      expect(before).toMatchObject([{ first_name: "a1" }]);
+
+      // After: m2m junction + target go inside one EXISTS
+      const { rows: after } = await knex.raw(`
+        SELECT a.id, a.first_name
+        FROM authors a
+        WHERE EXISTS (
+          SELECT 1
+          FROM authors_to_tags att
+          JOIN tags t ON att.tag_id = t.id
+          WHERE att.author_id = a.id AND t.name = 't1'
+        )
+        AND EXISTS (
+          SELECT 1 FROM books b WHERE b.author_id = a.id AND b.title = 'b1'
+        )
+        ORDER BY a.id
+      `);
+      expect(after).toMatchObject([{ first_name: "a1" }]);
+    });
+
+    it("same-row AND: EXISTS preserves row-level semantics", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1, order: 1 }); // title AND order match
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b1", author_id: 2, order: 2 }); // title matches, order doesn't
+      await insertComment({ text: "c1", parent_author_id: 2 });
+
+      // Before: WHERE on both columns requires the same book row to match both
+      const { rows: before } = await knex.raw(`
+        SELECT DISTINCT a.id, a.first_name
+        FROM authors a
+        LEFT JOIN books b ON a.id = b.author_id
+        LEFT JOIN comments c ON a.id = c.parent_author_id
+        WHERE b.title = 'b1' AND b."order" = 1 AND c.text = 'c1'
+        ORDER BY a.id
+      `);
+      expect(before).toMatchObject([{ first_name: "a1" }]);
+
+      // After: both conditions inside a single EXISTS preserves same-row semantics
+      const { rows: after } = await knex.raw(`
+        SELECT a.id, a.first_name
+        FROM authors a
+        WHERE EXISTS (
+          SELECT 1 FROM books b WHERE b.author_id = a.id AND b.title = 'b1' AND b."order" = 1
+        )
+        AND EXISTS (
+          SELECT 1 FROM comments c WHERE c.parent_author_id = a.id AND c.text = 'c1'
+        )
+        ORDER BY a.id
+      `);
+      expect(after).toMatchObject([{ first_name: "a1" }]);
+    });
+
+    it("cross-product explosion: JOINs produce N*M rows, EXISTS produces 1", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBook({ title: "b2", author_id: 1 });
+      await insertBook({ title: "b3", author_id: 1 });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      await insertComment({ text: "c2", parent_author_id: 1 });
+      await insertComment({ text: "c3", parent_author_id: 1 });
+
+      // Before: 3 books × 3 comments = 9 rows before DISTINCT
+      const { rows: crossProduct } = await knex.raw(`
+        SELECT a.id, a.first_name
+        FROM authors a
+        LEFT JOIN books b ON a.id = b.author_id
+        LEFT JOIN comments c ON a.id = c.parent_author_id
+        WHERE b.title LIKE 'b%' AND c.text LIKE 'c%'
+      `);
+      expect(crossProduct).toHaveLength(9); // 3 * 3 cross-product!
+
+      // After: EXISTS avoids the cross-product entirely — exactly 1 row
+      const { rows: exists } = await knex.raw(`
+        SELECT a.id, a.first_name
+        FROM authors a
+        WHERE EXISTS (
+          SELECT 1 FROM books b WHERE b.author_id = a.id AND b.title LIKE 'b%'
+        )
+        AND EXISTS (
+          SELECT 1 FROM comments c WHERE c.parent_author_id = a.id AND c.text LIKE 'c%'
+        )
+      `);
+      expect(exists).toHaveLength(1);
+      expect(exists).toMatchObject([{ first_name: "a1" }]);
+    });
+
+    it("nested o2m: reviews nested inside books EXISTS", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBookReview({ book_id: 1, rating: 5 });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      // a2 has low-rated review
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b2", author_id: 2 });
+      await insertBookReview({ book_id: 2, rating: 1 });
+      await insertComment({ text: "c1", parent_author_id: 2 });
+
+      // Before: three JOINs deep
+      const { rows: before } = await knex.raw(`
+        SELECT DISTINCT a.id, a.first_name
+        FROM authors a
+        LEFT JOIN books b ON a.id = b.author_id
+        LEFT JOIN book_reviews br ON b.id = br.book_id
+        LEFT JOIN comments c ON a.id = c.parent_author_id
+        WHERE br.rating >= 4 AND c.text = 'c1'
+        ORDER BY a.id
+      `);
+      expect(before).toMatchObject([{ first_name: "a1" }]);
+
+      // After: reviews as nested EXISTS inside the books EXISTS
+      const { rows: after } = await knex.raw(`
+        SELECT a.id, a.first_name
+        FROM authors a
+        WHERE EXISTS (
+          SELECT 1 FROM books b
+          WHERE b.author_id = a.id
+          AND EXISTS (SELECT 1 FROM book_reviews br WHERE br.book_id = b.id AND br.rating >= 4)
+        )
+        AND EXISTS (
+          SELECT 1 FROM comments c WHERE c.parent_author_id = a.id AND c.text = 'c1'
+        )
+        ORDER BY a.id
+      `);
+      expect(after).toMatchObject([{ first_name: "a1" }]);
+    });
+
+    it("anti-join: 'no children' uses NOT EXISTS", async () => {
+      // a1 has NO books but has a comment
+      await insertAuthor({ first_name: "a1" });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      // a2 has books
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b1", author_id: 2 });
+      await insertComment({ text: "c1", parent_author_id: 2 });
+
+      // Before: LEFT JOIN + IS NULL detects missing children
+      const { rows: before } = await knex.raw(`
+        SELECT DISTINCT a.id, a.first_name
+        FROM authors a
+        LEFT JOIN books b ON a.id = b.author_id
+        LEFT JOIN comments c ON a.id = c.parent_author_id
+        WHERE b.id IS NULL AND c.text = 'c1'
+        ORDER BY a.id
+      `);
+      expect(before).toMatchObject([{ first_name: "a1" }]);
+
+      // After: NOT EXISTS detects no children
+      const { rows: after } = await knex.raw(`
+        SELECT a.id, a.first_name
+        FROM authors a
+        WHERE NOT EXISTS (
+          SELECT 1 FROM books b WHERE b.author_id = a.id
+        )
+        AND EXISTS (
+          SELECT 1 FROM comments c WHERE c.parent_author_id = a.id AND c.text = 'c1'
+        )
+        ORDER BY a.id
+      `);
+      expect(after).toMatchObject([{ first_name: "a1" }]);
+    });
+  });
+
+  describe("collection rewrite", () => {
+    it("rewrites two o2m collections to EXISTS", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b2", author_id: 2 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      const authors = await em.find(Author, { books: { title: "b1" }, comments: { text: "c1" } }, opts);
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id AND b.title = $1)`,
+          ` AND EXISTS (SELECT 1 FROM comments AS c WHERE a.id = c.parent_author_id AND c.text = $2)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+
+    it("rewrites single collection queries to EXISTS", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      const authors = await em.find(Author, { books: { title: "b1" } }, opts);
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id AND b.title = $1)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $2`,
+        ].join(""),
+      ]);
+    });
+
+    it("rewrites m2m + o2m collections", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertTag({ name: "t1" });
+      await insertAuthorToTag({ author_id: 1, tag_id: 1 });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertAuthorToTag({ author_id: 2, tag_id: 1 });
+      await insertBook({ title: "b2", author_id: 2 });
+      await insertAuthor({ first_name: "a3" });
+      await insertBook({ title: "b1", author_id: 3 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      const authors = await em.find(Author, { tags: { name: "t1" }, books: { title: "b1" } }, opts);
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM authors_to_tags AS att JOIN tags AS t ON att.tag_id = t.id WHERE a.id = att.author_id AND t.name = $1)`,
+          ` AND EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id AND b.title = $2)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+
+    it("preserves same-row AND semantics within a single collection", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1, order: 1 });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b1", author_id: 2, order: 2 });
+      await insertComment({ text: "c1", parent_author_id: 2 });
+      await insertAuthor({ first_name: "a3" });
+      await insertBook({ title: "b2", author_id: 3, order: 1 });
+      await insertComment({ text: "c1", parent_author_id: 3 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      const authors = await em.find(Author, { books: { title: "b1", order: 1 }, comments: { text: "c1" } }, opts);
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id AND b.title = $1 AND b."order" = $2)`,
+          ` AND EXISTS (SELECT 1 FROM comments AS c WHERE a.id = c.parent_author_id AND c.text = $3)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $4`,
+        ].join(""),
+      ]);
+    });
+
+    it("avoids cross-product row explosion", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBook({ title: "b2", author_id: 1 });
+      await insertBook({ title: "b3", author_id: 1 });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      await insertComment({ text: "c2", parent_author_id: 1 });
+      await insertComment({ text: "c3", parent_author_id: 1 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      const authors = await em.find(
+        Author,
+        { books: { title: { like: "b%" } }, comments: { text: { like: "c%" } } },
+        opts,
+      );
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id AND b.title LIKE $1)`,
+          ` AND EXISTS (SELECT 1 FROM comments AS c WHERE a.id = c.parent_author_id AND c.text LIKE $2)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+
+    it("handles nested collections (books -> reviews) with another collection", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBookReview({ book_id: 1, rating: 5 });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b2", author_id: 2 });
+      await insertBookReview({ book_id: 2, rating: 1 });
+      await insertComment({ text: "c1", parent_author_id: 2 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      const authors = await em.find(
+        Author,
+        { books: { reviews: { rating: { gte: 4 } } }, comments: { text: "c1" } },
+        opts,
+      );
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b`,
+          ` WHERE a.id = b.author_id`,
+          ` AND EXISTS (SELECT 1 FROM book_reviews AS br WHERE b.id = br.book_id AND br.rating >= $1))`,
+          ` AND EXISTS (SELECT 1 FROM comments AS c WHERE a.id = c.parent_author_id AND c.text = $2)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+
+    it("handles anti-join with another collection", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertComment({ text: "c1", parent_author_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b1", author_id: 2 });
+      await insertComment({ text: "c1", parent_author_id: 2 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      const authors = await em.find(Author, { books: { id: null }, comments: { text: "c1" } }, opts);
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE NOT EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id)`,
+          ` AND EXISTS (SELECT 1 FROM comments AS c WHERE a.id = c.parent_author_id AND c.text = $1)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $2`,
+        ].join(""),
+      ]);
+    });
+
+    it("returns empty results when no parent matches all collections", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertTag({ name: "t2" });
+      await insertAuthorToTag({ author_id: 1, tag_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b2", author_id: 2 });
+      await insertTag({ name: "t1" });
+      await insertAuthorToTag({ author_id: 2, tag_id: 2 });
+
+      const em = newEntityManager();
+      const authors = await em.find(Author, { books: { title: "b1" }, tags: { name: "t1" } }, opts);
+      expect(authors).toMatchEntity([]);
+    });
+
+    it("handles multiple results across multiple parents", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertTag({ name: "t1" });
+      await insertAuthorToTag({ author_id: 1, tag_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b1", author_id: 2 });
+      await insertAuthorToTag({ author_id: 2, tag_id: 1 });
+      await insertAuthor({ first_name: "a3" });
+      await insertBook({ title: "b1", author_id: 3 });
+
+      const em = newEntityManager();
+      const authors = await em.find(Author, { books: { title: "b1" }, tags: { name: "t1" } }, opts);
+      expect(authors).toMatchEntity([{ firstName: "a1" }, { firstName: "a2" }]);
+    });
+  });
+
+  describe("beforeFind plugin AST", () => {
+    class QueryMutatingPlugin extends Plugin {
+      seen: ParsedFindQuery[] = [];
+      mutate: (query: ParsedFindQuery) => void;
+
+      constructor(mutate: (query: ParsedFindQuery) => void) {
+        super();
+        this.mutate = mutate;
+      }
+
+      beforeFind(meta: unknown, operation: unknown, query: ParsedFindQuery): void {
+        this.seen.push(structuredClone(query));
+        this.mutate(query);
+      }
+    }
+
+    it("passes logical collection joins to beforeFind, then optimizes plugin-added local conditions", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "match", author_id: 1 });
+
+      const em = newEntityManager();
+      const plugin = new QueryMutatingPlugin((query) => {
+        const book = query.tables.find((table) => table.table === "books") ?? failTest("No books join");
+        addCondition(query, {
+          kind: "column",
+          alias: book.alias,
+          column: "title",
+          dbType: "character varying",
+          cond: { kind: "eq", value: "match" },
+        });
+      });
+      em.addPlugin(plugin);
+
+      resetQueryCount();
+      const [b] = aliases(Book);
+      const authors = await em.find(Author, { books: b }, opts);
+
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(plugin.seen[0]).toMatchObject({
+        tables: [
+          { alias: "a", table: "authors", join: "primary" },
+          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
+        ],
+      });
+      expect(JSON.stringify(plugin.seen[0]).includes('"kind":"exists"')).toEqual(false);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id AND b.title = $1)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $2`,
+        ].join(""),
+      ]);
+    });
+
+    it("keeps plugin-added mixed-scope OR conditions as LEFT OUTER JOINs", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "match", author_id: 1 });
+      await insertAuthor({ first_name: "match" });
+
+      const em = newEntityManager();
+      const plugin = new QueryMutatingPlugin((query) => {
+        const author = query.tables.find((table) => table.table === "authors") ?? failTest("No authors table");
+        const book = query.tables.find((table) => table.table === "books") ?? failTest("No books join");
+        addCondition(query, {
+          kind: "exp",
+          op: "or",
+          conditions: [
+            {
+              kind: "column",
+              alias: book.alias,
+              column: "title",
+              dbType: "character varying",
+              cond: { kind: "eq", value: "match" },
+            },
+            {
+              kind: "column",
+              alias: author.alias,
+              column: "first_name",
+              dbType: "character varying",
+              cond: { kind: "eq", value: "match" },
+            },
+          ],
+        });
+      });
+      em.addPlugin(plugin);
+
+      resetQueryCount();
+      const [b] = aliases(Book);
+      const authors = await em.find(Author, { books: b }, opts);
+
+      expect(authors).toMatchEntity([{ firstName: "a1" }, { firstName: "match" }]);
+      expect(queries[0].includes("LEFT OUTER JOIN books")).toEqual(true);
+      expect(queries[0].includes("EXISTS")).toEqual(false);
+    });
+
+    it("optimizes plugin-added alias id IS NULL conditions to NOT EXISTS", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b1", author_id: 2 });
+
+      const em = newEntityManager();
+      const plugin = new QueryMutatingPlugin((query) => {
+        const book = query.tables.find((table) => table.table === "books") ?? failTest("No books join");
+        addCondition(query, {
+          kind: "column",
+          alias: book.alias,
+          column: "id",
+          dbType: "int",
+          cond: { kind: "is-null" },
+        });
+      });
+      em.addPlugin(plugin);
+
+      resetQueryCount();
+      const [b] = aliases(Book);
+      const authors = await em.find(Author, { books: b }, opts);
+
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE NOT EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $1`,
+        ].join(""),
+      ]);
+    });
+  });
+
+  describe("deep sibling auto-detection", () => {
+    it("rewrites 2nd-level sibling collections (books → reviews + advances)", async () => {
+      // a1 has book with high-rated review AND a pending advance — should match
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBookReview({ book_id: 1, rating: 5 });
+      await insertPublisher({ name: "p1" });
+      await insertBookAdvance({ book_id: 1, publisher_id: 1 });
+      // a2 has book with high-rated review but no advance — should not match
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "b2", author_id: 2 });
+      await insertBookReview({ book_id: 2, rating: 5 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      const authors = await em.find(
+        Author,
+        { books: { reviews: { rating: { gte: 4 } }, advances: { status: AdvanceStatus.Pending } } },
+        opts,
+      );
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b`,
+          ` WHERE a.id = b.author_id`,
+          ` AND EXISTS (SELECT 1 FROM book_reviews AS br WHERE b.id = br.book_id AND br.rating >= $1)`,
+          ` AND EXISTS (SELECT 1 FROM book_advances AS ba WHERE b.id = ba.book_id AND ba.status_id = $2))`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+
+    it("generates correct SQL for deep sibling EXISTS", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBookReview({ book_id: 1, rating: 5 });
+      await insertPublisher({ name: "p1" });
+      await insertBookAdvance({ book_id: 1, publisher_id: 1 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      await em.find(
+        Author,
+        { books: { reviews: { rating: { gte: 4 } }, advances: { status: AdvanceStatus.Pending } } },
+        opts,
+      );
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b`,
+          ` WHERE a.id = b.author_id`,
+          ` AND EXISTS (SELECT 1 FROM book_reviews AS br WHERE b.id = br.book_id AND br.rating >= $1)`,
+          ` AND EXISTS (SELECT 1 FROM book_advances AS ba WHERE b.id = ba.book_id AND ba.status_id = $2))`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+
+    it("absorbs books into EXISTS when its siblings are at the deeper level", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      await insertBookReview({ book_id: 1, rating: 5 });
+      await insertPublisher({ name: "p1" });
+      await insertBookAdvance({ book_id: 1, publisher_id: 1 });
+
+      const em = newEntityManager();
+      resetQueryCount();
+      await em.find(
+        Author,
+        { books: { reviews: { rating: { gte: 4 } }, advances: { status: AdvanceStatus.Pending } } },
+        opts,
+      );
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE EXISTS (SELECT 1 FROM books AS b`,
+          ` WHERE a.id = b.author_id`,
+          ` AND EXISTS (SELECT 1 FROM book_reviews AS br WHERE b.id = br.book_id AND br.rating >= $1)`,
+          ` AND EXISTS (SELECT 1 FROM book_advances AS ba WHERE b.id = ba.book_id AND ba.status_id = $2))`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cross-scope alias conditions: when `conditions: { or/and: [...] }` references
+  // aliases from BOTH the outer entity AND a collection (o2m/m2m) path.
+  //
+  // The key challenge: collection fields become EXISTS subqueries, so the collection's
+  // alias lives inside the EXISTS. If an outer `conditions` expression references that
+  // alias alongside the outer entity's alias, the scopes conflict.
+  //
+  // Resolution depends on the expression operator:
+  //   - AND: each branch can be evaluated independently, so the collection branch
+  //     moves into the EXISTS while the outer branch stays outside. No unwrap needed.
+  //   - OR: all branches must be visible in the same scope (you can't split an OR
+  //     across an EXISTS boundary), so the EXISTS is unwrapped back to a regular
+  //     LEFT OUTER JOIN + DISTINCT ON.
+  // -----------------------------------------------------------------------
+  describe("cross-scope alias conditions", () => {
+    describe("approach", () => {
+      it("OR across scopes: must unwrap EXISTS to JOIN because both sides of OR need same scope", async () => {
+        // a1 has book "b1" — matches via b.title
+        await insertAuthor({ first_name: "a1" });
+        await insertBook({ title: "match", author_id: 1 });
+        // a2 has first_name "match" — matches via a.first_name
+        await insertAuthor({ first_name: "match" });
+        await insertBook({ title: "other", author_id: 2 });
+        // a3 matches neither
+        await insertAuthor({ first_name: "a3" });
+        await insertBook({ title: "other", author_id: 3 });
+
+        // With EXISTS: can't express `WHERE (EXISTS(... b.title='match') OR a.first_name='match')`
+        // because OR requires both sides visible in the same FROM. Must fall back to JOIN:
+        const { rows } = await knex.raw(`
+          SELECT DISTINCT ON (a.id) a.id, a.first_name
+          FROM authors a
+          LEFT OUTER JOIN books b ON a.id = b.author_id
+          WHERE (b.title = 'match' OR a.first_name = 'match')
+          ORDER BY a.id
+        `);
+        expect(rows).toMatchObject([{ first_name: "a1" }, { first_name: "match" }]);
+      });
+
+      it("AND across scopes: each branch evaluates independently, EXISTS stays intact", async () => {
+        // a1 has first_name "a1" AND book "match" — matches both
+        await insertAuthor({ first_name: "a1" });
+        await insertBook({ title: "match", author_id: 1 });
+        // a2 has first_name "a2" AND book "match" — outer condition fails
+        await insertAuthor({ first_name: "a2" });
+        await insertBook({ title: "match", author_id: 2 });
+        // a3 has first_name "a1" but no matching book — EXISTS fails
+        await insertAuthor({ first_name: "a3" });
+        await insertBook({ title: "other", author_id: 3 });
+
+        // AND can keep EXISTS: outer condition goes on the outer WHERE,
+        // collection condition goes inside the EXISTS subquery.
+        const { rows } = await knex.raw(`
+          SELECT a.id, a.first_name
+          FROM authors a
+          WHERE a.first_name = 'a1'
+          AND EXISTS (SELECT 1 FROM books b WHERE b.author_id = a.id AND b.title = 'match')
+          ORDER BY a.id
+        `);
+        expect(rows).toMatchObject([{ first_name: "a1" }]);
+      });
+    });
+
+    // ---- Simple OR: o2m alias + outer alias ----
+    // The OR references `b` (inside books EXISTS) and `a` (outer Author).
+    // Since OR requires both aliases in the same scope, the books EXISTS is
+    // unwrapped to a LEFT OUTER JOIN, and DISTINCT ON is added.
+    it("OR with o2m alias + outer alias unwraps EXISTS to JOIN", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "match", author_id: 1 });
+      await insertAuthor({ first_name: "match" });
+      await insertBook({ title: "other", author_id: 2 });
+      await insertAuthor({ first_name: "a3" });
+      await insertBook({ title: "other", author_id: 3 });
+
+      const em = newEntityManager();
+      const [a, b] = aliases(Author, Book);
+      resetQueryCount();
+      const authors = await em.find(
+        Author,
+        { as: a, books: b },
+        { ...opts, conditions: { or: [b.title.eq("match"), a.firstName.eq("match")] } },
+      );
+      // a1 matches via b.title, a2 matches via a.firstName
+      expect(authors).toMatchEntity([{ firstName: "a1" }, { firstName: "match" }]);
+      // The EXISTS for books was unwrapped to a JOIN — look for LEFT OUTER JOIN + DISTINCT ON
+      expect(queries).toEqual([expect.stringContaining("DISTINCT ON")]);
+      expect(queries).toEqual([expect.stringContaining("LEFT OUTER JOIN books")]);
+    });
+
+    // ---- Simple AND: o2m alias + outer alias ----
+    // The AND references `b` (inside books EXISTS) and `a` (outer Author).
+    // Since AND branches are independent, `b.title` moves into the EXISTS
+    // while `a.firstName` stays on the outer WHERE. No unwrap needed.
+    it("AND with o2m alias + outer alias keeps EXISTS intact", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "match", author_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertBook({ title: "match", author_id: 2 });
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "other", author_id: 3 });
+
+      const em = newEntityManager();
+      const [a, b] = aliases(Author, Book);
+      resetQueryCount();
+      const authors = await em.find(
+        Author,
+        { as: a, books: b },
+        { ...opts, conditions: { and: [b.title.eq("match"), a.firstName.eq("a1")] } },
+      );
+      // Only a1 matches both: firstName="a1" AND has book with title="match"
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      // The EXISTS stays intact — `b.title` moved inside, `a.firstName` stays outside
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE a.first_name = $1`,
+          ` AND EXISTS (SELECT 1 FROM books AS b WHERE a.id = b.author_id AND b.title = $2)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+
+    // ---- Nested: cross-scope OR inside an AND ----
+    // The outer AND has `a.age > 20` (outer) plus an inner OR that mixes
+    // `b.title` (inside books EXISTS) with `a.firstName` (outer).
+    // The OR forces the books EXISTS to unwrap, but the outer `a.age` condition
+    // stays as a regular WHERE clause.
+    it("OR inside AND: cross-scope OR forces unwrap even within outer AND", async () => {
+      await insertAuthor({ first_name: "match", age: 30 });
+      await insertBook({ title: "other", author_id: 1 });
+      await insertAuthor({ first_name: "a2", age: 30 });
+      await insertBook({ title: "match", author_id: 2 });
+      // a3 matches OR but not age
+      await insertAuthor({ first_name: "match", age: 10 });
+      await insertBook({ title: "other", author_id: 3 });
+
+      const em = newEntityManager();
+      const [a, b] = aliases(Author, Book);
+      resetQueryCount();
+      const authors = await em.find(
+        Author,
+        { as: a, books: b },
+        {
+          ...opts,
+          conditions: {
+            and: [a.age.gt(20), { or: [b.title.eq("match"), a.firstName.eq("match")] }],
+          },
+        },
+      );
+      // a1: age=30 ✓, firstName="match" ✓ (via OR) → matches
+      // a2: age=30 ✓, book title="match" ✓ (via OR) → matches
+      // a3: age=10 ✗ → excluded by AND
+      expect(authors).toMatchEntity([{ firstName: "match" }, { firstName: "a2" }]);
+      // The OR forced unwrap — should have LEFT OUTER JOIN + DISTINCT ON
+      expect(queries).toEqual([expect.stringContaining("DISTINCT ON")]);
+    });
+
+    // ---- AND with m2m alias + outer alias ----
+    // Same as the o2m case but through a many-to-many (tags).
+    // `t.name` moves into the m2m EXISTS, `a.firstName` stays outside.
+    it("AND with m2m alias + outer alias keeps EXISTS intact", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertTag({ name: "match" });
+      await insertAuthorToTag({ author_id: 1, tag_id: 1 });
+      await insertAuthor({ first_name: "a2" });
+      await insertAuthorToTag({ author_id: 2, tag_id: 1 });
+      await insertAuthor({ first_name: "a1" });
+
+      const em = newEntityManager();
+      const [a, t] = aliases(Author, Tag);
+      resetQueryCount();
+      const authors = await em.find(
+        Author,
+        { as: a, tags: t },
+        { ...opts, conditions: { and: [t.name.eq("match"), a.firstName.eq("a1")] } },
+      );
+      // Only a1 matches both: firstName="a1" AND has tag "match"
+      expect(authors).toMatchEntity([{ firstName: "a1" }]);
+      // m2m EXISTS stays intact — `t.name` moved inside
+      expect(queries).toEqual([
+        [
+          `SELECT a.* FROM authors AS a`,
+          ` WHERE a.first_name = $1`,
+          ` AND EXISTS (SELECT 1 FROM authors_to_tags AS att JOIN tags AS t ON att.tag_id = t.id WHERE a.id = att.author_id AND t.name = $2)`,
+          ` ORDER BY a.id ASC`,
+          ` LIMIT $3`,
+        ].join(""),
+      ]);
+    });
+
+    // ---- OR with m2m alias + outer alias ----
+    // The OR forces the m2m EXISTS to unwrap to regular JOINs.
+    it("OR with m2m alias + outer alias unwraps EXISTS to JOIN", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertTag({ name: "match" });
+      await insertAuthorToTag({ author_id: 1, tag_id: 1 });
+      await insertAuthor({ first_name: "match" });
+      await insertTag({ name: "other" });
+      await insertAuthorToTag({ author_id: 2, tag_id: 2 });
+      await insertAuthor({ first_name: "a3" });
+
+      const em = newEntityManager();
+      const [a, t] = aliases(Author, Tag);
+      resetQueryCount();
+      const authors = await em.find(
+        Author,
+        { as: a, tags: t },
+        { ...opts, conditions: { or: [t.name.eq("match"), a.firstName.eq("match")] } },
+      );
+      // a1 matches via t.name, a2 matches via a.firstName
+      expect(authors).toMatchEntity([{ firstName: "a1" }, { firstName: "match" }]);
+      // m2m EXISTS unwrapped to JOINs
+      expect(queries).toEqual([expect.stringContaining("DISTINCT ON")]);
+    });
+
+    // ---- Verify the parseFindQuery AST is stable before optimization ----
+    // This shows the plugin-facing structural result: collection aliases stay
+    // as top-level JOINs, and EXISTS is introduced later by optimizeCollectionJoins.
+    it("parseFindQuery: keeps AND conditions in the logical JOIN AST", async () => {
+      const [a, b] = aliases(Author, Book);
+      const filter = { as: a, books: b };
+      const conditions = { and: [b.title.eq("match"), a.firstName.eq("a1")] };
+      const result = parseFindQuery(am, filter, { ...opts, conditions });
+      expect(result).toMatchObject({
+        selects: [`a.*`],
+        tables: [
+          { alias: "a", table: "authors", join: "primary" },
+          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
+        ],
+        condition: {
+          op: "and",
+          conditions: [
+            { kind: "column", alias: "b", column: "title", cond: { kind: "eq", value: "match" } },
+            { kind: "column", alias: "a", column: "first_name", cond: { kind: "eq", value: "a1" } },
+          ],
+        },
+      });
+    });
+
+    it("parseFindQuery: keeps OR conditions in the logical JOIN AST", async () => {
+      const [a, b] = aliases(Author, Book);
+      const filter = { as: a, books: b };
+      const conditions = { or: [b.title.eq("match"), a.firstName.eq("a1")] };
+      const result = parseFindQuery(am, filter, { ...opts, conditions });
+      expect(result).toMatchObject({
+        selects: [`a.*`],
+        tables: [
+          { alias: "a", table: "authors", join: "primary" },
+          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
+        ],
+        condition: {
+          op: "or",
+          conditions: [
+            { kind: "column", alias: "b", column: "title", cond: { kind: "eq", value: "match" } },
+            { kind: "column", alias: "a", column: "first_name", cond: { kind: "eq", value: "a1" } },
+          ],
+        },
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Performance benchmarks — normally skipped. Remove `.skip` to run manually.
+  // These use raw SQL via knex.raw to compare JOIN+DISTINCT vs EXISTS
+  // at scale, demonstrating the cross-product explosion problem.
+  // -----------------------------------------------------------------------
+  describe.skip("benchmarks", () => {
+    const NUM_AUTHORS = 1_000;
+    const BOOKS_PER_AUTHOR = 50;
+    const COMMENTS_PER_AUTHOR = 50;
+    const NUM_TAGS = 20;
+    const TAGS_PER_AUTHOR = 5;
+
+    beforeEach(async () => {
+      const now = "now()";
+      await knex.raw(`
+        INSERT INTO authors (first_name, initials, number_of_books, created_at, updated_at)
+        SELECT 'author_' || i::text, '', ${BOOKS_PER_AUTHOR}, ${now}, ${now}
+        FROM generate_series(1, ${NUM_AUTHORS}) AS t(i)
+      `);
+      await knex.raw(`
+        INSERT INTO books (title, author_id, notes, created_at, updated_at)
+        SELECT 'book_' || a.id || '_' || j::text, a.id, '', ${now}, ${now}
+        FROM authors a, generate_series(1, ${BOOKS_PER_AUTHOR}) AS t(j)
+      `);
+      await knex.raw(`
+        INSERT INTO comments (parent_author_id, parent_tags, text, created_at, updated_at)
+        SELECT a.id, '', 'comment_' || a.id || '_' || j::text, ${now}, ${now}
+        FROM authors a, generate_series(1, ${COMMENTS_PER_AUTHOR}) AS t(j)
+      `);
+      await knex.raw(`
+        INSERT INTO tags (name, created_at, updated_at)
+        SELECT 'tag_' || i::text, ${now}, ${now}
+        FROM generate_series(1, ${NUM_TAGS}) AS t(i)
+      `);
+      await knex.raw(`
+        INSERT INTO authors_to_tags (author_id, tag_id)
+        SELECT a.id, j
+        FROM authors a, generate_series(1, ${TAGS_PER_AUTHOR}) AS t(j)
+      `);
+      await knex.raw(`ANALYZE authors; ANALYZE books; ANALYZE comments; ANALYZE tags; ANALYZE authors_to_tags`);
+    });
+
+    // ---- Queries under test (three approaches) ----
+
+    // 1. JOIN + DISTINCT: naive multi-JOIN
+    const joinDistinctSQL = `
+      SELECT DISTINCT a.id, a.first_name
+      FROM authors a
+      LEFT JOIN books b ON a.id = b.author_id
+      LEFT JOIN comments c ON a.id = c.parent_author_id
+      WHERE b.title LIKE ? AND c.text LIKE ?
+      ORDER BY a.id
+    `;
+
+    // 2. LATERAL + BOOL_OR: previous approach
+    const lateralSQL = `
+      SELECT a.id, a.first_name
+      FROM authors a
+      CROSS JOIN LATERAL (
+        SELECT BOOL_OR(b.title LIKE ?) AS has_match
+        FROM books b WHERE b.author_id = a.id
+      ) _books
+      CROSS JOIN LATERAL (
+        SELECT BOOL_OR(c.text LIKE ?) AS has_match
+        FROM comments c WHERE c.parent_author_id = a.id
+      ) _comments
+      WHERE _books.has_match AND _comments.has_match
+      ORDER BY a.id
+    `;
+
+    // 3. EXISTS: current approach
+    const existsSQL = `
+      SELECT a.id, a.first_name
+      FROM authors a
+      WHERE EXISTS (
+        SELECT 1 FROM books b WHERE b.author_id = a.id AND b.title LIKE ?
+      )
+      AND EXISTS (
+        SELECT 1 FROM comments c WHERE c.parent_author_id = a.id AND c.text LIKE ?
+      )
+      ORDER BY a.id
+    `;
+
+    // m2m variants
+    const joinDistinctM2mSQL = `
+      SELECT DISTINCT a.id, a.first_name
+      FROM authors a
+      LEFT JOIN authors_to_tags att ON a.id = att.author_id
+      LEFT JOIN tags t ON att.tag_id = t.id
+      LEFT JOIN books b ON a.id = b.author_id
+      WHERE t.name = ? AND b.title LIKE ?
+      ORDER BY a.id
+    `;
+
+    const lateralM2mSQL = `
+      SELECT a.id, a.first_name
+      FROM authors a
+      CROSS JOIN LATERAL (
+        SELECT BOOL_OR(t.name = ?) AS has_match
+        FROM authors_to_tags att
+        JOIN tags t ON att.tag_id = t.id
+        WHERE att.author_id = a.id
+      ) _tags
+      CROSS JOIN LATERAL (
+        SELECT BOOL_OR(b.title LIKE ?) AS has_match
+        FROM books b WHERE b.author_id = a.id
+      ) _books
+      WHERE _tags.has_match AND _books.has_match
+      ORDER BY a.id
+    `;
+
+    const existsM2mSQL = `
+      SELECT a.id, a.first_name
+      FROM authors a
+      WHERE EXISTS (
+        SELECT 1
+        FROM authors_to_tags att
+        JOIN tags t ON att.tag_id = t.id
+        WHERE att.author_id = a.id AND t.name = ?
+      )
+      AND EXISTS (
+        SELECT 1 FROM books b WHERE b.author_id = a.id AND b.title LIKE ?
+      )
+      ORDER BY a.id
+    `;
+
+    async function timeQuery(sql: string, bindings: any[], warmup = 3, iterations = 10): Promise<number[]> {
+      for (let i = 0; i < warmup; i++) {
+        await knex.raw(sql, bindings);
+      }
+      const times: number[] = [];
+      for (let i = 0; i < iterations; i++) {
+        const start = performance.now();
+        await knex.raw(sql, bindings);
+        times.push(performance.now() - start);
+      }
+      return times;
+    }
+
+    function stats(times: number[]) {
+      const sorted = [...times].sort((a, b) => a - b);
+      const median = sorted[Math.floor(sorted.length / 2)];
+      const mean = times.reduce((a, b) => a + b, 0) / times.length;
+      const min = sorted[0];
+      const max = sorted[sorted.length - 1];
+      return { median, mean, min, max };
+    }
+
+    function fmtStats(s: ReturnType<typeof stats>): string {
+      return `median=${s.median.toFixed(1)}ms  mean=${s.mean.toFixed(1)}ms  min=${s.min.toFixed(1)}ms  max=${s.max.toFixed(1)}ms`;
+    }
+
+    // ---- Timing benchmarks ----
+
+    it("o2m x o2m: broad match", async () => {
+      const bindings = ["book_1_%", "comment_1_%"];
+
+      const joinTimes = await timeQuery(joinDistinctSQL, bindings);
+      const lateralTimes = await timeQuery(lateralSQL, bindings);
+      const existsTimes = await timeQuery(existsSQL, bindings);
+      const jS = stats(joinTimes);
+      const lS = stats(lateralTimes);
+      const eS = stats(existsTimes);
+
+      console.log("\n=== o2m x o2m: Broad match ===");
+      console.log(`  JOIN+DISTINCT:    ${fmtStats(jS)}`);
+      console.log(`  LATERAL+BOOL_OR:  ${fmtStats(lS)}`);
+      console.log(`  EXISTS:           ${fmtStats(eS)}`);
+      console.log(`  EXISTS vs JOIN:    ${(jS.median / eS.median).toFixed(2)}x faster`);
+      console.log(`  EXISTS vs LATERAL: ${(lS.median / eS.median).toFixed(2)}x faster`);
+
+      expect(eS.median).toBeLessThan(jS.median * 1.5);
+    });
+
+    it("o2m x o2m: selective match", async () => {
+      const bindings = ["book_500_%", "comment_500_%"];
+
+      const joinTimes = await timeQuery(joinDistinctSQL, bindings);
+      const lateralTimes = await timeQuery(lateralSQL, bindings);
+      const existsTimes = await timeQuery(existsSQL, bindings);
+      const jS = stats(joinTimes);
+      const lS = stats(lateralTimes);
+      const eS = stats(existsTimes);
+
+      console.log("\n=== o2m x o2m: Selective match ===");
+      console.log(`  JOIN+DISTINCT:    ${fmtStats(jS)}`);
+      console.log(`  LATERAL+BOOL_OR:  ${fmtStats(lS)}`);
+      console.log(`  EXISTS:           ${fmtStats(eS)}`);
+      console.log(`  EXISTS vs JOIN:    ${(jS.median / eS.median).toFixed(2)}x faster`);
+      console.log(`  EXISTS vs LATERAL: ${(lS.median / eS.median).toFixed(2)}x faster`);
+    });
+
+    it("m2m + o2m", async () => {
+      const bindings = ["tag_1", "book_%"];
+
+      const joinTimes = await timeQuery(joinDistinctM2mSQL, bindings);
+      const lateralTimes = await timeQuery(lateralM2mSQL, bindings);
+      const existsTimes = await timeQuery(existsM2mSQL, bindings);
+      const jS = stats(joinTimes);
+      const lS = stats(lateralTimes);
+      const eS = stats(existsTimes);
+
+      console.log("\n=== m2m + o2m ===");
+      console.log(`  JOIN+DISTINCT:    ${fmtStats(jS)}`);
+      console.log(`  LATERAL+BOOL_OR:  ${fmtStats(lS)}`);
+      console.log(`  EXISTS:           ${fmtStats(eS)}`);
+      console.log(`  EXISTS vs JOIN:    ${(jS.median / eS.median).toFixed(2)}x faster`);
+      console.log(`  EXISTS vs LATERAL: ${(lS.median / eS.median).toFixed(2)}x faster`);
+
+      expect(eS.median).toBeLessThan(jS.median * 1.5);
+    });
+
+    // ---- EXPLAIN ANALYZE tests ----
+
+    async function explainAnalyze(sql: string, bindings: any[]): Promise<any> {
+      const { rows } = await knex.raw(`EXPLAIN (ANALYZE, FORMAT JSON) ${sql}`, bindings);
+      return rows[0]["QUERY PLAN"][0];
+    }
+
+    function extractPlanInfo(plan: any) {
+      const root = plan["Plan"];
+      const executionTime = plan["Execution Time"];
+      const planningTime = plan["Planning Time"];
+
+      function walkNodes(
+        node: any,
+        depth = 0,
+      ): Array<{ type: string; actualRows: number; loops: number; depth: number }> {
+        const result = [
+          {
+            type: node["Node Type"],
+            actualRows: node["Actual Rows"],
+            loops: node["Actual Loops"],
+            depth,
+          },
+        ];
+        for (const child of node["Plans"] ?? []) {
+          result.push(...walkNodes(child, depth + 1));
+        }
+        return result;
+      }
+
+      const nodes = walkNodes(root);
+      const totalActualRows = nodes.reduce((sum, n) => sum + n.actualRows * n.loops, 0);
+      const hasSeqScan = nodes.some((n) => n.type === "Seq Scan");
+      return { executionTime, planningTime, nodes, totalActualRows, hasSeqScan };
+    }
+
+    function fmtPlan(label: string, info: ReturnType<typeof extractPlanInfo>): string {
+      return `${label} exec=${info.executionTime.toFixed(1)}ms  plan=${info.planningTime.toFixed(1)}ms  totalRows=${info.totalActualRows}`;
+    }
+
+    function logNodes(label: string, info: ReturnType<typeof extractPlanInfo>): void {
+      console.log(`\n  ${label} nodes:`);
+      for (const n of info.nodes) {
+        console.log(`    ${"  ".repeat(n.depth)}${n.type}: rows=${n.actualRows} loops=${n.loops}`);
+      }
+    }
+
+    it("EXPLAIN: broad match — three-way comparison", async () => {
+      const bindings = ["book_1_%", "comment_1_%"];
+
+      const joinPlan = await explainAnalyze(joinDistinctSQL, bindings);
+      const lateralPlan = await explainAnalyze(lateralSQL, bindings);
+      const existsPlan = await explainAnalyze(existsSQL, bindings);
+      const jI = extractPlanInfo(joinPlan);
+      const lI = extractPlanInfo(lateralPlan);
+      const eI = extractPlanInfo(existsPlan);
+
+      console.log("\n=== EXPLAIN: Broad match ===");
+      console.log(`  ${fmtPlan("JOIN+DISTINCT:  ", jI)}`);
+      console.log(`  ${fmtPlan("LATERAL+BOOL_OR:", lI)}`);
+      console.log(`  ${fmtPlan("EXISTS:         ", eI)}`);
+      logNodes("JOIN", jI);
+      logNodes("LATERAL", lI);
+      logNodes("EXISTS", eI);
+
+      expect(eI.totalActualRows).toBeLessThan(jI.totalActualRows);
+    });
+
+    it("EXPLAIN: selective match — three-way comparison", async () => {
+      const bindings = ["book_500_%", "comment_500_%"];
+
+      const joinPlan = await explainAnalyze(joinDistinctSQL, bindings);
+      const lateralPlan = await explainAnalyze(lateralSQL, bindings);
+      const existsPlan = await explainAnalyze(existsSQL, bindings);
+      const jI = extractPlanInfo(joinPlan);
+      const lI = extractPlanInfo(lateralPlan);
+      const eI = extractPlanInfo(existsPlan);
+
+      console.log("\n=== EXPLAIN: Selective match ===");
+      console.log(`  ${fmtPlan("JOIN+DISTINCT:  ", jI)}`);
+      console.log(`  ${fmtPlan("LATERAL+BOOL_OR:", lI)}`);
+      console.log(`  ${fmtPlan("EXISTS:         ", eI)}`);
+      logNodes("JOIN", jI);
+      logNodes("LATERAL", lI);
+      logNodes("EXISTS", eI);
+
+      console.log(`\n  Row ratio: EXISTS/JOIN = ${(eI.totalActualRows / jI.totalActualRows).toFixed(2)}x`);
+      console.log(`  Row ratio: EXISTS/LATERAL = ${(eI.totalActualRows / lI.totalActualRows).toFixed(2)}x`);
+    });
+
+    it("EXPLAIN: broad predicates (match-all) — three-way comparison", async () => {
+      const bindings = ["book_%", "comment_%"];
+
+      const joinPlan = await explainAnalyze(joinDistinctSQL, bindings);
+      const lateralPlan = await explainAnalyze(lateralSQL, bindings);
+      const existsPlan = await explainAnalyze(existsSQL, bindings);
+      const jI = extractPlanInfo(joinPlan);
+      const lI = extractPlanInfo(lateralPlan);
+      const eI = extractPlanInfo(existsPlan);
+
+      console.log("\n=== EXPLAIN: Broad predicates (match-all) ===");
+      console.log(`  ${fmtPlan("JOIN+DISTINCT:  ", jI)}`);
+      console.log(`  ${fmtPlan("LATERAL+BOOL_OR:", lI)}`);
+      console.log(`  ${fmtPlan("EXISTS:         ", eI)}`);
+      logNodes("JOIN", jI);
+      logNodes("LATERAL", lI);
+      logNodes("EXISTS", eI);
+
+      expect(eI.executionTime).toBeLessThan(jI.executionTime * 3);
+    });
+  });
+});
+
+function addCondition(query: ParsedFindQuery, condition: ParsedExpressionCondition): void {
+  query.condition ??= { kind: "exp", op: "and", conditions: [] };
+  query.condition.conditions.push(condition);
+}
+
+function failTest(message: string): never {
+  throw new Error(message);
+}

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -25,6 +25,7 @@ import {
   aliases,
   getAliasMetadata,
   getMetadata,
+  optimizeCollectionJoins,
   parseFindQuery,
 } from "joist-orm";
 import { PasswordValue } from "src/entities/types";
@@ -74,6 +75,12 @@ const criticMeta = getMetadata(Critic);
 const taskItemMeta = getMetadata(TaskItem);
 const opts = { softDeletes: "include" } as const;
 
+function parseAndOptimizeFindQuery(...args: Parameters<typeof parseFindQuery>): ReturnType<typeof parseFindQuery> {
+  const query = parseFindQuery(...args);
+  optimizeCollectionJoins(query, args[2]);
+  return query;
+}
+
 describe("EntityManager.queries", () => {
   it("can find all", async () => {
     await insertAuthor({ first_name: "a1" });
@@ -103,7 +110,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -126,7 +133,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -163,7 +170,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a1");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -285,7 +292,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a1");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -346,7 +353,7 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     expect(authors.length).toEqual(0);
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -368,7 +375,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -409,7 +416,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -432,7 +439,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -454,7 +461,7 @@ describe("EntityManager.queries", () => {
     expect(authors[0].firstName).toEqual("a1");
     expect(authors[1].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -532,7 +539,7 @@ describe("EntityManager.queries", () => {
     const authors = await em.findGql(Author, where);
     expect(authors.length).toEqual(0);
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       orderBys: [expect.anything()],
@@ -556,7 +563,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -597,7 +604,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -620,7 +627,7 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a2");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
@@ -2169,15 +2176,27 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     expect(authors.length).toEqual(1);
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
-      ],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
         op: "and",
-        conditions: [{ alias: "att", column: "tag_id", dbType: "int", cond: { kind: "eq", value: 1 } }],
+        conditions: [
+          {
+            kind: "exists",
+            negate: false,
+            subquery: {
+              tables: [{ alias: "att", table: "authors_to_tags", join: "primary" }],
+              condition: {
+                op: "and",
+                conditions: [
+                  { kind: "raw", condition: "a.id = att.author_id" },
+                  { alias: "att", column: "tag_id", dbType: "int", cond: { kind: "eq", value: 1 } },
+                ],
+              },
+            },
+          },
+        ],
       },
       orderBys: [expect.anything()],
     });
@@ -2192,15 +2211,27 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     expect(authors.length).toEqual(0);
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
-      ],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
         op: "and",
-        conditions: [{ alias: "att", column: "tag_id", dbType: "int", cond: { kind: "in", value: [-1] } }],
+        conditions: [
+          {
+            kind: "exists",
+            negate: false,
+            subquery: {
+              tables: [{ alias: "att", table: "authors_to_tags", join: "primary" }],
+              condition: {
+                op: "and",
+                conditions: [
+                  { kind: "raw", condition: "a.id = att.author_id" },
+                  { alias: "att", column: "tag_id", dbType: "int", cond: { kind: "in", value: [-1] } },
+                ],
+              },
+            },
+          },
+        ],
       },
       orderBys: [expect.anything()],
     });
@@ -2217,16 +2248,30 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     expect(authors.length).toEqual(1);
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
-        { alias: "t", table: "tags", join: "outer", col1: "att.tag_id", col2: "t.id" },
-      ],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
         op: "and",
-        conditions: [{ alias: "t", column: "name", dbType: "citext", cond: { kind: "eq", value: "t1" } }],
+        conditions: [
+          {
+            kind: "exists",
+            negate: false,
+            subquery: {
+              tables: [
+                { alias: "att", table: "authors_to_tags", join: "primary" },
+                { alias: "t", table: "tags", join: "inner", col1: "att.tag_id", col2: "t.id" },
+              ],
+              condition: {
+                op: "and",
+                conditions: [
+                  { kind: "raw", condition: "a.id = att.author_id" },
+                  { alias: "t", column: "name", dbType: "citext", cond: { kind: "eq", value: "t1" } },
+                ],
+              },
+            },
+          },
+        ],
       },
       orderBys: [expect.anything()],
     });
@@ -2256,16 +2301,26 @@ describe("EntityManager.queries", () => {
     expect(authors.length).toEqual(1);
     expect(authors[0].firstName).toEqual("a1");
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
-      ],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
         op: "and",
         conditions: [
-          { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
+          {
+            kind: "exists",
+            negate: false,
+            subquery: {
+              tables: [{ alias: "b", table: "books", join: "primary" }],
+              condition: {
+                op: "and",
+                conditions: [
+                  { kind: "raw", condition: "a.id = b.author_id" },
+                  { alias: "b", column: "title", dbType: "character varying", cond: { kind: "like", value: "b1%" } },
+                ],
+              },
+            },
+          },
         ],
       },
       orderBys: [expect.anything()],
@@ -2284,15 +2339,27 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     expect(authors.length).toEqual(0);
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
-      ],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
         op: "and",
-        conditions: [{ alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } }],
+        conditions: [
+          {
+            kind: "exists",
+            negate: false,
+            subquery: {
+              tables: [{ alias: "b", table: "books", join: "primary" }],
+              condition: {
+                op: "and",
+                conditions: [
+                  { kind: "raw", condition: "a.id = b.author_id" },
+                  { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b3" } },
+                ],
+              },
+            },
+          },
+        ],
       },
       orderBys: [expect.anything()],
     });
@@ -2308,15 +2375,27 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     expect(authors.length).toEqual(1);
 
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
-      ],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
         op: "and",
-        conditions: [{ alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } }],
+        conditions: [
+          {
+            kind: "exists",
+            negate: false,
+            subquery: {
+              tables: [{ alias: "b", table: "books", join: "primary" }],
+              condition: {
+                op: "and",
+                conditions: [
+                  { kind: "raw", condition: "a.id = b.author_id" },
+                  { alias: "b", column: "id", dbType: "int", cond: { kind: "eq", value: 2 } },
+                ],
+              },
+            },
+          },
+        ],
       },
       orderBys: [expect.anything()],
     });
@@ -2334,12 +2413,9 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     // Then we only get back the 1st author
     expect(authors).toMatchEntity([{ firstName: "a1" }]);
-    expect(parseFindQuery(am, where)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where)).toMatchObject({
       selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
-      ],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: {
         op: "and",
         conditions: [
@@ -2351,18 +2427,26 @@ describe("EntityManager.queries", () => {
             pruneable: true,
           },
           {
-            alias: "b",
-            column: "deleted_at",
-            dbType: "timestamp with time zone",
-            cond: { kind: "is-null" },
-            pruneable: true,
-          },
-          {
-            op: "and",
-            conditions: [
-              { alias: "b", column: "acknowledgements", dbType: "text", cond: { kind: "is-null" } },
-              { alias: "b", column: "id", dbType: "int", cond: { kind: "not-null" } },
-            ],
+            kind: "exists",
+            negate: false,
+            subquery: {
+              tables: [{ alias: "b", table: "books", join: "primary" }],
+              condition: {
+                op: "and",
+                conditions: [
+                  { kind: "raw", condition: "a.id = b.author_id" },
+                  {
+                    alias: "b",
+                    column: "deleted_at",
+                    dbType: "timestamp with time zone",
+                    cond: { kind: "is-null" },
+                    pruneable: true,
+                  },
+                  { alias: "b", column: "acknowledgements", dbType: "text", cond: { kind: "is-null" } },
+                  { alias: "b", column: "id", dbType: "int", cond: { kind: "not-null" } },
+                ],
+              },
+            },
           },
         ],
       },
@@ -2382,13 +2466,25 @@ describe("EntityManager.queries", () => {
     const authors = await em.find(Author, where);
     // Then we only get back 2nd author
     expect(authors).toMatchEntity([{ firstName: "a2" }]);
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
       selects: [`a.*`],
-      tables: [
-        { alias: "a", table: "authors", join: "primary" },
-        { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
-      ],
-      condition: { op: "and", conditions: [{ alias: "b", column: "id", dbType: "int", cond: { kind: "is-null" } }] },
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
+      condition: {
+        op: "and",
+        conditions: [
+          {
+            kind: "exists",
+            negate: true,
+            subquery: {
+              tables: [{ alias: "b", table: "books", join: "primary" }],
+              condition: {
+                op: "and",
+                conditions: [{ kind: "raw", condition: "a.id = b.author_id" }],
+              },
+            },
+          },
+        ],
+      },
       orderBys: [expect.anything()],
     });
   });
@@ -2403,18 +2499,29 @@ describe("EntityManager.queries", () => {
     const critics = await em.find(Critic, where);
     expect(critics.length).toEqual(1);
 
-    expect(parseFindQuery(criticMeta, where, opts)).toMatchObject({
+    expect(parseAndOptimizeFindQuery(criticMeta, where, opts)).toMatchObject({
       selects: [`c.*`],
       tables: [
         { alias: "c", table: "critics", join: "primary" },
         { alias: "lp", table: "large_publishers", join: "outer", col1: "c.favorite_large_publisher_id", col2: "lp.id" },
-        // Perhaps ideally the `col1` would be `lp_b0.id` but it doesn't matter
-        { alias: "a", table: "authors", join: "outer", col1: "lp.id", col2: "a.publisher_id" },
       ],
       condition: {
         op: "and",
         conditions: [
-          { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
+          {
+            kind: "exists",
+            negate: false,
+            subquery: {
+              tables: [{ alias: "a", table: "authors", join: "primary" }],
+              condition: {
+                op: "and",
+                conditions: [
+                  { kind: "raw", condition: "lp.id = a.publisher_id" },
+                  { alias: "a", column: "first_name", dbType: "character varying", cond: { kind: "eq", value: "a1" } },
+                ],
+              },
+            },
+          },
         ],
       },
       orderBys: [expect.anything()],
@@ -2455,7 +2562,7 @@ describe("EntityManager.queries", () => {
 
   it("can prune m2o STI subtype only fields", async () => {
     const where = { copiedToTaskNew: { specialNewField: undefined } } satisfies TaskFilter;
-    expect(parseFindQuery(tm, where, opts)).toMatchObject({
+    expect(parseFindQuery(tm, where, { ...opts, pruneJoins: true })).toMatchObject({
       selects: [`t.*`],
       tables: [{ alias: "t", table: "tasks", join: "primary" }],
       condition: undefined,
@@ -2464,7 +2571,7 @@ describe("EntityManager.queries", () => {
 
   it("can prune m2o CTI subtype only fields", async () => {
     const where = { publisherLargePublisher: { country: undefined } } satisfies AuthorFilter;
-    expect(parseFindQuery(am, where, opts)).toMatchObject({
+    expect(parseFindQuery(am, where, { ...opts, pruneJoins: true })).toMatchObject({
       selects: [`a.*`],
       tables: [{ alias: "a", table: "authors", join: "primary" }],
       condition: undefined,
@@ -2833,18 +2940,37 @@ describe("EntityManager.queries", () => {
       expect(books.length).toEqual(1);
 
       expect(
-        parseFindQuery(bm, { author: { tags: t } }, { conditions: { or: [t.id.eq("t:1")] }, ...opts }),
+        parseAndOptimizeFindQuery(bm, { author: { tags: t } }, { conditions: { or: [t.id.eq("t:1")] }, ...opts }),
       ).toMatchObject({
         selects: [`b.*`],
         tables: [
           { alias: "b", table: "books", join: "primary" },
           { alias: "a", table: "authors", join: "inner", col1: "b.author_id", col2: "a.id" },
-          { alias: "att", table: "authors_to_tags", join: "outer", col1: "a.id", col2: "att.author_id" },
-          { alias: "t", table: "tags", join: "outer", col1: "att.tag_id", col2: "t.id" },
         ],
         condition: {
           op: "or",
-          conditions: [{ alias: "t", column: "id", dbType: "int", cond: { kind: "eq", value: 1 } }],
+          conditions: [
+            {
+              kind: "exists",
+              negate: false,
+              subquery: {
+                tables: [
+                  { alias: "att", table: "authors_to_tags", join: "primary" },
+                  { alias: "t", table: "tags", join: "inner", col1: "att.tag_id", col2: "t.id" },
+                ],
+                condition: {
+                  op: "and",
+                  conditions: [
+                    { kind: "raw", condition: "a.id = att.author_id" },
+                    {
+                      op: "or",
+                      conditions: [{ alias: "t", column: "id", dbType: "int", cond: { kind: "eq", value: 1 } }],
+                    },
+                  ],
+                },
+              },
+            },
+          ],
         },
         orderBys: expect.anything(),
       });
@@ -2931,16 +3057,182 @@ describe("EntityManager.queries", () => {
 
     it("prunes unused joins", async () => {
       const [a, p, b] = aliases(Author, Publisher, Book);
-      expect(parseFindQuery(am, { as: a, publisher: { as: p }, books: { as: b } }, opts)).toEqual({
+      expect(
+        parseFindQuery(am, { as: a, publisher: { as: p }, books: { as: b } }, { ...opts, pruneJoins: true }),
+      ).toEqual({
         selects: [`a.*`],
         tables: [{ alias: "a", table: "authors", join: "primary" }],
         orderBys: [expect.anything()],
       });
     });
 
-    it("keeps all joins if pruneJoins is false", async () => {
+    it("prunes nested unused collection aliases", async () => {
+      const [b, br] = aliases(Book, BookReview);
+      expect(parseFindQuery(am, { books: { as: b, reviews: { as: br } } }, { ...opts, pruneJoins: true })).toEqual({
+        selects: [`a.*`],
+        tables: [{ alias: "a", table: "authors", join: "primary" }],
+        orderBys: [{ alias: "a", column: "id", order: "ASC" }],
+      });
+    });
+
+    it("removes nested collection aliases not referenced by conditions", async () => {
+      const [a, br] = aliases(Author, BookReview);
+      const conditions = { and: [a.firstName.eq("a1")] };
+      expect(
+        parseFindQuery(am, { as: a, books: { reviews: { as: br } } }, { ...opts, conditions, pruneJoins: true }),
+      ).toEqual({
+        selects: [`a.*`],
+        tables: [{ alias: "a", table: "authors", join: "primary" }],
+        condition: {
+          kind: "exp",
+          op: "and",
+          conditions: [
+            {
+              kind: "column",
+              alias: "a",
+              column: "first_name",
+              dbType: "character varying",
+              cond: { kind: "eq", value: "a1" },
+            },
+          ],
+        },
+        orderBys: [{ alias: "a", column: "id", order: "ASC" }],
+      });
+    });
+
+    it("keeps pure collection alias id IS NULL conditions as NOT EXISTS", async () => {
+      const [a, b] = aliases(Author, Book);
+      const conditions = { and: [b.id.eq(null as never)] };
+      expect(parseAndOptimizeFindQuery(am, { as: a, books: { as: b } }, { ...opts, conditions })).toMatchObject({
+        selects: [`a.*`],
+        tables: [{ alias: "a", table: "authors", join: "primary" }],
+        condition: {
+          kind: "exp",
+          op: "and",
+          conditions: [
+            {
+              kind: "exists",
+              negate: true,
+              subquery: {
+                tables: [{ alias: "b", table: "books", join: "primary" }],
+                condition: { conditions: [{ kind: "raw", condition: "a.id = b.author_id" }] },
+              },
+            },
+          ],
+        },
+        orderBys: [{ alias: "a", column: "id", order: "ASC" }],
+      });
+    });
+
+    it("keeps multiple pure collection alias id IS NULL conditions as NOT EXISTS", async () => {
+      const [a, b, c] = aliases(Author, Book, Comment);
+      const conditions = { and: [b.id.eq(null as never), c.id.eq(null as never)] };
+      expect(
+        parseAndOptimizeFindQuery(am, { as: a, books: { as: b }, comments: { as: c } }, { ...opts, conditions }),
+      ).toMatchObject({
+        selects: [`a.*`],
+        tables: [{ alias: "a", table: "authors", join: "primary" }],
+        condition: {
+          kind: "exp",
+          op: "and",
+          conditions: [
+            {
+              kind: "exists",
+              negate: true,
+              subquery: {
+                tables: [{ alias: "b", table: "books", join: "primary" }],
+                condition: { conditions: [{ kind: "raw", condition: "a.id = b.author_id" }] },
+              },
+            },
+            {
+              kind: "exists",
+              negate: true,
+              subquery: {
+                tables: [{ alias: "c", table: "comments", join: "primary" }],
+                condition: { conditions: [{ kind: "raw", condition: "a.id = c.parent_author_id" }] },
+              },
+            },
+          ],
+        },
+        orderBys: [{ alias: "a", column: "id", order: "ASC" }],
+      });
+    });
+
+    it("unwraps collection alias id IS NULL conditions inside OR to left joins", async () => {
+      const [a, b] = aliases(Author, Book);
+      const conditions = { or: [b.id.eq(null as never), a.firstName.eq("a1")] };
+      expect(parseAndOptimizeFindQuery(am, { as: a, books: { as: b } }, { ...opts, conditions })).toMatchObject({
+        selects: [`a.*`],
+        tables: [
+          { alias: "a", table: "authors", join: "primary" },
+          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
+        ],
+        condition: {
+          kind: "exp",
+          op: "or",
+          conditions: [
+            { kind: "column", alias: "b", column: "id", dbType: "int", cond: { kind: "is-null" } },
+            {
+              kind: "column",
+              alias: "a",
+              column: "first_name",
+              dbType: "character varying",
+              cond: { kind: "eq", value: "a1" },
+            },
+          ],
+        },
+        orderBys: [{ alias: "a", column: "id", order: "ASC" }],
+      });
+    });
+
+    it("fails multiple collection left joins by default after optimization", async () => {
+      const [a, b, c] = aliases(Author, Book, Comment);
+      const conditions = { or: [b.title.eq("b1"), c.text.eq("c1")] };
+      expect(() => {
+        const query = parseFindQuery(am, { as: a, books: { as: b }, comments: { as: c } }, { ...opts, conditions });
+        optimizeCollectionJoins(query);
+      }).toThrow("allowMultipleLeftJoins");
+    });
+
+    it("fails em.find calls with multiple collection left joins by default", async () => {
+      const em = newEntityManager();
+      const [a, b, c] = aliases(Author, Book, Comment);
+      const conditions = { or: [b.title.eq("b1"), c.text.eq("c1")] };
+      await expect(
+        em.find(Author, { as: a, books: { as: b }, comments: { as: c } }, { ...opts, conditions }),
+      ).rejects.toThrow("allowMultipleLeftJoins");
+    });
+
+    it("allows multiple collection left joins with allowMultipleLeftJoins", async () => {
+      const [a, b, c] = aliases(Author, Book, Comment);
+      const conditions = { or: [b.title.eq("b1"), c.text.eq("c1")] };
+      expect(
+        parseAndOptimizeFindQuery(
+          am,
+          { as: a, books: { as: b }, comments: { as: c } },
+          { ...opts, conditions, allowMultipleLeftJoins: true },
+        ),
+      ).toMatchObject({
+        selects: [`a.*`],
+        tables: [
+          { alias: "a", table: "authors", join: "primary" },
+          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
+          { alias: "c", table: "comments", join: "outer", col1: "a.id", col2: "c.parent_author_id" },
+        ],
+        condition: {
+          kind: "exp",
+          op: "or",
+          conditions: [
+            { kind: "column", alias: "b", column: "title", cond: { kind: "eq", value: "b1" } },
+            { kind: "column", alias: "c", column: "text", cond: { kind: "eq", value: "c1" } },
+          ],
+        },
+      });
+    });
+
+    it("keeps all joins by default", async () => {
       const filter = { publisher: {}, books: {} } satisfies AuthorFilter;
-      expect(parseFindQuery(am, filter, { ...opts, pruneJoins: false })).toEqual({
+      expect(parseFindQuery(am, filter, opts)).toMatchObject({
         selects: [`a.*`],
         tables: [
           { alias: "a", table: "authors", join: "primary" },
@@ -2953,7 +3245,7 @@ describe("EntityManager.queries", () => {
 
     it("keeps marked aliases", async () => {
       const filter = { publisher: {}, books: {} } satisfies AuthorFilter;
-      expect(parseFindQuery(am, filter, { ...opts, keepAliases: ["b"] })).toEqual({
+      expect(parseFindQuery(am, filter, { ...opts, keepAliases: ["b"], pruneJoins: true })).toMatchObject({
         selects: [`a.*`],
         tables: [
           { alias: "a", table: "authors", join: "primary" },
@@ -2966,22 +3258,33 @@ describe("EntityManager.queries", () => {
     it("does not prune joins from complex conditions", async () => {
       const [p, b] = aliases(Publisher, Book);
       expect(
-        parseFindQuery(
+        parseAndOptimizeFindQuery(
           am,
           { publisher: { as: p }, books: { as: b } },
           { ...opts, conditions: { and: [b.title.eq("b1")] } },
         ),
       ).toMatchObject({
         selects: [`a.*`],
-        tables: [
-          { alias: "a", table: "authors", join: "primary" },
-          { alias: "b", table: "books", join: "outer", col1: "a.id", col2: "b.author_id" },
-        ],
+        tables: [{ alias: "a", table: "authors", join: "primary" }],
         condition: {
           op: "and",
-          conditions: [{ alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b1" } }],
+          conditions: [
+            {
+              kind: "exists",
+              negate: false,
+              subquery: {
+                tables: [{ alias: "b", table: "books", join: "primary" }],
+                condition: {
+                  op: "and",
+                  conditions: [
+                    { kind: "raw", condition: "a.id = b.author_id" },
+                    { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "b1" } },
+                  ],
+                },
+              },
+            },
+          ],
         },
-
         orderBys: [expect.anything()],
       });
     });
@@ -3119,7 +3422,7 @@ describe("EntityManager.queries", () => {
       const authors = await em.find(Author, where);
       expect(authors.length).toEqual(1);
 
-      expect(parseFindQuery(am, where, { softDeletes: "exclude" })).toMatchObject({
+      expect(parseFindQuery(am, where, { softDeletes: "exclude", pruneJoins: true })).toMatchObject({
         selects: [`a.*`],
         tables: [{ alias: "a", table: "authors", join: "primary" }],
         condition: {
@@ -3176,6 +3479,7 @@ describe("EntityManager.queries", () => {
         { as: c, user: { authorManyToOne: { books: { advances: { publisher: p } } } } },
         {
           conditions: { or: [p.name.eq("test"), c.text.eq("test")] },
+          allowMultipleLeftJoins: true,
         },
       );
 

--- a/packages/tests/integration/src/QueryParser.quotes.test.ts
+++ b/packages/tests/integration/src/QueryParser.quotes.test.ts
@@ -8,14 +8,13 @@ describe("QueryParser", () => {
     const q = buildQuery(knex, Book, { where: { author: { firstName: "jeff", schedules: { id: "4" } } } });
     expect(q.toSQL().sql).toEqual(
       [
-        "select distinct b.*, b.title, b.id",
+        "select b.*",
         " from books as b",
         " inner join authors as a on b.author_id = a.id",
-        ' left outer join author_schedules as "as" on a.id = "as".author_id',
         " where b.deleted_at IS NULL",
         " AND a.deleted_at IS NULL",
         " AND a.first_name = ?",
-        ' AND "as".id = ?',
+        ' AND EXISTS (select 1 from author_schedules as "as" where a.id = "as".author_id AND "as".id = ?)',
         " order by b.title ASC, b.id ASC",
       ].join(""),
     );


### PR DESCRIPTION
## Summary

- Rewrite collection `WHERE` clauses to use `EXISTS` / `NOT EXISTS` where possible, avoiding row explosion from joining across multiple collection relations.
- We keep collection filters as "logical" JOINs through parsing and plugin hooks, then optimize them after `beforeFind`-based plugins inspect/mutate the query AST.
- Adds an explicit `allowMultipleLeftJoins` opt-in for collection queries that cannot be safely rewritten and would otherwise issue multiple fanout `LEFT JOIN`s.

## Details

- Adds collection metadata to parsed join tables so Joist can identify collection-root subtrees after parsing.
- Adds `optimizeCollectionJoins`, which:
  - rewrites locally-scoped collection conditions into correlated `EXISTS` subqueries
  - rewrites pure collection `id IS NULL` filters into `NOT EXISTS`
  - preserves same-row semantics within a single collection subtree
  - leaves mixed-scope `OR` conditions as `LEFT JOIN`s when aliases must remain in the same SQL scope
  - detects unsafe remaining collection fanout `LEFT JOIN`s and requires `allowMultipleLeftJoins`
- Runs collection optimization after `beforeFind` plugins and before SQL execution, so plugins see stable JOIN-based ASTs instead of pre-optimized EXISTS shapes.
- Updates pruning/visitor support for `EXISTS` subqueries, CTE-backed joins, and join dependencies through either side of a join predicate.
- Documents collection filter behavior and the `allowMultipleLeftJoins` escape hatch.

## Why

- Multiple collection `LEFT JOIN`s can multiply result rows and create very large intermediate row sets.
- Most collection filters are semantically independent and can be expressed more efficiently as separate correlated `EXISTS` predicates.
- Keeping the parsed AST logical until after plugins avoids making plugin authors handle two different shapes for the same user query.

## Verification

- `yarn build`
- `yarn jest -- EntityManager.queries.test.ts`
- `yarn jest -- EntityManager.lateralJoins.test.ts`
- `yarn jest -- EntityManager.lens.test.ts`
- focused recursive CTE coverage in `relations/RecursiveCollection.test.ts`


## Benchmarks

Dataset: 1,000 authors × 50 books each × 50 comments each, 20 tags with 5 per author.
Timing (median, 10 iterations after 3 warmup)
| Scenario | JOIN+DISTINCT | LATERAL+BOOL_OR | EXISTS | EXISTS vs JOIN | EXISTS vs LATERAL |
|---|---|---|---|---|---|
| o2m × o2m (broad) | 33.1ms | 22.7ms | 3.0ms | 10.9× faster | 7.5× faster |
| o2m × o2m (selective) | 4.3ms | 32.5ms | 3.0ms | 1.4× faster | 10.8× faster |
| m2m + o2m | 34.3ms | 51.9ms | 17.3ms | 2.0× faster | 3.0× faster |
EXPLAIN ANALYZE (total rows processed by planner)
| Scenario | JOIN+DISTINCT | LATERAL+BOOL_OR | EXISTS |
|---|---|---|---|
| Broad match | 304,624 rows | 279,336 rows | 7,160 rows (42× fewer than JOIN) |
| Selective match | 7,651 rows | 301,303 rows | 56 rows (137× fewer than JOIN) |
| Match-all | 2,709,000 rows | 704,000 rows | 5,000 rows (542× fewer than JOIN) |
Key takeaways
- EXISTS consistently wins across all scenarios, from 1.4× to 10.9× faster than JOIN+DISTINCT in wall-clock time
- The biggest wins are in broad match scenarios where JOIN creates massive cross-products (50 books × 50 comments = 2,500 rows per author)
- EXISTS processes dramatically fewer rows — up to 542× fewer than JOIN+DISTINCT in the match-all case — because it short-circuits after finding the first matching row rather than materializing the full cross-product
- LATERAL+BOOL_OR performs especially poorly on selective queries because it must still scan all children for every parent, even when only 1 parent matches

---

Benchmarks 2nd run

<img width="1630" height="1288" alt="image" src="https://github.com/user-attachments/assets/26ecfe0e-b2a9-4d45-8a4a-6374c3d38a1e" />



Fixes #1338 