### PR TITLE
fix: Restore regular tagged id behavior in factories

### DIFF
--- a/docs/src/content/docs/testing/test-factories.md
+++ b/docs/src/content/docs/testing/test-factories.md
@@ -430,7 +430,7 @@ This works by:
 
 2. When a reference like `prequel: "b#1"` is encountered, Joist looks up the entity by its factory id in `em.entities`, resolving it to the already-created book.
 
-The `#` ids (like `b#1`, `a#2`) are the stable factory ids assigned when `em.create` is called — they match the `Author#1`, `Book#2` ids you see in `entity.toString()` output and factory logging. They are separate from the database-assigned `:` ids (like `b:1`) that only exist after `em.flush()`.
+The `#` ids (like `b#1`, `a#2`) are the stable factory ids assigned when `em.create` is called — they match the `Author#1`, `Book#2` ids you see in `entity.toString()` output and factory logging. They are separate from the database-assigned `:` ids (like `b:1`) that only exist after `em.flush()`. If you try to use a `:` id to refer to an unsaved factory-created entity, Joist throws and tells you to use the `#` test id instead.
 
 :::tip[Tip]
 
@@ -495,5 +495,4 @@ export function newPublisherType(
 ```
 
 The benefit of using `useExisting` is that the `existing` param will already be typed to your given entity type (i.e. `PublisherType`), and the `opts` param will be the "post-resolution" opts, i.e. instead of "maybe object literals or maybe object instances", they will be object instances (basically `OptsOf<PublisherType>`), which simplifies the lambda's matching logic.
-
 

--- a/packages/core/src/newTestInstance.ts
+++ b/packages/core/src/newTestInstance.ts
@@ -55,7 +55,7 @@ export const factories: Record<string, any> = new Proxy(Object.create(null), {
     const [, tag, id] = match;
     if (!lastFactoryEm) throw new Error("No EntityManager available; call a factory like newAuthor(em) first");
     const testId = `${tag}#${id}`;
-    const entity = lastFactoryEm.entities.find((e) => getTestId(lastFactoryEm!, e) === testId);
+    const entity = findFactoryEntity(lastFactoryEm, testId);
     if (!entity) throw new Error(`No factory entity found for '${testId}'`);
     return entity;
   },
@@ -357,7 +357,7 @@ function resolveFactoryOpt<T extends Entity>(
     return opt as T;
   } else if (isId(opt)) {
     // Try finding the entity in the UoW, otherwise fallback on just setting it as the id (which we support that now)
-    const found = (em.entities.find((e) => e.idTaggedMaybe === opt || getTestId(em, e) === opt) as T) || opt;
+    const found = findFactoryEntity<T>(em, opt) || opt;
     logger?.logFoundOpt(fieldWithIndex, found);
     return found;
   } else if (opt && !isPlainObject(opt) && !(opt instanceof MaybeNew)) {
@@ -664,6 +664,11 @@ function getTestId<T extends Entity>(em: EntityManager, entity: T): string | und
   const meta = getMetadata(entity);
   const createId = getInstanceData(entity).createId;
   return createId ? `${meta.tagName}#${createId}` : undefined;
+}
+
+function findFactoryEntity<T extends Entity>(em: EntityManager, id: string): T | undefined {
+  // We support both testId/createId like `a#1` (preferred) and also `a:1` tagged ids
+  return em.entities.find((e) => e.idTaggedMaybe === id || getTestId(em, e) === id) as T | undefined;
 }
 
 // We keep a local copy of `global.Date`, in case a faking library

--- a/packages/tests/integration/src/EntityManager.factories.test.ts
+++ b/packages/tests/integration/src/EntityManager.factories.test.ts
@@ -40,6 +40,7 @@ import {
   setFactoryWriter,
   testIndex,
 } from "joist-orm";
+import { insertAuthor, select } from "src/entities/inserts";
 
 let factoryOutput: string[] = [];
 
@@ -63,7 +64,7 @@ describe("EntityManager.factories", () => {
     expect(b1.author.get.firstName).toEqual("a1");
     expect(factoryOutput).toMatchInlineSnapshot(`
      [
-       "Creating new Book at EntityManager.factories.test.ts:60↩",
+       "Creating new Book at EntityManager.factories.test.ts:61↩",
        "  author = creating new Author↩",
        "    created Author#1 added to scope↩",
        "  created Book#1 added to scope↩",
@@ -158,7 +159,7 @@ describe("EntityManager.factories", () => {
     expect(b1.author.get).not.toMatchEntity(a2);
     expect(factoryOutput).toMatchInlineSnapshot(`
      [
-       "Creating new Tag at EntityManager.factories.test.ts:151↩",
+       "Creating new Tag at EntityManager.factories.test.ts:152↩",
        "  created Tag#1 added to scope↩",
        "  books[0] = creating new Book↩",
        "    author = creating new Author↩",
@@ -184,7 +185,7 @@ describe("EntityManager.factories", () => {
     expect(b1.author.get).toEqual(a1);
     expect(factoryOutput).toMatchInlineSnapshot(`
      [
-       "Creating new Book at EntityManager.factories.test.ts:181↩",
+       "Creating new Book at EntityManager.factories.test.ts:182↩",
        "  ...adding Author#1 opt to scope↩",
        "  author = Author#1 from scope↩",
        "  created Book#1 added to scope↩",
@@ -416,6 +417,15 @@ describe("EntityManager.factories", () => {
     const a1 = newAuthor(em);
     const b1 = newBook(em, { author: "a#1" });
     expect(b1.author.get).toEqual(a1);
+  });
+
+  it("accepts tagged ids for unsaved m2o shortcuts", async () => {
+    await insertAuthor({ first_name: "a1" });
+    const em = newEntityManager();
+    newBook(em, { author: "a:1" });
+    await em.flush();
+    const rows = await select("books");
+    expect(rows[0].author_id).toEqual(1);
   });
 
   it("can use tagged ids as shortcuts in list", async () => {
@@ -953,7 +963,7 @@ describe("EntityManager.factories", () => {
       await em.flush();
       expect(factoryOutput).toMatchInlineSnapshot(`
        [
-         "Creating new ChildGroup at EntityManager.factories.test.ts:944↩",
+         "Creating new ChildGroup at EntityManager.factories.test.ts:954↩",
          "  childGroup = creating new Child↩",
          "    created Child#1 added to scope↩",
          "  parentGroup = creating new ParentGroup↩",


### PR DESCRIPTION
With the new `is` support, factory ids should always use the `a#1` create id and not the old `a:1` format.