### PR TITLE
fix: order m2m preload results by join-row id

### DIFF
--- a/packages/core/src/preloading/JsonAggregatePreloader.ts
+++ b/packages/core/src/preloading/JsonAggregatePreloader.ts
@@ -141,6 +141,7 @@ function calcLateralJoins<I extends EntityOrId>(
 
       const cb = new ConditionBuilder();
       let m2mTable: JoinTable | undefined;
+      let m2mAlias: string | undefined;
       if (otherField.kind === "m2o") {
         cb.addRawCondition({
           aliases: [otherAlias, parentAlias],
@@ -171,7 +172,7 @@ function calcLateralJoins<I extends EntityOrId>(
           pruneable: true,
         });
       } else if (otherField.kind === "m2m") {
-        const m2mAlias = assigner.getAlias(otherField.joinTableName);
+        m2mAlias = assigner.getAlias(otherField.joinTableName);
         // Get the m2m row's id to track in JoinRows
         selects.unshift(kqDot(m2mAlias, "id"));
         m2mTable = {
@@ -212,7 +213,12 @@ function calcLateralJoins<I extends EntityOrId>(
         fromAlias: "unset",
         table: otherMeta.tableName,
         query: {
-          selects: [`json_agg(json_build_array(${selects.join(", ")}) order by ${kq(otherAlias)}.id) as _`],
+          // For m2m, order by the join-row's id so preloaded results match the
+          // order the lazy batch loader returns (which orders by join-row id).
+          // Otherwise, order by the target entity's id.
+          selects: [
+            `json_agg(json_build_array(${selects.join(", ")}) order by ${kq(m2mAlias ?? otherAlias)}.id) as _`,
+          ],
           tables: [
             { join: "primary", table: otherMeta.tableName, alias: otherAlias },
             ...(m2mTable ? [m2mTable] : []),

--- a/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
@@ -930,4 +930,35 @@ describe("ManyToManyCollection", () => {
     );
     expect(tags).toMatchEntity([{ name: "t1" }, { name: "t2" }, { name: "t3" }]);
   });
+
+  it("returns m2m items in the same order whether loaded lazily or via a populate hint", async () => {
+    // Given a book and three tags, with the join rows inserted in a different
+    // order than the tag ids — so "ORDER BY join-row.id" vs "ORDER BY tag.id"
+    // would produce visibly different orderings.
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ id: 1, title: "b1", author_id: 1 });
+    await insertTag({ id: 1, name: "t1" });
+    await insertTag({ id: 2, name: "t2" });
+    await insertTag({ id: 3, name: "t3" });
+    // Insert m2m rows in reverse tag order: btt:1 -> t3, btt:2 -> t1, btt:3 -> t2
+    await insertBookToTag({ id: 1, book_id: 1, tag_id: 3 });
+    await insertBookToTag({ id: 2, book_id: 1, tag_id: 1 });
+    await insertBookToTag({ id: 3, book_id: 1, tag_id: 2 });
+
+    // When we load the tags via the lazy (batch-loader) path
+    const em1 = newEntityManager();
+    const book1 = await em1.load(Book, "b:1");
+    const lazyTags = await book1.tags.load();
+
+    // And separately via the populate-hint (JSON-aggregate preloader) path
+    const em2 = newEntityManager();
+    const book2 = await em2.load(Book, "b:1", "tags");
+    const populatedTags = book2.tags.get;
+
+    // Then both paths agree on the ordering — join-row id order
+    const lazyNames = lazyTags.map((t) => t.name);
+    const populatedNames = populatedTags.map((t) => t.name);
+    expect(lazyNames).toEqual(["t3", "t1", "t2"]);
+    expect(populatedNames).toEqual(["t3", "t1", "t2"]);
+  });
 });


### PR DESCRIPTION
## Problem                                                                              
   
m2m collections return items in different orders depending on the load path:            
                             
- **Lazy** (`collection.load()`) orders by **join-row id**                              
- **Preload** (`em.load(…, hint)` via `JsonAggregatePreloader`) orders by **target-entity id**                                                                    
   
Same data, same relation — different order. A load hint added upstream can silently reorder a collection downstream.
                                                                                          
## Fix

In `JsonAggregatePreloader`, use the join-table alias for `ORDER BY` on m2m fields so it matches the lazy path.