### PR TITLE
fix: Reactive hint subtype matching

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,7 @@ export { JoinResult, PreloadHydrator, PreloadPlugin } from "./plugins/PreloadPlu
 export { JsonAggregatePreloader } from "./preloading/JsonAggregatePreloader";
 export {
   convertToLoadHint,
+  isTypeOrSubType,
   Reactable,
   Reacted,
   ReactiveHint,

--- a/packages/core/src/reactiveHints.ts
+++ b/packages/core/src/reactiveHints.ts
@@ -4,7 +4,6 @@ import {
   EntityMetadata,
   getBaseAndSelfMetas,
   getMetadata,
-  getSubMetas,
   ManyToManyField,
   ManyToOneField,
   OneToManyField,
@@ -12,7 +11,6 @@ import {
   PolymorphicFieldComponent,
 } from "./EntityMetadata";
 import { Changes, FieldStatus, ManyToOneFieldStatus } from "./changes";
-import { getMetadataForType } from "./configure";
 import { isChangeableField } from "./fields";
 import { getProperties } from "./getProperties";
 import { Loadable, Loaded, LoadHint } from "./loadHints";
@@ -627,16 +625,11 @@ function maybeApplyTypeFilter(loadPromise: Promise<Entity | Entity[]>, viaType: 
 }
 
 /** Handle `viaType` filtering with subtype awareness. */
-function isTypeOrSubType(entity: Entity, typeName: string): boolean {
+export function isTypeOrSubType(entity: Entity, typeName: string): boolean {
   const meta = getMetadata(entity);
-  // Easy check for the name is the same
-  if (meta.type === typeName) return true;
   // Otherwise see if the entity is a subtype of the typeName, i.e. if our poly/type
-  // filter is `@Publisher`, and we're a `SmallPublisher`, that's valid to traverse.
-  for (const other of getSubMetas(getMetadataForType(typeName))) {
-    if (other.type === typeName) return true;
-  }
-  return false;
+  // filter is `@Publisher`, and we're a `SmallPublisher`, walk up our base types.
+  return meta.type == typeName || meta.baseTypes.some((b) => b.type === typeName);
 }
 
 export function isPolyHint(key: string): boolean {

--- a/packages/core/src/reactiveHints.ts
+++ b/packages/core/src/reactiveHints.ts
@@ -624,12 +624,15 @@ function maybeApplyTypeFilter(loadPromise: Promise<Entity | Entity[]>, viaType: 
   return loadPromise;
 }
 
-/** Handle `viaType` filtering with subtype awareness. */
+/** Returns true if `entity` is exactly `typeName` or a subtype of `typeName`.
+ *
+ * Used to honor poly/type filters like `@Publisher` during reverse-hint walks:
+ * a `SmallPublisher` entity should pass an `@Publisher` filter because it is
+ * a Publisher via inheritance.
+ */
 export function isTypeOrSubType(entity: Entity, typeName: string): boolean {
   const meta = getMetadata(entity);
-  // Otherwise see if the entity is a subtype of the typeName, i.e. if our poly/type
-  // filter is `@Publisher`, and we're a `SmallPublisher`, walk up our base types.
-  return meta.type == typeName || meta.baseTypes.some((b) => b.type === typeName);
+  return meta.type === typeName || meta.baseTypes.some((b) => b.type === typeName);
 }
 
 export function isPolyHint(key: string): boolean {

--- a/packages/tests/integration/src/reactiveHints.test.ts
+++ b/packages/tests/integration/src/reactiveHints.test.ts
@@ -1,4 +1,17 @@
-import { Author, Book, BookReview, Comment, Critic, Publisher, PublisherGroup, User } from "@src/entities";
+import {
+  Author,
+  Book,
+  BookReview,
+  Comment,
+  Critic,
+  newAuthor,
+  newLargePublisher,
+  newSmallPublisher,
+  Publisher,
+  PublisherGroup,
+  User,
+} from "@src/entities";
+import { newEntityManager } from "@src/testEm";
 import {
   Entity,
   LoadHint,
@@ -9,6 +22,7 @@ import {
   ReactiveTarget,
   convertToLoadHint,
   getMetadata,
+  isTypeOrSubType,
   reverseReactiveHint,
 } from "joist-orm";
 
@@ -430,6 +444,34 @@ describe("reactiveHints", () => {
       // @ts-expect-error
       calcAuthor(a1);
     }
+  });
+
+  describe("isTypeOrSubType", () => {
+    it("matches same concrete type", () => {
+      const em = newEntityManager();
+      const sp = newSmallPublisher(em);
+      expect(isTypeOrSubType(sp, "SmallPublisher")).toBe(true);
+    });
+
+    it("matches a subtype against its base type", () => {
+      const em = newEntityManager();
+      const sp = newSmallPublisher(em);
+      const lp = newLargePublisher(em);
+      expect(isTypeOrSubType(sp, "Publisher")).toBe(true);
+      expect(isTypeOrSubType(lp, "Publisher")).toBe(true);
+    });
+
+    it("does not match a sibling subtype", () => {
+      const em = newEntityManager();
+      const sp = newSmallPublisher(em);
+      expect(isTypeOrSubType(sp, "LargePublisher")).toBe(false);
+    });
+
+    it("does not match an unrelated type", () => {
+      const em = newEntityManager();
+      const a = newAuthor(em);
+      expect(isTypeOrSubType(a, "Publisher")).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
### Summary
- Fix `isTypeOrSubType` to walk an entity's base types when checking subtype compatibility.
- Export the helper and add coverage for concrete, base-type, sibling, and unrelated type cases.

### Test Plan
- `yarn jest src/reactiveHints.test.ts`