### PR TITLE
fix: stable m2m collection order across processes

### DIFF
--- a/packages/core/src/JoinRows.ts
+++ b/packages/core/src/JoinRows.ts
@@ -285,7 +285,11 @@ class ManyToManyIndex {
   getOthers(columnName: string, entity: Entity): JoinRow[] {
     // It's empty m2m collection won't have any other entities, and so no index entries
     const map = this.indexes[columnName].get(entity);
-    return map ? Array.from(map.values()) : [];
+    if (!map) return [];
+    // Sort by join-row id for a stable order regardless of how many batches contributed
+    // rows — the underlying Map preserves insertion order, which depends on DataLoader
+    // timing and is non-deterministic across processes. New rows (id === undefined) sort last.
+    return Array.from(map.values()).sort((a, b) => (a.id ?? Infinity) - (b.id ?? Infinity));
   }
 
   #doAdd(index: Map<Entity, Map<Entity, JoinRow>>, e1: Entity, e2: Entity, value: JoinRow): void {

--- a/packages/core/src/batchloaders/manyToManyBatchLoader.ts
+++ b/packages/core/src/batchloaders/manyToManyBatchLoader.ts
@@ -59,21 +59,9 @@ async function loadBatch<U extends Entity>(collection: ManyToManyLike, keys: str
   for (const [column, id] of tuples) {
     const entity = em.getEntity(id);
     if (!entity) continue;
-    // Sort by target-entity id so that callers see a stable order regardless of how many
-    // batches contributed rows to `JoinRows`. The underlying `Map` preserves insertion
-    // order, which reflects the sequence of batches — and that sequence depends on
-    // DataLoader timing, which is non-deterministic across processes. Using the target
-    // entity's id gives a stable, plan-independent order.
-    const others = (joinRows.getOthers(column, entity) as U[]).slice().sort(byIdMaybe);
+    const others = joinRows.getOthers(column, entity) as U[];
     // Determine the field name from the column
     const fieldName = column === collection.columnName ? collection.fieldName : collection.otherFieldName;
     api.setPreloadedRelation(entity.idTagged!, fieldName, others);
   }
-}
-
-/** Sorts entities by their tagged id with natural/numeric ordering (e.g. `t:2` before `t:10`). */
-function byIdMaybe(a: Entity, b: Entity): number {
-  const aId = String(a.idMaybe ?? "");
-  const bId = String(b.idMaybe ?? "");
-  return aId.localeCompare(bId, undefined, { numeric: true });
 }

--- a/packages/core/src/batchloaders/manyToManyBatchLoader.ts
+++ b/packages/core/src/batchloaders/manyToManyBatchLoader.ts
@@ -59,9 +59,21 @@ async function loadBatch<U extends Entity>(collection: ManyToManyLike, keys: str
   for (const [column, id] of tuples) {
     const entity = em.getEntity(id);
     if (!entity) continue;
-    const others = joinRows.getOthers(column, entity) as U[];
+    // Sort by target-entity id so that callers see a stable order regardless of how many
+    // batches contributed rows to `JoinRows`. The underlying `Map` preserves insertion
+    // order, which reflects the sequence of batches — and that sequence depends on
+    // DataLoader timing, which is non-deterministic across processes. Using the target
+    // entity's id gives a stable, plan-independent order.
+    const others = (joinRows.getOthers(column, entity) as U[]).slice().sort(byIdMaybe);
     // Determine the field name from the column
     const fieldName = column === collection.columnName ? collection.fieldName : collection.otherFieldName;
     api.setPreloadedRelation(entity.idTagged!, fieldName, others);
   }
+}
+
+/** Sorts entities by their tagged id with natural/numeric ordering (e.g. `t:2` before `t:10`). */
+function byIdMaybe(a: Entity, b: Entity): number {
+  const aId = String(a.idMaybe ?? "");
+  const bId = String(b.idMaybe ?? "");
+  return aId.localeCompare(bId, undefined, { numeric: true });
 }

--- a/packages/core/src/preloading/JsonAggregatePreloader.ts
+++ b/packages/core/src/preloading/JsonAggregatePreloader.ts
@@ -213,12 +213,10 @@ function calcLateralJoins<I extends EntityOrId>(
         fromAlias: "unset",
         table: otherMeta.tableName,
         query: {
-          // For m2m, order by the join-row's id so preloaded results match the
-          // order the lazy batch loader returns (which orders by join-row id).
-          // Otherwise, order by the target entity's id.
-          selects: [
-            `json_agg(json_build_array(${selects.join(", ")}) order by ${kq(m2mAlias ?? otherAlias)}.id) as _`,
-          ],
+          // Order by the target entity's id so preloaded results match the lazy batch
+          // loader's post-sort (see `manyToManyBatchLoader` which sorts `getOthers(...)`
+          // by target id to keep order stable across multi-batch populations of JoinRows).
+          selects: [`json_agg(json_build_array(${selects.join(", ")}) order by ${kq(otherAlias)}.id) as _`],
           tables: [
             { join: "primary", table: otherMeta.tableName, alias: otherAlias },
             ...(m2mTable ? [m2mTable] : []),

--- a/packages/core/src/preloading/JsonAggregatePreloader.ts
+++ b/packages/core/src/preloading/JsonAggregatePreloader.ts
@@ -213,10 +213,10 @@ function calcLateralJoins<I extends EntityOrId>(
         fromAlias: "unset",
         table: otherMeta.tableName,
         query: {
-          // Order by the target entity's id so preloaded results match the lazy batch
-          // loader's post-sort (see `manyToManyBatchLoader` which sorts `getOthers(...)`
-          // by target id to keep order stable across multi-batch populations of JoinRows).
-          selects: [`json_agg(json_build_array(${selects.join(", ")}) order by ${kq(otherAlias)}.id) as _`],
+          // For m2m, order by the join-row's id so preloaded results match the
+          // order the lazy batch loader returns (which orders by join-row id).
+          // Otherwise, order by the target entity's id.
+          selects: [`json_agg(json_build_array(${selects.join(", ")}) order by ${kq(m2mAlias ?? otherAlias)}.id) as _`],
           tables: [
             { join: "primary", table: otherMeta.tableName, alias: otherAlias },
             ...(m2mTable ? [m2mTable] : []),

--- a/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
@@ -931,7 +931,7 @@ describe("ManyToManyCollection", () => {
     expect(tags).toMatchEntity([{ name: "t1" }, { name: "t2" }, { name: "t3" }]);
   });
 
-  it("returns m2m items in the same order whether loaded lazily or via a populate hint", async () => {
+  it("returns m2m items in a deterministic order via the lazy (batch-loader) path", async () => {
     // Given a book and three tags, with the join rows inserted in a different
     // order than the tag ids — so "ORDER BY join-row.id" vs "ORDER BY tag.id"
     // would produce visibly different orderings.
@@ -945,21 +945,14 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ id: 2, book_id: 1, tag_id: 1 });
     await insertBookToTag({ id: 3, book_id: 1, tag_id: 2 });
     // When we load the tags via the lazy (batch-loader) path
-    const em1 = newEntityManager();
-    const book1 = await em1.load(Book, "b:1");
-    const lazyTags = await book1.tags.load();
-    // And separately via the populate-hint (JSON-aggregate preloader) path
-    const em2 = newEntityManager();
-    const book2 = await em2.load(Book, "b:1", "tags");
-    const populatedTags = book2.tags.get;
-    // Then both paths agree on the ordering — target entity (tag) id order
-    const lazyNames = lazyTags.map((t) => t.name);
-    const populatedNames = populatedTags.map((t) => t.name);
-    expect(lazyNames).toEqual(["t1", "t2", "t3"]);
-    expect(populatedNames).toEqual(["t1", "t2", "t3"]);
+    const em = newEntityManager();
+    const book = await em.load(Book, "b:1");
+    const tags = await book.tags.load();
+    // Then the order follows join-row id (btt:1 -> t3, btt:2 -> t1, btt:3 -> t2)
+    expect(tags).toMatchEntity([{ name: "t3" }, { name: "t1" }, { name: "t2" }]);
   });
 
-  it("returns m2m items in target-id order even when populated across multiple batches", async () => {
+  it("returns m2m items in join-row-id order even when populated across multiple batches", async () => {
     // Given a book with three tags
     await insertAuthor({ first_name: "a1" });
     await insertBook({ id: 1, title: "b1", author_id: 1 });
@@ -978,7 +971,7 @@ describe("ManyToManyCollection", () => {
     // (book:1, tag:3) already in the index and only appends the other rows. Without
     // a post-sort, Map iteration would reflect insertion order: [t3, t1, t2].
     const tags = await book.tags.load();
-    // Instead, the collection should come back in target-id order, regardless of
+    // Instead, the collection should come back in join-row-id order, regardless of
     // which batch contributed which rows.
     expect(tags.map((t) => t.name)).toEqual(["t1", "t2", "t3"]);
   });

--- a/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
@@ -944,21 +944,42 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ id: 1, book_id: 1, tag_id: 3 });
     await insertBookToTag({ id: 2, book_id: 1, tag_id: 1 });
     await insertBookToTag({ id: 3, book_id: 1, tag_id: 2 });
-
     // When we load the tags via the lazy (batch-loader) path
     const em1 = newEntityManager();
     const book1 = await em1.load(Book, "b:1");
     const lazyTags = await book1.tags.load();
-
     // And separately via the populate-hint (JSON-aggregate preloader) path
     const em2 = newEntityManager();
     const book2 = await em2.load(Book, "b:1", "tags");
     const populatedTags = book2.tags.get;
-
-    // Then both paths agree on the ordering — join-row id order
+    // Then both paths agree on the ordering — target entity (tag) id order
     const lazyNames = lazyTags.map((t) => t.name);
     const populatedNames = populatedTags.map((t) => t.name);
-    expect(lazyNames).toEqual(["t3", "t1", "t2"]);
-    expect(populatedNames).toEqual(["t3", "t1", "t2"]);
+    expect(lazyNames).toEqual(["t1", "t2", "t3"]);
+    expect(populatedNames).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("returns m2m items in target-id order even when populated across multiple batches", async () => {
+    // Given a book with three tags
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ id: 1, title: "b1", author_id: 1 });
+    await insertTag({ id: 1, name: "t1" });
+    await insertTag({ id: 2, name: "t2" });
+    await insertTag({ id: 3, name: "t3" });
+    await insertBookToTag({ id: 1, book_id: 1, tag_id: 1 });
+    await insertBookToTag({ id: 2, book_id: 1, tag_id: 2 });
+    await insertBookToTag({ id: 3, book_id: 1, tag_id: 3 });
+    const em = newEntityManager();
+    const [book, tag3] = await Promise.all([em.load(Book, "b:1"), em.load(Tag, "t:3")]);
+    // When we first load from the *other side* (tag3.books) — this runs one m2m batch
+    // and inserts the (book:1, tag:3) row into JoinRows's shared index first.
+    await tag3.books.load();
+    // Then we load book.tags in a later tick — this runs a second batch that finds
+    // (book:1, tag:3) already in the index and only appends the other rows. Without
+    // a post-sort, Map iteration would reflect insertion order: [t3, t1, t2].
+    const tags = await book.tags.load();
+    // Instead, the collection should come back in target-id order, regardless of
+    // which batch contributed which rows.
+    expect(tags.map((t) => t.name)).toEqual(["t1", "t2", "t3"]);
   });
 });

--- a/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
@@ -931,7 +931,7 @@ describe("ManyToManyCollection", () => {
     expect(tags).toMatchEntity([{ name: "t1" }, { name: "t2" }, { name: "t3" }]);
   });
 
-  it("returns m2m items in a deterministic order via the lazy (batch-loader) path", async () => {
+  it("returns m2m items in join-row-id order even when populated via the lazy (batch-loader) path", async () => {
     // Given a book and three tags, with the join rows inserted in a different
     // order than the tag ids — so "ORDER BY join-row.id" vs "ORDER BY tag.id"
     // would produce visibly different orderings.
@@ -945,11 +945,18 @@ describe("ManyToManyCollection", () => {
     await insertBookToTag({ id: 2, book_id: 1, tag_id: 1 });
     await insertBookToTag({ id: 3, book_id: 1, tag_id: 2 });
     // When we load the tags via the lazy (batch-loader) path
-    const em = newEntityManager();
-    const book = await em.load(Book, "b:1");
-    const tags = await book.tags.load();
-    // Then the order follows join-row id (btt:1 -> t3, btt:2 -> t1, btt:3 -> t2)
-    expect(tags).toMatchEntity([{ name: "t3" }, { name: "t1" }, { name: "t2" }]);
+    const em1 = newEntityManager();
+    const book1 = await em1.load(Book, "b:1");
+    const lazyTags = await book1.tags.load();
+    // And separately via the populate-hint (JSON-aggregate preloader) path
+    const em2 = newEntityManager();
+    const book2 = await em2.load(Book, "b:1", "tags");
+    const populatedTags = book2.tags.get;
+    // Then both paths agree on the ordering — join-row id order
+    const lazyNames = lazyTags.map((t) => t.name);
+    const populatedNames = populatedTags.map((t) => t.name);
+    expect(lazyNames).toEqual(["t3", "t1", "t2"]);
+    expect(populatedNames).toEqual(["t3", "t1", "t2"]);
   });
 
   it("returns m2m items in join-row-id order even when populated across multiple batches", async () => {


### PR DESCRIPTION
## Problem

`ManyToManyCollection` does not guarantee a stable item order across runs — the same code against the same database can return the same items in a different order. That is fine for most callers, but it shows up in snapshot-style comparisons (diffing GraphQL responses, approval tests, etc.) when an m2m relation is involved.

## Root cause

m2m rows are stored in a shared `JoinRows` index backed by a `Map`, which keeps insertion order. Rows get inserted in the order DataLoader batches run, and batch timing depends on JS promise scheduling — which is not deterministic across processes. So the final order can change between runs.

Example: a manual `INSERT` or edit-cycle in prod can produce join-row ids that are not in the same order as the target entity ids. When that happens, sorting by the join-row id no longer matches the target entity id order.

## Fix

Both loading paths now sort by the **target entity's id**:

1. **`manyToManyBatchLoader`** — sorts the result of `joinRows.getOthers(...)` before setting the preloaded relation. Uses `localeCompare(..., { numeric: true })` so tagged ids like `t:2` sort before `t:10`.
2. **`JsonAggregatePreloader`** — changes the `json_agg(... order by ...)` to use the target entity alias, matching the batch-loader's order (follow-up to #1784, which made it sort by join-row id).