### PR TITLE
feat: Rename AsyncProperty to Property for simpler naming

### DIFF
--- a/docs/src/content/docs/modeling/derived-properties.md
+++ b/docs/src/content/docs/modeling/derived-properties.md
@@ -28,11 +28,11 @@ class Author {
 
 Asynchronous Properties calculate their value from the entity and other related child/parent entities.
 
-For example, to implement an `Author`'s `numberOfBooks` property that requires counting the Author's `books` collection, use `hasAsyncProperty` with a populate hint stating it depends on the `books` collection:
+For example, to implement an `Author`'s `numberOfBooks` property that requires counting the Author's `books` collection, use `hasProperty` with a populate hint stating it depends on the `books` collection:
 
 ```typescript
 export class Author {
-  readonly numberOfBooks: AsyncProperty<Author, number> = hasAsyncProperty(
+  readonly numberOfBooks: Property<Author, number> = hasProperty(
     // Declare the relations to load
     "books",
     // Only `a.books` will be marked as loaded
@@ -55,11 +55,11 @@ const a2 = await em.load(Author, "a:1", "numberOfBooks");
 const num2 = a2.numberOfBooks.get;
 ```
 
-Like populate hints, `hasAsyncProperty`s can used nested hints:
+Like populate hints, `hasProperty`s can used nested hints:
 
 ```typescript
 export class Author {
-  readonly latestComments: AsyncProperty<Author, Comment[]> = hasAsyncProperty(
+  readonly latestComments: Property<Author, Comment[]> = hasProperty(
     // Pass a nested load hint
     { publisher: "comments", comments: {} },
     // `a` will have the deep relations loaded
@@ -99,12 +99,12 @@ console.log(a.fullName.get);
 
 ## Reactive Async Properties
 
-Similar to Reactive Getters, if you have a [Reactive Field](./reactive-fields) that wants to depend on an Async Property, you need to declare the property's **field-level** dependencies by using `hasReactiveAsyncProperty`:
+Similar to Reactive Getters, if you have a [Reactive Field](./reactive-fields) that wants to depend on an Async Property, you need to declare the property's **field-level** dependencies by using `hasReactiveProperty`:
 
 ```typescript
 export class Author {
-  readonly numberOfBooks: AsyncProperty<Author, number> =
-   hasReactiveAsyncProperty(
+  readonly numberOfBooks: Property<Author, number> =
+   hasReactiveProperty(
      // Now this is a field-level reactive hint
      { books: "title" },
      // `a` can only access fields declared by the hint
@@ -113,5 +113,5 @@ export class Author {
 }
 ```
 
-This is similar to regular `hasAsyncProperty`s, except that the hint declares the specific fields that the lambda uses, and the lambda will be restricted from using any field not declared in the hint. 
+This is similar to regular `hasProperty`s, except that the hint declares the specific fields that the lambda uses, and the lambda will be restricted from using any field not declared in the hint. 
 

--- a/docs/src/content/docs/modeling/relations.md
+++ b/docs/src/content/docs/modeling/relations.md
@@ -321,7 +321,7 @@ class BookReview extends PublisherCodegen {
 
 `hasAsyncQueryProperty` creates a derived value calculated from a SQL query, rather than from in-memory graph data. This is useful when pulling all the related data into memory would be too expensive, and you'd rather let the database do the work.
 
-Unlike `hasAsyncProperty`, there is no load hint or reactive hint — the lambda receives the entity directly and is expected to perform its own queries:
+Unlike `hasProperty`, there is no load hint or reactive hint — the lambda receives the entity directly and is expected to perform its own queries:
 
 ```typescript
 export class Publisher extends PublisherCodegen {
@@ -347,7 +347,7 @@ await em.flush();
 console.log(p.numberOfAuthors.isLoaded); // false
 ```
 
-It also works as a populate hint, just like `hasAsyncProperty`:
+It also works as a populate hint, just like `hasProperty`:
 
 ```typescript
 const p = await em.load(Publisher, "p:1", "numberOfAuthors");

--- a/docs/src/content/docs/modeling/why-entities.md
+++ b/docs/src/content/docs/modeling/why-entities.md
@@ -63,12 +63,12 @@ Although not a true  "end-to-end framework" like Rails, Joist grew out of a Grap
 
 ### Examples for Reads
 
-An example of Joist's "rich domain model" features is derived properties, which are calculations on top of your raw database values. For example a `hasManyThrough` or `hasAsyncProperty`:
+An example of Joist's "rich domain model" features is derived properties, which are calculations on top of your raw database values. For example a `hasManyThrough` or `hasProperty`:
 
 ```typescript
 class Author extends AuthorCodegen {
   readonly reviews: Collection<Author, BookReview> = hasMany((a) => a.books.reviews);
-  readonly totalRatings: AsyncProperty<Author, number> = hasAsyncProperty(
+  readonly totalRatings: Property<Author, number> = hasProperty(
     { books: "reviews" },
     (a) => a.reviews.get.reduce((acc, r) => acc + r.rating, 0)
   );

--- a/packages/codegen/src/codemods/__testfixtures__/v2_1_0_rename_has_async_property.input.ts
+++ b/packages/codegen/src/codemods/__testfixtures__/v2_1_0_rename_has_async_property.input.ts
@@ -1,0 +1,18 @@
+import {
+  AsyncProperty,
+  hasAsyncProperty,
+  hasReactiveAsyncProperty,
+  isAsyncProperty,
+  isLoadedAsyncProperty,
+} from "joist-core";
+
+class Author {
+  count: AsyncProperty<Author, number> = hasAsyncProperty({ books: "title" }, (a) => a.books.get.length);
+  reactive: AsyncProperty<Author, number> = hasReactiveAsyncProperty({ books: "title" }, (a) => a.books.get.length);
+}
+
+function check(maybe: any) {
+  if (isAsyncProperty(maybe) && isLoadedAsyncProperty(maybe)) {
+    return maybe.get;
+  }
+}

--- a/packages/codegen/src/codemods/__testfixtures__/v2_1_0_rename_has_async_property.output.ts
+++ b/packages/codegen/src/codemods/__testfixtures__/v2_1_0_rename_has_async_property.output.ts
@@ -1,0 +1,18 @@
+import {
+  Property,
+  hasProperty,
+  hasReactiveProperty,
+  isProperty,
+  isLoadedProperty,
+} from "joist-core";
+
+class Author {
+  count: Property<Author, number> = hasProperty({ books: "title" }, (a) => a.books.get.length);
+  reactive: Property<Author, number> = hasReactiveProperty({ books: "title" }, (a) => a.books.get.length);
+}
+
+function check(maybe: any) {
+  if (isProperty(maybe) && isLoadedProperty(maybe)) {
+    return maybe.get;
+  }
+}

--- a/packages/codegen/src/codemods/__tests__/v2_1_0_rename_has_async_property.test.ts
+++ b/packages/codegen/src/codemods/__tests__/v2_1_0_rename_has_async_property.test.ts
@@ -1,0 +1,7 @@
+import { defineTest } from "jscodeshift/src/testUtils";
+
+describe("v2_1_0_rename_has_async_property", () => {
+  defineTest(__dirname, "v2_1_0_rename_has_async_property", null, "v2_1_0_rename_has_async_property", {
+    parser: "ts",
+  });
+});

--- a/packages/codegen/src/codemods/index.ts
+++ b/packages/codegen/src/codemods/index.ts
@@ -7,6 +7,7 @@ import { v1_148_0_move_codegen_files } from "./v1_148_0_move_codegen_files";
 import { v1_151_0_rename_derived_reference } from "./v1_151_0_rename_derived_async_reference";
 import { v1_226_0_rename_current_txn_knex } from "./v1_226_0_rename_current_txn_knex";
 import { v1_245_0_upsert_rename } from "./v1_245_0_upsert_rename";
+import { v2_1_0_rename_has_async_property } from "./v2_1_0_rename_has_async_property";
 
 export async function maybeRunTransforms(config: Config): Promise<void> {
   const { confirm } = await import("@inquirer/prompts");
@@ -72,5 +73,6 @@ function findApplyableCodemods(prevVersion: string): Codemod[] {
     v1_151_0_rename_derived_reference,
     v1_226_0_rename_current_txn_knex,
     v1_245_0_upsert_rename,
+    v2_1_0_rename_has_async_property,
   ].filter((t) => semver.lt(prevVersion, t.version));
 }

--- a/packages/codegen/src/codemods/v2_1_0_rename_has_async_property.ts
+++ b/packages/codegen/src/codemods/v2_1_0_rename_has_async_property.ts
@@ -1,0 +1,32 @@
+import { Transform } from "jscodeshift";
+import { JscodeshiftMod } from "./JscodeshiftMod";
+
+export const v2_1_0_rename_has_async_property = new JscodeshiftMod(
+  "2.1.0",
+  "v2_1_0_rename_has_async_property",
+  "Rename `hasAsyncProperty` to `hasProperty`",
+  (config) => `${config.entitiesDirectory}/*.ts`,
+);
+
+const renames: Record<string, string> = {
+  hasAsyncProperty: "hasProperty",
+  hasReactiveAsyncProperty: "hasReactiveProperty",
+  AsyncProperty: "Property",
+  AsyncPropertyImpl: "PropertyImpl",
+  isAsyncProperty: "isProperty",
+  isLoadedAsyncProperty: "isLoadedProperty",
+};
+
+/** Find/replace the various `*AsyncProperty*` symbols with their `*Property*` counterparts. */
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  return j(file.source)
+    .find(j.Identifier)
+    .filter(({ node }) => node.name in renames)
+    .forEach((path) => {
+      j(path).replaceWith(j.identifier(renames[path.node.name]));
+    })
+    .toSource();
+};
+
+export default transform;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ import { New } from "./loadHints";
 import { isAllSqlPaths } from "./loadLens";
 import { FactoryInitialValue } from "./newTestInstance";
 import { partitionHint } from "./preloading/partitionHint";
-import { isAsyncProperty, isAsyncQueryProperty, isReactiveField, isReactiveGetter, isReactiveQueryField } from "./relations";
+import { isAsyncQueryProperty, isProperty, isReactiveField, isReactiveGetter, isReactiveQueryField } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
 import { ReactiveFieldImpl } from "./relations/ReactiveField";
 import { ReactiveQueryFieldImpl } from "./relations/ReactiveQueryField";
@@ -220,7 +220,7 @@ export function setOpt<T extends Entity>(
     } else {
       current.set(value);
     }
-  } else if (isAsyncProperty(current) || isAsyncQueryProperty(current) || isReactiveGetter(current)) {
+  } else if (isProperty(current) || isAsyncQueryProperty(current) || isReactiveGetter(current)) {
     throw new Error(`Invalid argument, cannot set over ${key} ${current.constructor.name}`);
   } else if (isReactiveField(current) || isReactiveQueryField(current)) {
     if (value instanceof FactoryInitialValue) {

--- a/packages/core/src/json.ts
+++ b/packages/core/src/json.ts
@@ -3,12 +3,12 @@ import { IdOf } from "./EntityManager";
 import { getMetadata } from "./EntityMetadata";
 import { normalizeHint } from "./normalizeHints";
 import { convertToLoadHint } from "./reactiveHints";
-import { AsyncMethod, AsyncProperty, Collection, ReactiveGetter, Reference } from "./relations";
+import { AsyncMethod, Collection, Property, ReactiveGetter, Reference } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
 import { ReactiveFieldImpl } from "./relations/ReactiveField";
 import { ReactiveGetterImpl } from "./relations/ReactiveGetter";
 import { ReactiveQueryFieldImpl } from "./relations/ReactiveQueryField";
-import { AsyncPropertyImpl } from "./relations/hasAsyncProperty";
+import { PropertyImpl } from "./relations/hasProperty";
 
 /**
  * A JSON hint of a single key, multiple keys, or nested keys and sub-hints.
@@ -61,7 +61,7 @@ export type JsonableValue<V> =
       ? U
       : V extends AsyncMethod<any, any, any>
         ? never
-        : V extends AsyncProperty<any, infer P>
+        : V extends Property<any, infer P>
           ? DropUndefined<P>
           : V extends ReactiveGetter<any, infer P>
             ? P
@@ -147,7 +147,7 @@ type JsonPayloadKey<T, H, TK extends keyof T, HK extends keyof NormalizeHint<H>>
     ? JsonPayloadReference<U, NormalizeHint<H>[HK]>
     : T[TK] extends Collection<any, infer U>
       ? JsonPayloadCollection<U, NormalizeHint<H>[HK]>
-      : T[TK] extends AsyncProperty<any, infer U>
+      : T[TK] extends Property<any, infer U>
         ? JsonPayloadProperty<U, NormalizeHint<H>[HK]>
         : T[TK] extends ReactiveGetter<any, infer V>
           ? V
@@ -208,7 +208,7 @@ async function copyToPayload(payload: Record<string, {}>, entity: any, hint: obj
         value instanceof ReactiveFieldImpl ||
         value instanceof ReactiveGetterImpl ||
         value instanceof ReactiveQueryFieldImpl ||
-        value instanceof AsyncPropertyImpl
+        value instanceof PropertyImpl
       ) {
         await copyToPayloadValue(payload, payloadKey, value.get, nextHint);
       } else {

--- a/packages/core/src/loadHints.ts
+++ b/packages/core/src/loadHints.ts
@@ -3,7 +3,6 @@ import { NormalizeHint } from "./normalizeHints";
 import { getRelationFromMaybePolyKey } from "./reactiveHints";
 import {
   AsyncMethod,
-  AsyncProperty,
   Collection,
   LoadedCollection,
   LoadedMethod,
@@ -11,6 +10,7 @@ import {
   LoadedReadOnlyCollection,
   LoadedReference,
   OneToOneReference,
+  Property,
   ReadOnlyCollection,
   Reference,
   Relation,
@@ -42,7 +42,7 @@ export type MarkLoaded<T extends Entity, P, UH = {}> =
         ? LoadedCollection<T, Loaded<U, UH>>
         : P extends ReadOnlyCollection<MaybeBaseType, infer U>
           ? LoadedReadOnlyCollection<T, Loaded<U, UH>>
-          : P extends AsyncProperty<MaybeBaseType, infer V>
+          : P extends Property<MaybeBaseType, infer V>
             ? // prettier-ignore
               [V] extends [(infer U extends Entity) | undefined]
     ? LoadedProperty<T, Loaded<U, UH> | Exclude<V, U>>
@@ -63,7 +63,7 @@ type MarkDeepLoaded<T extends Entity, P> =
         ? LoadedCollection<T, Loaded<U, DeepLoadHint<U>>>
         : P extends ReadOnlyCollection<MaybeBaseType, infer U>
           ? LoadedReadOnlyCollection<T, Loaded<U, DeepLoadHint<U>>>
-          : P extends AsyncProperty<MaybeBaseType, infer V>
+          : P extends Property<MaybeBaseType, infer V>
             ? // prettier-ignore
               [V] extends [(infer U extends Entity) | undefined]
     ? LoadedProperty<T, Loaded<U, DeepLoadHint<U>> | Exclude<V, U>>
@@ -162,8 +162,8 @@ export type LoadableValue<V> =
         ? U
         : V extends AsyncMethod<any, any, infer V>
           ? V
-          : V extends AsyncProperty<any, infer P>
-            ? // If the AsyncProperty returns `Comment | undefined`, then we want to return `Comment`
+          : V extends Property<any, infer P>
+            ? // If the Property returns `Comment | undefined`, then we want to return `Comment`
               // prettier-ignore
               P extends (infer U extends Entity) | undefined ? U : P
             : never;

--- a/packages/core/src/loadLens.ts
+++ b/packages/core/src/loadLens.ts
@@ -12,7 +12,7 @@ import {
 } from "./EntityMetadata";
 import { lensDataLoader } from "./dataloaders/lensDataLoader";
 import { LoadHint } from "./loadHints";
-import { isAsyncProperty } from "./relations";
+import { isProperty } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
 
 /** Generically matches on a Reference/Collection's load method. */
@@ -315,7 +315,7 @@ export function lensToPath<T extends Entity, U, V>(fn: (lens: Lens<T>) => Lens<U
 
 function isNotLoaded(object: any, path: string): boolean {
   const value = object && object[path];
-  if (value instanceof AbstractRelationImpl || isAsyncProperty(value)) {
+  if (value instanceof AbstractRelationImpl || isProperty(value)) {
     return !value.isLoaded;
   }
   return false;

--- a/packages/core/src/reactiveHints.ts
+++ b/packages/core/src/reactiveHints.ts
@@ -16,8 +16,6 @@ import { getProperties } from "./getProperties";
 import { Loadable, Loaded, LoadHint } from "./loadHints";
 import { NormalizeHint, normalizeHint, suffixRe, SuffixSeperator } from "./normalizeHints";
 import {
-  AsyncProperty,
-  AsyncPropertyImpl,
   Collection,
   LoadedCollection,
   LoadedProperty,
@@ -26,6 +24,8 @@ import {
   ManyToManyCollection,
   OneToOneReference,
   PolymorphicReference,
+  Property,
+  PropertyImpl,
   ReactiveGetter,
   ReadOnlyCollection,
   Reference,
@@ -44,7 +44,7 @@ import { fail, flatAndUnique, mergeNormalizedHints } from "./utils";
 export type Reactable<T extends Entity> =
   // This will be primitives + enums + m2os
   FieldsOf<T> &
-    // We include `Loadable` so that we include hasReactiveAsyncProperties,
+    // We include `Loadable` so that we include hasReactiveProperties,
     // which are reversable but won't be in any of our codegen types.
     Loadable<T> &
     Gettable<T> &
@@ -102,7 +102,7 @@ export type Reacted<T extends Entity, H> = Entity & {
           ? LoadedCollection<T, Entity & Reacted<U, NormalizeHint<H>[K]>>
           : T[K] extends ReadOnlyCollection<any, infer U>
             ? LoadedReadOnlyCollection<T, Entity & Reacted<U, NormalizeHint<H>[K]>>
-            : T[K] extends AsyncProperty<any, infer V>
+            : T[K] extends Property<any, infer V>
               ? LoadedProperty<any, V>
               : T[K];
 } & {
@@ -122,10 +122,10 @@ export type Reacted<T extends Entity, H> = Entity & {
 export type MaybeReactedEntity<V> = V extends Entity ? { fullNonReactiveAccess: V } : V;
 
 /**
- * Allow returning reacted entities from `hasReactiveAsyncProperty`.
+ * Allow returning reacted entities from `hasReactiveProperty`.
  *
  * The `MaybeReactedEntity` is used by `hasReactiveReference` which already has `undefined | never`
- * broken out as a separate generic; `hasReactiveAsyncProperty` does not, and so this type conditionally
+ * broken out as a separate generic; `hasReactiveProperty` does not, and so this type conditionally
  * pulls `undefined` out first, and then defers to `MaybeReactedEntity`.
  */
 export type MaybeReactedPropertyEntity<V> = V extends (infer V1 extends Entity) | undefined
@@ -303,22 +303,22 @@ function reverseSubHint(
         throw new Error(`Invalid hint in ${rootType.name}.ts hint ${JSON.stringify(hint)}`);
     }
   } else {
-    // We only need to look for ReactiveAsyncProperties here, because ReactiveFields & ReactiveReferences
+    // We only need to look for ReactiveProperties here, because ReactiveFields & ReactiveReferences
     // have underlying primitive fields that, when/if they change, will be handled in the ^ code.
     //
     // I.e. we specifically don't need to handle RFs & RRs ^, because the EntityManager.flush loop will
     // notice their primitive values changing, and kicking off any downstream reactive fields as necessary.
     const p = getProperties(meta)[key];
-    if (p instanceof AsyncPropertyImpl) {
+    if (p instanceof PropertyImpl) {
       // If the field is marked as readonly (i.e. using the `_ro` suffix), then we can assume that applies to its
       // entire hint as well and can simply omit it. This also allows us to use non-reactive async props as long as
       // they are readonly.
       if (isReadOnly) return [];
       if (!p.reactiveHint) {
         throw new Error(
-          `AsyncProperty ${key} cannot be used in reactive hints in ${rootType.name}.ts hint ${JSON.stringify(
+          `Property ${key} cannot be used in reactive hints in ${rootType.name}.ts hint ${JSON.stringify(
             hint,
-          )}, please use hasReactiveAsyncProperty instead`,
+          )}, please use hasReactiveProperty instead`,
         );
       }
       return reverseReactiveHint(rootType, meta.cstr, p.reactiveHint, undefined, false, false);

--- a/packages/core/src/relations/ReactiveField.ts
+++ b/packages/core/src/relations/ReactiveField.ts
@@ -7,23 +7,23 @@ import { IsLoadedCachable } from "../IsLoadedCache";
 import { lazyField } from "../newEntity";
 import { convertToLoadHint, Reacted, ReactiveHint } from "../reactiveHints";
 import { AbstractPropertyImpl } from "./AbstractPropertyImpl";
-import { AsyncPropertyT } from "./hasAsyncProperty";
+import { PropertyT } from "./hasProperty";
 
 /**
  * A `ReactiveField` is a value that is derived from other entities/values,
- * similar to an `AsyncProperty`, but it is also persisted in the database.
+ * similar to a `Property`, but it is also persisted in the database.
  *
  * This allows callers (or SQL queries) to access the value without first calling
  * `await load()` on the property.
  *
- * So, unlike `AsyncProperty`, `.get` is always available; if the property is unloaded,
+ * So, unlike `Property`, `.get` is always available; if the property is unloaded,
  * then `.get` will return the last-calculated value, but if the property is loaded,
  * then it will go ahead and invoke function to calculate the latest value (i.e. so
  * that you can observe the latest & greatest value w/o waiting for `em.flush` to
  * re-calc the value while persisting to the database.
  */
 export interface ReactiveField<T extends Entity, V> {
-  [AsyncPropertyT]: T;
+  [PropertyT]: T;
   isLoaded: boolean;
   isSet: boolean;
 
@@ -193,7 +193,7 @@ export class ReactiveFieldImpl<T extends Entity, H extends ReactiveHint<T>, V>
     this.#isCached = "factory-value";
   }
 
-  [AsyncPropertyT] = undefined as any as T;
+  [PropertyT] = undefined as any as T;
 
   private resetCacheUnlessFactoryPinned(): void {
     // If factories asked for a hard-coded value, don't reset the cached flag
@@ -202,12 +202,7 @@ export class ReactiveFieldImpl<T extends Entity, H extends ReactiveHint<T>, V>
   }
 }
 
-/** Type guard utility for determining if an entity field is an AsyncProperty. */
-export function isReactiveField(maybeAsyncProperty: any): maybeAsyncProperty is ReactiveField<any, any> {
-  return maybeAsyncProperty instanceof ReactiveFieldImpl;
-}
-
-/** Type guard utility for determining if an entity field is a loaded AsyncProperty. */
-export function isLoadedAsyncProperty(maybeAsyncProperty: any): maybeAsyncProperty is ReactiveField<any, any> {
-  return isReactiveField(maybeAsyncProperty) && maybeAsyncProperty.isLoaded;
+/** Type guard utility for determining if an entity field is a ReactiveField. */
+export function isReactiveField(maybeReactiveField: any): maybeReactiveField is ReactiveField<any, any> {
+  return maybeReactiveField instanceof ReactiveFieldImpl;
 }

--- a/packages/core/src/relations/ReactiveGetter.ts
+++ b/packages/core/src/relations/ReactiveGetter.ts
@@ -1,12 +1,12 @@
 import { Entity } from "../Entity";
 import { lazyField } from "../newEntity";
 import { Reacted, ShallowReactiveHint } from "../reactiveHints";
-import { AsyncPropertyT } from "./hasAsyncProperty";
+import { PropertyT } from "./hasProperty";
 
 /**
  * A `ReactiveGetter` is a getter that declares what primitive fields it depends on.
  *
- * This is very similar to a `ReactiveAsyncProperty`, except because it's limited to
+ * This is very similar to a `ReactiveProperty`, except because it's limited to
  * only immediate fields on the entity, it can always have `.get` called, and doesn't
  * need to be loaded.
  *
@@ -15,7 +15,7 @@ import { AsyncPropertyT } from "./hasAsyncProperty";
  * to access getter, and risk missing reactivity.
  */
 export interface ReactiveGetter<T extends Entity, V> {
-  [AsyncPropertyT]: T;
+  [PropertyT]: T;
   get: V;
 }
 
@@ -54,10 +54,10 @@ export class ReactiveGetterImpl<T extends Entity, const H extends ShallowReactiv
     return this.#hint;
   }
 
-  [AsyncPropertyT] = undefined as any as T;
+  [PropertyT] = undefined as any as T;
 }
 
-/** Type guard utility for determining if an entity field is an AsyncProperty. */
+/** Type guard utility for determining if an entity field is a ReactiveGetter. */
 export function isReactiveGetter(maybeReactiveGetter: any): maybeReactiveGetter is ReactiveGetter<any, any> {
   return maybeReactiveGetter instanceof ReactiveGetterImpl;
 }

--- a/packages/core/src/relations/ReactiveQueryField.ts
+++ b/packages/core/src/relations/ReactiveQueryField.ts
@@ -6,7 +6,7 @@ import { lazyField } from "../newEntity";
 import { Reacted, ReactiveHint, convertToLoadHint } from "../reactiveHints";
 import { mergeNormalizedHints } from "../utils";
 import { AbstractPropertyImpl } from "./AbstractPropertyImpl";
-import { AsyncPropertyT } from "./hasAsyncProperty";
+import { PropertyT } from "./hasProperty";
 
 /**
  * A `ReactiveQueryField` is a value that is derived from a SQL query, similar to
@@ -123,7 +123,7 @@ export class ReactiveQueryFieldImpl<T extends Entity, H1 extends ReactiveHint<T>
     setField(this.entity, this.fieldName, newValue);
   }
 
-  [AsyncPropertyT] = undefined as any as T;
+  [PropertyT] = undefined as any as T;
 }
 
 /** Type guard utility for determining if an entity field is an ReactiveQueryField. */

--- a/packages/core/src/relations/hasAsyncQueryProperty.ts
+++ b/packages/core/src/relations/hasAsyncQueryProperty.ts
@@ -1,10 +1,10 @@
 import { Entity } from "../Entity";
 import { lazyField } from "../newEntity";
 import { AbstractPropertyImpl } from "./AbstractPropertyImpl";
-import { AsyncPropertyT } from "./hasAsyncProperty";
+import { PropertyT } from "./hasProperty";
 
 export interface AsyncQueryProperty<T extends Entity, V> {
-  [AsyncPropertyT]: T;
+  [PropertyT]: T;
   isLoaded: boolean;
   load(opts?: { forceReload?: boolean }): Promise<V>;
 }
@@ -12,7 +12,7 @@ export interface AsyncQueryProperty<T extends Entity, V> {
 /**
  * Creates a derived value calculated from a SQL query.
  *
- * Unlike `hasAsyncProperty`, the lambda receives the entity and is expected
+ * Unlike `hasProperty`, the lambda receives the entity and is expected
  * to perform its own SQL queries rather than relying on in-memory graph data.
  *
  * - For new (un-flushed) entities, `load` throws because the entity has no id yet.
@@ -79,7 +79,7 @@ export class AsyncQueryPropertyImpl<T extends Entity, V>
     this.#value = undefined;
   }
 
-  [AsyncPropertyT] = undefined as any as T;
+  [PropertyT] = undefined as any as T;
 }
 
 /** Type guard utility for determining if an entity field is an AsyncQueryProperty. */

--- a/packages/core/src/relations/hasProperty.ts
+++ b/packages/core/src/relations/hasProperty.ts
@@ -5,11 +5,11 @@ import { lazyField } from "../newEntity";
 import { MaybeReactedPropertyEntity, Reacted, ReactiveHint, convertToLoadHint } from "../reactiveHints";
 import { tryResolve } from "../utils";
 
-export const AsyncPropertyT = Symbol();
+export const PropertyT = Symbol();
 
-export interface AsyncProperty<T extends Entity, V> {
+export interface Property<T extends Entity, V> {
   // Differentiate from AsyncMethod
-  [AsyncPropertyT]: T;
+  [PropertyT]: T;
   isLoaded: boolean;
   load(): Promise<V>;
 }
@@ -26,12 +26,12 @@ export interface LoadedProperty<T extends Entity, V> {
  * But if `someProperty` is used as a populate hint, then it can be accessed synchronously,
  * with `someProperty.get`.
  */
-export function hasAsyncProperty<T extends Entity, const H extends LoadHint<T>, V>(
+export function hasProperty<T extends Entity, const H extends LoadHint<T>, V>(
   loadHint: H,
   fn: (entity: Loaded<T, H>) => V,
-): AsyncProperty<T, V> {
+): Property<T, V> {
   return lazyField((entity: T) => {
-    return new AsyncPropertyImpl(entity, loadHint, fn);
+    return new PropertyImpl(entity, loadHint, fn);
   });
 }
 
@@ -43,16 +43,16 @@ export function hasAsyncProperty<T extends Entity, const H extends LoadHint<T>, 
  * But if `someProperty` is used as a populate hint, then it can be accessed synchronously,
  * with `someProperty.get`.
  */
-export function hasReactiveAsyncProperty<T extends Entity, const H extends ReactiveHint<T>, V>(
+export function hasReactiveProperty<T extends Entity, const H extends ReactiveHint<T>, V>(
   reactiveHint: H,
   fn: (entity: Reacted<T, H>) => MaybeReactedPropertyEntity<V>,
-): AsyncProperty<T, V> {
+): Property<T, V> {
   return lazyField((entity: T) => {
-    return new AsyncPropertyImpl(entity, reactiveHint as any, fn as any, { isReactive: true });
+    return new PropertyImpl(entity, reactiveHint as any, fn as any, { isReactive: true });
   });
 }
 
-export class AsyncPropertyImpl<T extends Entity, H extends LoadHint<T>, V> implements AsyncProperty<T, V> {
+export class PropertyImpl<T extends Entity, H extends LoadHint<T>, V> implements Property<T, V> {
   // We'll probe for loaded if undefined
   #loaded: boolean | undefined = undefined;
   #loadPromise: any;
@@ -107,17 +107,17 @@ export class AsyncPropertyImpl<T extends Entity, H extends LoadHint<T>, V> imple
     return !!this.#loaded;
   }
 
-  [AsyncPropertyT] = undefined as any as T;
+  [PropertyT] = undefined as any as T;
 }
 
-/** Type guard utility for determining if an entity field is an AsyncProperty. */
-export function isAsyncProperty(maybeAsyncProperty: any): maybeAsyncProperty is AsyncProperty<any, any> {
-  return maybeAsyncProperty instanceof AsyncPropertyImpl;
+/** Type guard utility for determining if an entity field is a Property. */
+export function isProperty(maybeProperty: any): maybeProperty is Property<any, any> {
+  return maybeProperty instanceof PropertyImpl;
 }
 
-/** Type guard utility for determining if an entity field is a loaded AsyncProperty. */
-export function isLoadedAsyncProperty(
-  maybeAsyncProperty: any,
-): maybeAsyncProperty is AsyncProperty<any, any> & LoadedProperty<any, any> {
-  return isAsyncProperty(maybeAsyncProperty) && maybeAsyncProperty.isLoaded;
+/** Type guard utility for determining if an entity field is a loaded Property. */
+export function isLoadedProperty(
+  maybeProperty: any,
+): maybeProperty is Property<any, any> & LoadedProperty<any, any> {
+  return isProperty(maybeProperty) && maybeProperty.isLoaded;
 }

--- a/packages/core/src/relations/index.ts
+++ b/packages/core/src/relations/index.ts
@@ -3,14 +3,14 @@ export { CustomCollection, hasCustomCollection } from "./CustomCollection";
 export { CustomReference, hasCustomReference } from "./CustomReference";
 export { AsyncMethod, LoadedMethod, hasAsyncMethod } from "./hasAsyncMethod";
 export {
-  AsyncProperty,
-  AsyncPropertyImpl,
   LoadedProperty,
-  hasAsyncProperty,
-  hasReactiveAsyncProperty,
-  isAsyncProperty,
-  isLoadedAsyncProperty,
-} from "./hasAsyncProperty";
+  Property,
+  PropertyImpl,
+  hasProperty,
+  hasReactiveProperty,
+  isLoadedProperty,
+  isProperty,
+} from "./hasProperty";
 export {
   AsyncQueryProperty,
   AsyncQueryPropertyImpl,

--- a/packages/core/src/withLoaded.ts
+++ b/packages/core/src/withLoaded.ts
@@ -1,10 +1,10 @@
 import { Entity } from "./Entity";
 import { assertLoaded, Loaded, LoadHint } from "./loadHints";
 import {
-  isAsyncProperty,
-  isLoadedAsyncProperty,
   isLoadedCollection,
+  isLoadedProperty,
   isLoadedReference,
+  isProperty,
   isReactiveField,
   isReactiveGetter,
   isReactiveQueryField,
@@ -76,14 +76,14 @@ export function withLoaded<T extends Entity, H extends LoadHint<T>, L extends Lo
           const value: any = (target as any)[prop];
           if (
             isRelation(value) ||
-            isAsyncProperty(value) ||
+            isProperty(value) ||
             isReactiveField(value) ||
             isReactiveGetter(value) ||
             isReactiveQueryField(value)
           ) {
             return isLoadedReference(value) ||
               isLoadedCollection(value) ||
-              isLoadedAsyncProperty(value) ||
+              isLoadedProperty(value) ||
               isReactiveField(value) ||
               isLoadedReactiveQueryField(value) ||
               isReactiveGetter(value)

--- a/packages/graphql-resolver-utils/src/entityResolver.ts
+++ b/packages/graphql-resolver-utils/src/entityResolver.ts
@@ -1,6 +1,5 @@
 import { GraphQLResolveInfo } from "graphql/type";
 import {
-  AsyncProperty,
   Collection,
   Entity,
   EntityMetadata,
@@ -8,14 +7,14 @@ import {
   getMetadata,
   getProperties,
   IdOf,
-  isAsyncProperty,
   isCollection,
-  isLoadedAsyncProperty,
   isLoadedCollection,
+  isLoadedProperty,
   isLoadedReadOnlyCollection,
   isLoadedReference,
   isManyToOneField,
   isOneToManyField,
+  isProperty,
   isReactiveGetter,
   isReadOnlyCollection,
   isReference,
@@ -23,6 +22,7 @@ import {
   ManyToManyField,
   ManyToOneField,
   MaybeAbstractEntityConstructor,
+  Property,
   OneToManyField,
   OneToOneField,
   PolymorphicField,
@@ -58,7 +58,7 @@ export type EntityResolver<T extends Entity> = {
           ? Resolver<T, Record<string, any>, U[]>
           : T[P] extends Reference<any, infer U, infer N>
             ? Resolver<T, Record<string, any>, U>
-            : T[P] extends AsyncProperty<any, infer V>
+            : T[P] extends Property<any, infer V>
               ? Resolver<T, Record<string, any>, V>
               : T[P] extends ReactiveGetter<any, infer V>
                 ? Resolver<T, Record<string, any>, V>
@@ -176,8 +176,8 @@ export function entityResolver<T extends Entity, A extends Record<string, keyof 
         return (property as Function).apply(entity);
       } else if (isReactiveGetter(property)) {
         return property.get;
-      } else if (isReference(property) || isCollection(property) || isAsyncProperty(property)) {
-        if (isLoadedReference(property) || isLoadedCollection(property) || isLoadedAsyncProperty(property)) {
+      } else if (isReference(property) || isCollection(property) || isProperty(property)) {
+        if (isLoadedReference(property) || isLoadedCollection(property) || isLoadedProperty(property)) {
           return property.get;
         }
         // ...we need to know the `property.otherMetadata()` return type, which isn't available right now

--- a/packages/test-utils/src/toMatchEntity.ts
+++ b/packages/test-utils/src/toMatchEntity.ts
@@ -1,14 +1,14 @@
 import {
-  AsyncProperty,
   BaseEntity,
   Entity,
   EntityManager,
-  isAsyncProperty,
   isCollection,
   isDefined,
   isEntity,
+  isProperty,
   isReactiveField,
   isReference,
+  Property,
   ReadOnlyCollection,
   Reference,
 } from "joist-core";
@@ -90,7 +90,7 @@ export type MatchedEntity<T> =
               ? MatchedEntity<U> | U
               : T[K] extends ReadOnlyCollection<any, infer U>
                 ? Array<MatchedEntity<U> | U>
-                : T[K] extends AsyncProperty<any, infer V>
+                : T[K] extends Property<any, infer V>
                   ? V
                   : T[K] extends Entity | null | undefined
                     ? MatchedEntity<T[K]> | T[K] | null | undefined
@@ -148,7 +148,7 @@ function maybeGetRelation(actualValue: unknown): unknown {
   if (
     isReference(actualValue) ||
     isCollection(actualValue) ||
-    isAsyncProperty(actualValue) ||
+    isProperty(actualValue) ||
     isReactiveField(actualValue)
   ) {
     return getWithSoftDeleted(actualValue);

--- a/packages/tests/integration/src/Entity.json.test.ts
+++ b/packages/tests/integration/src/Entity.json.test.ts
@@ -48,7 +48,7 @@ describe("Entity.json", () => {
       numberOfPublicReviews: {}, // ReactiveField
       initials: {}, // getter
       favoriteBook: "title", // ReactiveReference
-      numberOfBooks2: {}, // hasReactiveAsyncProperty
+      numberOfBooks2: {}, // hasReactiveProperty
       hasLowerCaseFirstName: {}, // ReactiveGetter
     });
     expect(payload).toEqual({

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -135,7 +135,7 @@ describe("Entity", () => {
       const a1 = em.create(Author, { firstName: "a1" });
       expect(() => {
         a1.set({ latestComments: [] } as any);
-      }).toThrow("Invalid argument, cannot set over latestComments AsyncPropertyImpl");
+      }).toThrow("Invalid argument, cannot set over latestComments PropertyImpl");
     });
 
     it("cannot set over an hasOneDerived relation", async () => {

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -1,8 +1,8 @@
 import {
   AsyncMethod,
-  AsyncProperty,
   Collection,
   Loaded,
+  Property,
   ReactiveField,
   ReactiveGetter,
   ReactiveManyToMany,
@@ -10,14 +10,14 @@ import {
   Reference,
   cannotBeUpdated,
   hasAsyncMethod,
-  hasAsyncProperty,
   hasManyDerived,
   hasManyThrough,
   hasOneDerived,
-  hasReactiveAsyncProperty,
+  hasProperty,
   hasReactiveField,
   hasReactiveGetter,
   hasReactiveManyToMany,
+  hasReactiveProperty,
   hasReactiveReference,
   isDefined,
   withLoaded,
@@ -109,7 +109,7 @@ export class Author extends AuthorCodegen {
   );
 
   // this prop should fail if loaded to test preventing `this` usage in props/relations/fields
-  readonly thisTestProp: AsyncProperty<Author, any> = hasAsyncProperty({}, () => this.search);
+  readonly thisTestProp: Property<Author, any> = hasProperty({}, () => this.search);
 
   public transientFields = {
     beforeFlushRan: false,
@@ -334,8 +334,8 @@ export class Author extends AuthorCodegen {
    * Example of an async property that can be loaded via a populate hint.
    * @generated Author.md
    */
-  readonly numberOfBooks2: AsyncProperty<Author, number> = hasReactiveAsyncProperty({ books: "title" }, (a) => {
-    // Use the title to test reactivity to an hasReactiveAsyncProperty calc changing
+  readonly numberOfBooks2: Property<Author, number> = hasReactiveProperty({ books: "title" }, (a) => {
+    // Use the title to test reactivity to a hasReactiveProperty calc changing
     return a.books.get.filter((b) => b.title !== "Ignore").length;
   });
 
@@ -343,7 +343,7 @@ export class Author extends AuthorCodegen {
    * Example of an async property that returns an entity.
    * @generated Author.md
    */
-  readonly latestComment2: AsyncProperty<Author, Comment | undefined> = hasReactiveAsyncProperty(
+  readonly latestComment2: Property<Author, Comment | undefined> = hasReactiveProperty(
     { publisher: "comments", comments: {} },
     (author) => author.publisher.get?.comments.get[0] ?? author.comments.get[0],
   );
@@ -352,7 +352,7 @@ export class Author extends AuthorCodegen {
    * Example of an async property that has a conflicting/overlapping reactive hint with ^.
    * @generated Author.md
    */
-  readonly allPublisherAuthorNames: AsyncProperty<Author, string | undefined> = hasReactiveAsyncProperty(
+  readonly allPublisherAuthorNames: Property<Author, string | undefined> = hasReactiveProperty(
     { publisher: { authors: "firstName" } },
     (author) => author.publisher.get?.authors.get.flatMap((a) => a.firstName).join(),
   );
@@ -361,7 +361,7 @@ export class Author extends AuthorCodegen {
    * Example of an async property that returns a list of entities.
    * @generated Author.md
    */
-  readonly latestComments: AsyncProperty<Author, Comment[]> = hasAsyncProperty(
+  readonly latestComments: Property<Author, Comment[]> = hasProperty(
     { publisher: "comments", comments: {} },
     (author) => [...(author.publisher.get?.comments.get ?? []), ...author.comments.get],
   );
@@ -370,7 +370,7 @@ export class Author extends AuthorCodegen {
    * For testing reacting to poly CommentParent properties.
    * @generated Author.md
    */
-  readonly commentParentInfo: AsyncProperty<Author, string> = hasReactiveAsyncProperty(
+  readonly commentParentInfo: Property<Author, string> = hasReactiveProperty(
     "numberOfBooks",
     (a) => `books=${a.numberOfBooks.get}`,
   );

--- a/packages/tests/integration/src/entities/Book.ts
+++ b/packages/tests/integration/src/entities/Book.ts
@@ -1,4 +1,4 @@
-import { AsyncProperty, hasReactiveAsyncProperty, hasReactiveField, ReactiveField } from "joist-orm";
+import { hasReactiveField, hasReactiveProperty, Property, ReactiveField } from "joist-orm";
 import { Author, BookCodegen, bookReviewBeforeFlushRan, bookConfig as config } from "./entities";
 
 export class Book extends BookCodegen {
@@ -19,7 +19,7 @@ export class Book extends BookCodegen {
    * For testing reacting to poly CommentParent properties.
    * @generated Book.md
    */
-  readonly commentParentInfo: AsyncProperty<Book, string> = hasReactiveAsyncProperty(
+  readonly commentParentInfo: Property<Book, string> = hasReactiveProperty(
     { reviews: "isPublic" },
     (b) => `reviews=${b.reviews.get.filter((r) => r.isPublic.get).length}`,
   );

--- a/packages/tests/integration/src/entities/BookReview.ts
+++ b/packages/tests/integration/src/entities/BookReview.ts
@@ -1,10 +1,10 @@
 import {
-  AsyncProperty,
   cannotBeUpdated,
   hasOneDerived,
   hasOneThrough,
-  hasReactiveAsyncProperty,
   hasReactiveField,
+  hasReactiveProperty,
+  Property,
   ReactiveField,
   Reference,
   withLoaded,
@@ -63,8 +63,8 @@ export class BookReview extends BookReviewCodegen {
     return review.isTest.get;
   });
 
-  // Used to test reactivity to hasReactiveAsyncProperty results changing.
-  readonly isPublic2: AsyncProperty<BookReview, boolean> = hasReactiveAsyncProperty({ comment: "text" }, (review) => {
+  // Used to test reactivity to hasReactiveProperty results changing.
+  readonly isPublic2: Property<BookReview, boolean> = hasReactiveProperty({ comment: "text" }, (review) => {
     review.transientFields.numberOfIsPublic2Calcs++;
     return !review.comment.get?.text?.includes("Ignore");
   });
@@ -73,7 +73,7 @@ export class BookReview extends BookReviewCodegen {
    * For testing reacting to poly CommentParent properties.
    * @generated BookReview.md
    */
-  readonly commentParentInfo: AsyncProperty<BookReview, string> = hasReactiveAsyncProperty([], () => ``);
+  readonly commentParentInfo: Property<BookReview, string> = hasReactiveProperty([], () => ``);
 }
 
 // Example of cannotBeUpdated on a m2o so "it won't be reactive" (but really is b/c of creates & deletes)

--- a/packages/tests/integration/src/entities/Critic.ts
+++ b/packages/tests/integration/src/entities/Critic.ts
@@ -1,9 +1,9 @@
-import { AsyncProperty, hasReactiveAsyncProperty } from "joist-orm";
+import { hasReactiveProperty, Property } from "joist-orm";
 import { criticConfig as config, CriticCodegen, PublisherGroup } from "./entities";
 
 export class Critic extends CriticCodegen {
-  // For testing returning Reacted<...> from hasReactiveAsyncProperty
-  readonly filteredGroup: AsyncProperty<Critic, PublisherGroup | undefined> = hasReactiveAsyncProperty(
+  // For testing returning Reacted<...> from hasReactiveProperty
+  readonly filteredGroup: Property<Critic, PublisherGroup | undefined> = hasReactiveProperty(
     "group",
     (c) => c.group.get,
   );

--- a/packages/tests/integration/src/entities/Publisher.ts
+++ b/packages/tests/integration/src/entities/Publisher.ts
@@ -1,16 +1,16 @@
 import {
-  AsyncProperty,
   AsyncQueryProperty,
   cannotBeUpdated,
   Collection,
   hasAsyncQueryProperty,
   hasCustomCollection,
-  hasReactiveAsyncProperty,
   hasReactiveField,
+  hasReactiveProperty,
   hasReactiveQueryField,
   hasReactiveReference,
   isLoaded,
   Loaded,
+  Property,
   ReactiveField,
   ReactiveReference,
 } from "joist-orm";
@@ -170,7 +170,7 @@ export abstract class Publisher extends PublisherCodegen {
    * For testing reacting to poly CommentParent properties.
    * @generated Publisher.md
    */
-  readonly commentParentInfo: AsyncProperty<Publisher, string> = hasReactiveAsyncProperty([], () => ``);
+  readonly commentParentInfo: Property<Publisher, string> = hasReactiveProperty([], () => ``);
 }
 
 config.afterMetadata((meta) => {

--- a/packages/tests/integration/src/entities/TaskOld.ts
+++ b/packages/tests/integration/src/entities/TaskOld.ts
@@ -1,4 +1,4 @@
-import { AsyncProperty, hasReactiveAsyncProperty, hasReactiveField, ReactiveField } from "joist-orm";
+import { hasReactiveField, hasReactiveProperty, Property, ReactiveField } from "joist-orm";
 import { taskOldConfig as config, TaskOldCodegen } from "./entities";
 
 export class TaskOld extends TaskOldCodegen {
@@ -11,7 +11,7 @@ export class TaskOld extends TaskOldCodegen {
    * For testing reacting to poly CommentParent properties.
    * @generated TaskOld.md
    */
-  readonly commentParentInfo: AsyncProperty<TaskOld, string> = hasReactiveAsyncProperty(
+  readonly commentParentInfo: Property<TaskOld, string> = hasReactiveProperty(
     { parentOldTask: "id" },
     (t) => `parent=${t.parentOldTask.get?.id}`,
   );

--- a/packages/tests/integration/src/getProperties.test.ts
+++ b/packages/tests/integration/src/getProperties.test.ts
@@ -34,7 +34,7 @@ describe("getProperties", () => {
      {
        "advances": "OneToManyCollection",
        "author": "ManyToOneReferenceImpl",
-       "commentParentInfo": "AsyncPropertyImpl",
+       "commentParentInfo": "PropertyImpl",
        "comments": "OneToManyCollection",
        "currentDraftAuthor": "OneToOneReferenceImpl",
        "favoriteAuthor": "OneToOneReferenceImpl",

--- a/packages/tests/integration/src/reactiveHints.test.ts
+++ b/packages/tests/integration/src/reactiveHints.test.ts
@@ -343,12 +343,12 @@ describe("reactiveHints", () => {
     });
 
     it("does not squash multiple expanded hints", () => {
-      // Given one Author hasReactiveAsyncProperty that goes through publisher -> comments
+      // Given one Author hasReactiveProperty that goes through publisher -> comments
       expect(convertToLoadHint(am, ["latestComment2"])).toEqual({
         publisher: { comments: {} },
         comments: {},
       });
-      // And another Author hasReactiveAsyncProperty that goes through publisher -> authors
+      // And another Author hasReactiveProperty that goes through publisher -> authors
       expect(convertToLoadHint(am, ["allPublisherAuthorNames"])).toEqual({
         publisher: { authors: {} },
       });


### PR DESCRIPTION
## Summary

This PR renames `AsyncProperty` and related types/functions to `Property` throughout the codebase for a simpler, more intuitive naming convention. The "Async" prefix was redundant since the async nature is already implicit in the interface design (with the `load()` method and `isLoaded` property).

## Key Changes

- **Type/Interface Renames:**
  - `AsyncProperty<T, V>` → `Property<T, V>`
  - `AsyncPropertyImpl` → `PropertyImpl`
  - `AsyncPropertyT` symbol → `PropertyT`

- **Function Renames:**
  - `hasAsyncProperty()` → `hasProperty()`
  - `hasReactiveAsyncProperty()` → `hasReactiveProperty()`
  - `isAsyncProperty()` → `isProperty()`
  - `isLoadedAsyncProperty()` → `isLoadedProperty()`

- **Codemod for Migration:**
  - Added `v2_1_0_rename_has_async_property` codemod to automatically update user code
  - Includes test fixtures demonstrating the transformation

- **Updated References:**
  - All imports/exports in `packages/core/src/relations/index.ts`
  - All type references in reactive hints, load hints, and JSON serialization
  - Documentation updated to reflect new naming
  - Test files and integration examples updated

## Implementation Details

- The rename is purely a naming change with no functional modifications
- The `PropertyT` symbol is used consistently across `Property`, `ReactiveField`, `ReactiveGetter`, and `AsyncQueryProperty` interfaces for type discrimination
- All comments and documentation updated to reference "Property" instead of "AsyncProperty"
- The codemod uses jscodeshift to automatically transform identifier names in user code during migration

https://claude.ai/code/session_01P786i6Qify8sh39YD2mWrg