### PR TITLE
fix: avoid stack overflow in BatchLoader.loadAll on huge key arrays

### DIFF
--- a/packages/core/src/batchloaders/BatchLoader.ts
+++ b/packages/core/src/batchloaders/BatchLoader.ts
@@ -22,7 +22,10 @@ export class BatchLoader<K> {
 
   loadAll(keys: K[]): Promise<void> {
     this.#ensureBatch();
-    this.#pending!.push(...keys);
+    // Avoid `push(...keys)`: spread passes each key as a separate function argument, and V8 throws
+    // `RangeError: Maximum call stack size exceeded` once `keys.length` exceeds the argument-count
+    // limit (~65k). This trips on real-world m2m fan-outs (e.g. ~250k join rows).
+    for (const key of keys) this.#pending!.push(key);
     return this.#batchPromise!;
   }
 

--- a/packages/core/src/batchloaders/BatchLoader.ts
+++ b/packages/core/src/batchloaders/BatchLoader.ts
@@ -22,10 +22,10 @@ export class BatchLoader<K> {
 
   loadAll(keys: K[]): Promise<void> {
     this.#ensureBatch();
-    // Avoid `push(...keys)`: spread passes each key as a separate function argument, and V8 throws
-    // `RangeError: Maximum call stack size exceeded` once `keys.length` exceeds the argument-count
-    // limit (~65k). This trips on real-world m2m fan-outs (e.g. ~250k join rows).
-    for (const key of keys) this.#pending!.push(key);
+    // Avoid `push(...keys)`: spread passes each key as a separate function argument, exceeding the
+    // JS engine's argument-count limit on large arrays and throwing `RangeError: Maximum call stack
+    // size exceeded`. Trips on real-world m2m fan-outs (e.g. ~250k join rows).
+    this.#pending = this.#pending!.concat(keys);
     return this.#batchPromise!;
   }
 


### PR DESCRIPTION
## Summary                                                                                                   

`BatchLoader.loadAll` uses spread-push (`this.#pending.push(...keys)`) to enqueue keys, which exceeds the JS engine's argument-count limit on large arrays and throws RangeError: Maximum call stack size exceeded. The exact threshold is engine- and stack-dependent ([MDN documents JavaScriptCore's](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#:~:text=The%20consequences%20of,the%20full%20array.) hard limit of 65,536 and recommends chunking at 32,768; V8's limit isn't a fixed number but lands in a similar ballpark depending on remaining stack).
                                                                                                               
Fix: Replace the spread with a sequential loop:
```js                                                          
for (const key of keys) this.#pending.push(key);
```