### PR TITLE
feat: Batch em.findPaginated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 *.tsbuildinfo
 .clinic/
 .envrc
+*.log
 
 .yarn/*
 !.yarn/patches

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -22,6 +22,7 @@ import { findCountDataLoader, findCountOperation } from "./dataloaders/findCount
 import { findDataLoader, findOperation } from "./dataloaders/findDataLoader";
 import { findIdsDataLoader, findIdsOperation } from "./dataloaders/findIdsDataLoader";
 import { entityMatches, findOrCreateDataLoader } from "./dataloaders/findOrCreateDataLoader";
+import { findPaginatedDataLoader, findPaginatedOperation } from "./dataloaders/findPaginatedDataLoader";
 import { lensOperation } from "./dataloaders/lensDataLoader";
 import { manyToManyFindOperation } from "./dataloaders/manyToManyFindDataLoader";
 import { oneToManyFindOperation } from "./dataloaders/oneToManyFindDataLoader";
@@ -60,7 +61,6 @@ import {
   OneToManyCollection,
   optimizeCollectionJoins,
   ParsedFindQuery,
-  parseFindQuery,
   PartialOrNull,
   Plugin,
   PolymorphicReferenceImpl,
@@ -90,9 +90,9 @@ import { ReactionsManager } from "./ReactionsManager";
 import { followReverseHint } from "./reactiveHints";
 import { ManyToOneReferenceImpl, OneToOneReferenceImpl, ReactiveReferenceImpl } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
+import { AsyncPropertyImpl } from "./relations/AsyncProperty";
 import { Collection } from "./relations/Collection";
 import { AsyncMethodPopulateSecret } from "./relations/hasAsyncMethod";
-import { AsyncPropertyImpl } from "./relations/AsyncProperty";
 import { RecursiveCycleError } from "./relations/RecursiveCollection";
 import { combineJoinRows, createTodos, JoinRowTodo, Todo } from "./Todo";
 import { runInTrustedContext } from "./trusted";
@@ -205,7 +205,7 @@ export type EntityManagerMode = "read-only" | "in-memory-writes" | "writes";
 
 export type FindOperation =
   | typeof findOperation
-  | "findPaginated"
+  | typeof findPaginatedOperation
   | typeof findByUniqueOperation
   | typeof findCountOperation
   | typeof findIdsOperation
@@ -471,15 +471,15 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   }
 
   /**
-   * Finds entities of `type` with the `where` filter, without auto-batching, so this method
-   * may call N+1s if called in a loop.
+   * Finds entities of `type` with the `where` filter, with auto-batching, so this method
+   * will not cause N+1s if called in a loop.
    *
    * The `where` filter is one of Joist's "join literals", which can combine both joining into
    * related entities and simple column conditions in a single literal. All conditions are ANDed.
    * For more complex conditions, use the `find` overload that has a `conditions` option.
    *
-   * This method is *NOT* batch-friendly, i.e. if called in a loop, it will cause N+1s. Because
-   * of this, you should prefer using `find`, unless you explicitly pagination support.
+   * This method is batch-friendly for calls with the same query structure, i.e. if called in a loop,
+   * it will be automatically batched to avoid N+1s.
    */
   public async findPaginated<T extends EntityW>(
     type: MaybeAbstractEntityConstructor<T>,
@@ -496,11 +496,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     where: FilterWithAlias<T>,
     options: FindPaginatedFilterOptions<T> & { populate?: any },
   ): Promise<T[]> {
-    const { populate, limit, offset, ...rest } = options || {};
-    const meta = getMetadata(type);
-    const query = parseFindQuery(meta, where, rest);
-    const rows = await this.executeFind(meta, "findPaginated", query, { ...rest, limit, offset, checkLimit: false });
-    const result = this.hydrate(type, rows);
+    const { populate, ...rest } = options || {};
+    const settings = { where, ...rest };
+    const result = await findPaginatedDataLoader(this, type, settings, populate)
+      .load(settings)
+      .catch(function findPaginated(err) {
+        throw appendStack(err, new Error());
+      });
     if (populate) {
       await this.populate(result, populate);
     }
@@ -522,18 +524,66 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       keepAliases?: string[];
     },
   ) {
-    const { checkLimit, ...driverSettings } = settings;
+    const { checkLimit, driverSettings } = this.prepareFind(meta, operation, parsed, settings);
+    return this.executePreparedFind(meta, operation, parsed, driverSettings, checkLimit);
+  }
+
+  /** Executes a query that has already had find hooks and optimizations applied. */
+  private async executePreparedFind(
+    meta: EntityMetadata,
+    operation: FindOperation,
+    parsed: ParsedFindQuery,
+    driverSettings: {
+      limit?: number;
+      offset?: number;
+      allowMultipleLeftJoins?: boolean;
+      optimizeJoinsToExists?: boolean;
+      pruneJoins?: boolean;
+      keepAliases?: string[];
+    },
+    checkLimit: boolean | undefined,
+  ) {
     const { pluginManager } = getEmInternalApi(this);
-    pluginManager.beforeFind(meta, operation, parsed, driverSettings);
-    optimizeCollectionJoins(parsed, settings);
     const rows = await this.driver.executeFind(this, parsed, driverSettings);
     // Check by default unless explicitly disabled or the caller removed the LIMIT via `limit: undefined`
-    const shouldCheck = checkLimit ?? !("limit" in settings && settings.limit === undefined);
+    const shouldCheck = checkLimit ?? !("limit" in driverSettings && driverSettings.limit === undefined);
     if (shouldCheck && rows.length >= this.entityLimit) {
       throw new Error(`Query returned more than ${this.entityLimit} entityLimit rows`);
     }
     pluginManager.afterFind(meta, operation, rows);
     return rows;
+  }
+
+  /**
+   * Runs pre-SQL find hooks and optimizations against a parsed query.
+   *
+   * This allows plugins to see "pre-batched" / "logical" query ASTs, instead of our
+   * more complicated `_find` batched queries. The flow would be:
+   *
+   * - A loader calls `prepareFind(originalQuery)`
+   * - Plugins inspect/modify the query as/if needed
+   * - The loader crafts a new, more complicated query that embeds the originalQuery
+   * - The loader calls `executePreparedFind` with the 2nd query
+   */
+  private prepareFind(
+    meta: EntityMetadata,
+    operation: FindOperation,
+    parsed: ParsedFindQuery,
+    settings: {
+      limit?: number;
+      offset?: number;
+      checkLimit?: boolean;
+      allowMultipleLeftJoins?: boolean;
+      optimizeJoinsToExists?: boolean;
+      pruneJoins?: boolean;
+      keepAliases?: string[];
+    },
+  ) {
+    const { checkLimit, ...driverSettings } = settings;
+    const { pluginManager } = getEmInternalApi(this);
+    pluginManager.beforeFind(meta, operation, parsed, driverSettings);
+    optimizeCollectionJoins(parsed, settings);
+    return { checkLimit, driverSettings };
   }
 
   /**

--- a/packages/core/src/QueryParser.ts
+++ b/packages/core/src/QueryParser.ts
@@ -177,6 +177,8 @@ export interface LateralJoinTable {
   table: string;
   /** The subquery that will look for/roll-up N children. */
   query: ParsedFindQuery;
+  /** Optional settings for the subquery, i.e. per-parent pagination. */
+  settings?: { limit?: number; offset?: number };
 }
 
 export type ParsedTable = PrimaryTable | JoinTable | CrossJoinTable | LateralJoinTable;

--- a/packages/core/src/dataloaders/findPaginatedDataLoader.ts
+++ b/packages/core/src/dataloaders/findPaginatedDataLoader.ts
@@ -1,0 +1,100 @@
+import DataLoader from "dataloader";
+import { Entity } from "../Entity";
+import { FilterAndSettings } from "../EntityFilter";
+import { EntityManager, MaybeAbstractEntityConstructor, getEmInternalApi } from "../EntityManager";
+import { getMetadata } from "../EntityMetadata";
+import { buildHintTree } from "../HintTree";
+import { LoadHint } from "../loadHints";
+import { ParsedFindQuery, parseFindQuery } from "../QueryParser";
+import { buildUnnestCte } from "../unnest";
+import {
+  collectAndReplaceArgs,
+  createColumnValues,
+  getBatchKeyFromGenericStructure,
+  whereFilterHash,
+} from "./findDataLoader";
+
+export const findPaginatedOperation = "findPaginated";
+
+/** Returns a dataloader that batches paginated finds by applying pagination inside each lateral subquery. */
+export function findPaginatedDataLoader<T extends Entity>(
+  em: EntityManager,
+  type: MaybeAbstractEntityConstructor<T>,
+  filter: FilterAndSettings<T>,
+  hint: LoadHint<T> | undefined,
+): DataLoader<FilterAndSettings<T>, T[]> {
+  const { where, limit, offset, ...opts } = filter;
+  const meta = getMetadata(type);
+  const query = parseFindQuery(meta, where, opts);
+  const batchKey = [getBatchKeyFromGenericStructure(meta, query), JSON.stringify(hint), limit, offset].join("-");
+
+  return em.getLoader(
+    findPaginatedOperation,
+    batchKey,
+    async (queries) => {
+      if (queries.length === 1) {
+        // Skip batching & just execute the query as-is
+        const { where, limit, offset, ...options } = queries[0];
+        const query = parseFindQuery(meta, where, options);
+        const { preloader } = getEmInternalApi(em);
+        const preloadHydrator = preloader && hint && preloader.addPreloading(meta, buildHintTree(hint), query);
+        const rows = await em["executeFind"](meta, findPaginatedOperation, query, {
+          ...options,
+          limit,
+          offset,
+          checkLimit: false,
+        });
+        const entities = em.hydrate(type, rows);
+        preloadHydrator?.(rows, entities);
+        return [entities];
+      }
+
+      // Call prepareFind to let plugins see the pre-batched AST
+      const { where, limit, offset, ...options } = queries[0];
+      const query = parseFindQuery(meta, where, options);
+      const { preloader } = getEmInternalApi(em);
+      const preloadHydrator = preloader && hint && preloader.addPreloading(meta, buildHintTree(hint), query);
+      em["prepareFind"](meta, findPaginatedOperation, query, { ...options, limit, offset, checkLimit: false });
+
+      // Now craft the actual batched query
+      const argsColumns = collectAndReplaceArgs(query);
+      argsColumns.unshift({ columnName: "tag", dbType: "int" });
+      const columnValues = createColumnValues(meta, argsColumns, queries);
+      const query2: ParsedFindQuery = {
+        selects: ["_find.tag as tag", "_data.*"],
+        tables: [
+          { join: "primary", table: "_find", alias: "_find" },
+          {
+            join: "lateral",
+            query,
+            table: meta.tableName,
+            alias: "_data",
+            fromAlias: "_find",
+            settings: { limit, offset },
+          },
+        ],
+        ctes: [buildUnnestCte("_find", argsColumns, columnValues)],
+        orderBys: [],
+      };
+
+      const rows = await em["executePreparedFind"](
+        meta,
+        findPaginatedOperation,
+        query2,
+        { ...options, limit: undefined },
+        false,
+      );
+      const entities = em.hydrate(type, rows);
+      preloadHydrator?.(rows, entities);
+
+      const results = queries.map(() => [] as T[]);
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        results[row.tag].push(entities[i]);
+        delete row.tag;
+      }
+      return results;
+    },
+    { cacheKeyFn: whereFilterHash },
+  );
+}

--- a/packages/core/src/drivers/buildRawQuery.ts
+++ b/packages/core/src/drivers/buildRawQuery.ts
@@ -3,6 +3,8 @@ import { kq, kqDot } from "../keywords";
 import { assertNever, cleanSql } from "../utils";
 import { buildWhereClause } from "./buildUtils";
 
+type QuerySettings = { limit?: number; offset?: number };
+
 /**
  * Transforms `ParsedFindQuery` into a raw SQL string.
  *
@@ -11,7 +13,7 @@ import { buildWhereClause } from "./buildUtils";
  */
 export function buildRawQuery(
   parsed: ParsedFindQuery,
-  settings: { limit?: number; offset?: number },
+  settings: QuerySettings,
 ): { sql: string; bindings: readonly any[] } {
   const { limit, offset } = settings;
 
@@ -89,7 +91,7 @@ export function buildRawQuery(
     } else if (t.join === "primary") {
       // handled above
     } else if (t.join === "lateral") {
-      const { sql: subQ, bindings: subB } = buildRawQuery(t.query, {});
+      const { sql: subQ, bindings: subB } = buildRawQuery(t.query, t.settings ?? {});
       sql += ` CROSS JOIN LATERAL (${subQ}) AS ${kq(t.alias)}`;
       bindings.push(...subB);
     } else if (t.join === "cross") {
@@ -115,11 +117,11 @@ export function buildRawQuery(
     sql += " ORDER BY " + parsed.orderBys.map((ob) => kqDot(ob.alias, ob.column) + " " + ob.order).join(", ");
   }
 
-  if (limit) {
+  if (limit !== undefined) {
     sql += ` LIMIT ?`;
     bindings.push(limit);
   }
-  if (offset) {
+  if (offset !== undefined) {
     sql += ` OFFSET ?`;
     bindings.push(offset);
   }

--- a/packages/tests/integration/src/EntityManager.find.batch.test.ts
+++ b/packages/tests/integration/src/EntityManager.find.batch.test.ts
@@ -75,6 +75,101 @@ describe("EntityManager.find.batch", () => {
     ]);
   });
 
+  it("batches paginated queries with matching limits", async () => {
+    await insertAuthor({ first_name: "a1", age: 10 });
+    await insertAuthor({ first_name: "a2", age: 10 });
+    await insertAuthor({ first_name: "b1", age: 20 });
+    await insertAuthor({ first_name: "b2", age: 20 });
+    resetQueryCount();
+    const em = newEntityManager();
+
+    const [q1, q2] = await Promise.all([
+      em.findPaginated(Author, { age: 10 }, { limit: 1, orderBy: { firstName: "ASC" } }),
+      em.findPaginated(Author, { age: 20 }, { limit: 1, orderBy: { firstName: "ASC" } }),
+    ]);
+
+    expect(numberOfQueries).toEqual(1);
+    expect(queries).toEqual([
+      [
+        `WITH _find (tag, arg0) AS (SELECT unnest($1::int[]), unnest($2::int[]))`,
+        ` SELECT _find.tag as tag, _data.* FROM _find AS _find`,
+        ` CROSS JOIN LATERAL`,
+        ` (SELECT a.* FROM authors AS a`,
+        ` WHERE a.deleted_at IS NULL AND a.age = _find.arg0`,
+        ` ORDER BY a.first_name ASC, a.id ASC LIMIT $3) AS _data`,
+      ].join(""),
+    ]);
+    expect(q1.map((a) => a.firstName)).toEqual(["a1"]);
+    expect(q2.map((a) => a.firstName)).toEqual(["b1"]);
+  });
+
+  it("does not batch paginated queries with different limits", async () => {
+    await insertAuthor({ first_name: "a1", age: 10 });
+    await insertAuthor({ first_name: "a2", age: 10 });
+    await insertAuthor({ first_name: "b1", age: 20 });
+    await insertAuthor({ first_name: "b2", age: 20 });
+    resetQueryCount();
+    const em = newEntityManager();
+
+    const [q1, q2] = await Promise.all([
+      em.findPaginated(Author, { age: 10 }, { limit: 1, orderBy: { firstName: "ASC" } }),
+      em.findPaginated(Author, { age: 20 }, { limit: 2, orderBy: { firstName: "ASC" } }),
+    ]);
+
+    expect(numberOfQueries).toEqual(2);
+    expect(q1.map((a) => a.firstName)).toEqual(["a1"]);
+    expect(q2.map((a) => a.firstName)).toEqual(["b1", "b2"]);
+  });
+
+  it("batches paginated queries with matching offsets", async () => {
+    await insertAuthor({ first_name: "a1", age: 10 });
+    await insertAuthor({ first_name: "a2", age: 10 });
+    await insertAuthor({ first_name: "b1", age: 20 });
+    await insertAuthor({ first_name: "b2", age: 20 });
+    resetQueryCount();
+    const em = newEntityManager();
+
+    const [q1, q2] = await Promise.all([
+      em.findPaginated(Author, { age: 10 }, { limit: 1, offset: 1, orderBy: { firstName: "ASC" } }),
+      em.findPaginated(Author, { age: 20 }, { limit: 1, offset: 1, orderBy: { firstName: "ASC" } }),
+    ]);
+
+    expect(numberOfQueries).toEqual(1);
+    expect(q1.map((a) => a.firstName)).toEqual(["a2"]);
+    expect(q2.map((a) => a.firstName)).toEqual(["b2"]);
+  });
+
+  it("supports paginated limit zero", async () => {
+    await insertAuthor({ first_name: "a1", age: 10 });
+    resetQueryCount();
+    const em = newEntityManager();
+
+    const q1 = await em.findPaginated(Author, { age: 10 }, { limit: 0 });
+
+    expect(numberOfQueries).toEqual(1);
+    expect(queries).toEqual([
+      `SELECT a.* FROM authors AS a WHERE a.deleted_at IS NULL AND a.age = $1 ORDER BY a.id ASC LIMIT $2`,
+    ]);
+    expect(q1).toEqual([]);
+  });
+
+  it("batches paginated queries with undefined limits", async () => {
+    await insertAuthor({ first_name: "a1", age: 10 });
+    await insertAuthor({ first_name: "a2", age: 10 });
+    await insertAuthor({ first_name: "b1", age: 20 });
+    resetQueryCount();
+    const em = newEntityManager();
+
+    const [q1, q2] = await Promise.all([
+      em.findPaginated(Author, { age: 10 }, { limit: undefined, orderBy: { firstName: "ASC" } }),
+      em.findPaginated(Author, { age: 20 }, { limit: undefined, orderBy: { firstName: "ASC" } }),
+    ]);
+
+    expect(numberOfQueries).toEqual(1);
+    expect(q1.map((a) => a.firstName)).toEqual(["a1", "a2"]);
+    expect(q2.map((a) => a.firstName)).toEqual(["b1"]);
+  });
+
   it("batches queries with complex expressions", async () => {
     await insertAuthor({ first_name: "a1", last_name: "l1" });
     await insertAuthor({ first_name: "a2", last_name: "l2" });


### PR DESCRIPTION
The LLM figured out we can use our existing `CROSS JOIN LATERAL` support to push the `LIMIT` / `OFFSET` down into an subquery that will be ran per `_find` row.

We include the `LIMIT` and `OFFSET` values in the batch key, so that they'll be consts in the query, for the query planner to have an easier time on things.

The idea is that for a nested query like `query { authors(...) { books(limit: 5) }`, we'll have the same `limit: 5` across all book finds anyway.

```ts
    const [q1, q2] = await Promise.all([
      em.findPaginated(Author, { age: 10 }, { limit: 1, orderBy: { firstName: "ASC" } }),
      em.findPaginated(Author, { age: 20 }, { limit: 1, orderBy: { firstName: "ASC" } }),
    ]);

    expect(numberOfQueries).toEqual(1);
    expect(queries).toEqual([
      [
        `WITH _find (tag, arg0) AS (SELECT unnest($1::int[]), unnest($2::int[]))`,
        ` SELECT _find.tag as tag, _data.* FROM _find AS _find`,
        ` CROSS JOIN LATERAL`,
        ` (SELECT a.* FROM authors AS a`,
        ` WHERE a.deleted_at IS NULL AND a.age = _find.arg0`,
        ` ORDER BY a.first_name ASC, a.id ASC LIMIT $3) AS _data`,
      ].join(""),
    ]);
```
