### PR TITLE
fix: Call beforeFind with pre-batch ASTs.

### DIFF
--- a/packages/core/src/dataloaders/findDataLoader.ts
+++ b/packages/core/src/dataloaders/findDataLoader.ts
@@ -81,13 +81,29 @@ export function findDataLoader<T extends Entity>(
       // Build the list of 'arg1', 'arg2', ... strings
       const { where, ...options } = queries[0];
       const query = parseFindQuery(getMetadata(type), where, options);
+      const { preloader } = getEmInternalApi(em);
+      const preloadJoins = preloader && hint && preloader.getPreloadJoins(meta, buildHintTree(hint), query);
+
+      // Let plugins see the pre-batched query AST
+      const { checkLimit, driverSettings } = em["prepareFind"](meta, findOperation, query, { limit: em.entityLimit });
+
       const argsColumns = collectAndReplaceArgs(query);
       argsColumns.unshift({ columnName: "tag", dbType: "int" });
-
       query.selects.unshift("array_agg(_find.tag) as _tags");
       // Inject a cross join into the query
       query.tables.unshift({ join: "cross", table: "_find", alias: "_find" });
       query.ctes = [buildUnnestCte("_find", argsColumns, createColumnValues(meta, argsColumns, queries))];
+      if (preloadJoins) {
+        query.selects.push(
+          ...preloadJoins.flatMap((j) =>
+            // Because we 'group by primary.id' to collapse the "a1 matched multiple finds" into
+            // a single row, we also need to pick just the first value of each preload column
+            j.selects.map((s) => `(array_agg(${s.value}))[1] AS ${s.as}`),
+          ),
+        );
+        query.tables.push(...preloadJoins.map((j) => j.join));
+      }
+
       // Because we want to use `array_agg(tag)`, add `GROUP BY`s to the values we're selecting
       query.groupBys = query.selects
         .filter((s) => typeof s === "string")
@@ -106,20 +122,7 @@ export function findDataLoader<T extends Entity>(
         }
       }
 
-      const { preloader } = getEmInternalApi(em);
-      const preloadJoins = preloader && hint && preloader.getPreloadJoins(meta, buildHintTree(hint), query);
-      if (preloadJoins) {
-        query.selects.push(
-          ...preloadJoins.flatMap((j) =>
-            // Because we 'group by primary.id' to collapse the "a1 matched multiple finds" into
-            // a single row, we also need to pick just the first value of each preload column
-            j.selects.map((s) => `(array_agg(${s.value}))[1] AS ${s.as}`),
-          ),
-        );
-        query.tables.push(...preloadJoins.map((j) => j.join));
-      }
-
-      const rows = await em["executeFind"](meta, findOperation, query, { limit: em.entityLimit });
+      const rows = await em["executePreparedFind"](meta, findOperation, query, driverSettings, checkLimit);
 
       const entities = em.hydrate(type, rows);
       preloadJoins?.forEach((j) => j.hydrator(rows, entities));

--- a/packages/tests/integration/src/EntityManager.find.batch.test.ts
+++ b/packages/tests/integration/src/EntityManager.find.batch.test.ts
@@ -1,6 +1,6 @@
 import { insertAuthor, insertPublisher } from "@src/entities/inserts";
 import { zeroTo } from "@src/utils";
-import { aliases } from "joist-orm";
+import { aliases, type ParsedFindQuery, Plugin } from "joist-orm";
 import {
   AdvanceStatus,
   Author,
@@ -73,6 +73,36 @@ describe("EntityManager.find.batch", () => {
         ` LIMIT $4`,
       ].join(""),
     ]);
+  });
+
+  it("passes the unbatched query AST to beforeFind plugins", async () => {
+    class BeforeFindPlugin extends Plugin {
+      tables: string[][] = [];
+      beforeFind(_meta: unknown, operation: unknown, query: ParsedFindQuery): void {
+        // Capture the query.plugins at beforeFind-time
+        if (operation === "find") {
+          this.tables.push(query.tables.map((table) => table.alias));
+        }
+      }
+    }
+
+    await insertAuthor({ first_name: "a1", last_name: "l1" });
+    await insertAuthor({ first_name: "a2", last_name: "l2" });
+    resetQueryCount();
+    const em = newEntityManager();
+    const plugin = new BeforeFindPlugin();
+    em.addPlugin(plugin);
+
+    // Given we batch two em.finds
+    await Promise.all([
+      em.find(Author, { firstName: "a1", lastName: "l1" }),
+      em.find(Author, { firstName: "a2", lastName: "l2" }),
+    ]);
+    // Then there was only 1 query issues
+    expect(numberOfQueries).toEqual(1);
+    // And the plugin only saw the pre-batched `authors a` table, and not
+    // our more complicated `_find` structure
+    expect(plugin.tables).toEqual([["a"]]);
   });
 
   it("batches paginated queries with matching limits", async () => {


### PR DESCRIPTION
This simplifies the `ParsedFindQuery` ASTs that plugin `beforeFind`s are seen, b/c they will be the pre-batched logical query, and not the post-batched physical query.

This is fine b/c we trust the batch-ification of the logical query to be mechanical and not change the query semantics that plugins observed in `beforeFind`.

If plugins eventually want to see "the post-batch physical query", we could add another hook, but my hope is that won't be necessary, b/c at that point they might as well inspect the raw SQL strings, and not our ASTs.