### PR TITLE
perf: Optimize entity hydration registration

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -55,7 +55,6 @@ import {
   GraphQLFilterWithAlias,
   InstanceData,
   isLoadedReference,
-  keyToTaggedId,
   Lens,
   loadLens,
   OneToManyCollection,
@@ -448,12 +447,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   ): Promise<T[]> {
     const { populate, ...rest } = options || {};
     const settings = { where, ...rest };
-    const result = await (hasPaginationSettings(rest)
-      ? findPaginatedDataLoader(this, type, settings, populate)
-      : findDataLoader(this, type, settings, populate))
-      .catch(function find(err) {
-        throw appendStack(err, new Error());
-      });
+    const result = await (
+      hasPaginationSettings(rest)
+        ? findPaginatedDataLoader(this, type, settings, populate)
+        : findDataLoader(this, type, settings, populate)
+    ).catch(function find(err) {
+      throw appendStack(err, new Error());
+    });
     if (populate) {
       await this.populate(result, populate);
     }
@@ -665,10 +665,9 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     options: FindCountFilterOptions<T> = {},
   ): Promise<number> {
     const settings = { where, ...options };
-    let count = await findCountDataLoader(this, type, settings)
-      .catch(function findCount(err) {
-        throw appendStack(err, new Error());
-      });
+    let count = await findCountDataLoader(this, type, settings).catch(function findCount(err) {
+      throw appendStack(err, new Error());
+    });
     // If the user is do "count all", we can adjust the number up/down based on
     // WIP creates/deletes. We can't do this if the WHERE clause is populated b/c
     // then we'd also have to eval each created/deleted entity against the WHERE
@@ -703,10 +702,9 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     options: FindCountFilterOptions<T> = {},
   ): Promise<string[]> {
     const settings = { where, ...options };
-    return findIdsDataLoader(this, type, settings)
-      .catch(function findIds(err) {
-        throw appendStack(err, new Error());
-      });
+    return findIdsDataLoader(this, type, settings).catch(function findIds(err) {
+      throw appendStack(err, new Error());
+    });
   }
 
   /**
@@ -1933,11 +1931,14 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     options?: { overwriteExisting?: boolean },
   ): T[] {
     const maybeBaseMeta = getMetadata(type);
+    const taggedIdPrefix = `${maybeBaseMeta.tagName}:`;
+    const overwriteExisting = options?.overwriteExisting === true;
 
     let i = 0;
     const entities = new Array(rows.length);
     for (const row of rows) {
-      const taggedId = keyToTaggedId(maybeBaseMeta, row["id"]) || fail("No id column was available");
+      const id = row["id"];
+      const taggedId = id === undefined || id === null ? fail("No id column was available") : `${taggedIdPrefix}${id}`;
       // See if this is already in our UoW
       let entity = this.findExistingInstance(taggedId) as T;
       if (!entity) {
@@ -1946,22 +1947,34 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         // Pass id as a hint that we're in hydrate mode
         entity = newEntity(this, asConcreteCstr(meta.cstr), false) as T;
         getInstanceData(entity).row = row;
-        this.#doRegister(entity as any, taggedId);
-      } else if (options?.overwriteExisting === true) {
+        this.#doRegister(entity as any, taggedId, meta, true);
+      } else if (overwriteExisting) {
         // Usually if the entity already exists, we don't write over it, but in this case we assume that
         // `EntityManager.refresh` is telling us to explicitly load the latest data.
         // First swap out the old row with the new row
-        getInstanceData(entity).row = row;
+        const instanceData = getInstanceData(entity);
+        instanceData.row = row;
         // And then only refresh the data keys that have already been serde-d from rows
         // (this keeps us from deserializing data out of rows that we don't need).
-        const { data, originalData } = getInstanceData(entity);
-        const changedFields = (entity as any).changes.fieldsWithoutRelations;
-        for (const fieldName of Object.keys(data)) {
-          const serde = getMetadata(entity).allFields[fieldName].serde ?? fail(`Missing serde for ${fieldName}`);
-          serde.setOnEntity(data, row);
-          // Make the field look not-dirty
-          if (changedFields.includes(fieldName)) {
-            delete originalData[fieldName];
+        const { data, originalData } = instanceData;
+        const dataKeys = Object.keys(data);
+        if (dataKeys.length > 0) {
+          const allFields = getMetadata(entity).allFields;
+          const changedFields = (entity as any).changes.fieldsWithoutRelations;
+          if (changedFields.length === 0) {
+            for (const fieldName of dataKeys) {
+              const serde = allFields[fieldName].serde ?? fail(`Missing serde for ${fieldName}`);
+              serde.setOnEntity(data, row);
+            }
+          } else {
+            for (const fieldName of dataKeys) {
+              const serde = allFields[fieldName].serde ?? fail(`Missing serde for ${fieldName}`);
+              serde.setOnEntity(data, row);
+              // Make the field look not-dirty
+              if (changedFields.includes(fieldName)) {
+                delete originalData[fieldName];
+              }
+            }
           }
         }
       }
@@ -2470,11 +2483,11 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   }
 
   /** Registers a newly-instantiated entity with our EntityManager; only called by #doCreate and hydrate. */
-  #doRegister(entity: Entity, id?: string): void {
+  #doRegister(entity: Entity, id?: string, meta?: EntityMetadata, skipDuplicateCheck: boolean = false): void {
     // Keep our indexes up to date...
     const maybeId = id ?? entity.idTaggedMaybe;
     if (maybeId) {
-      if (this.findExistingInstance(maybeId) !== undefined) {
+      if (!skipDuplicateCheck && this.findExistingInstance(maybeId) !== undefined) {
         throw new Error(`Entity ${entity} has a duplicate instance already loaded`);
       }
       this.#entitiesById.set(maybeId, entity);
@@ -2484,7 +2497,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     }
     this.#entitiesArray.push(entity);
 
-    const meta = getMetadata(entity);
+    meta ??= getMetadata(entity);
     const set = this.#entitiesByTag.get(meta.tagName) ?? [];
     if (set.length === 0) this.#entitiesByTag.set(meta.tagName, set);
     set.push(entity);
@@ -2970,15 +2983,12 @@ function findConcreteMeta(maybeBaseMeta: EntityMetadata, row: any): EntityMetada
       throw new Error(`${maybeBaseMeta.type} ${tagId(maybeBaseMeta, row.id)} must be instantiated via a subtype`);
     }
     // Look for the CTI __class from the driver telling us which subtype to instantiate
-    return maybeBaseMeta.subTypes.find((st) => st.type === row.__class) ?? maybeBaseMeta;
+    return maybeBaseMeta.subTypesByType!.get(row.__class) ?? maybeBaseMeta;
   } else if (maybeBaseMeta.inheritanceType === "sti") {
     // Look for the STI discriminator value
     const baseMeta = getBaseMeta(maybeBaseMeta);
-    const field = baseMeta.fields[baseMeta.stiDiscriminatorField!];
-    if (field.kind !== "enum") throw new Error("Discriminator field must be an enum");
-    const columnName = field.serde.columns[0].columnName;
-    const value = row[columnName];
-    return baseMeta.subTypes.find((st) => st.stiDiscriminatorValue === value) ?? baseMeta;
+    const value = row[baseMeta.stiDiscriminatorColumnName!];
+    return baseMeta.subTypesByStiValue!.get(value) ?? baseMeta;
   } else {
     throw new Error("Unknown inheritance type");
   }
@@ -2987,7 +2997,7 @@ function findConcreteMeta(maybeBaseMeta: EntityMetadata, row: any): EntityMetada
 /** Sets the `Animal.type` enum to the right subtype value. */
 function setStiDiscriminatorValue(baseMeta: EntityMetadata, entity: Entity): void {
   const typeName = entity.constructor.name;
-  const st = baseMeta.subTypes.find((st) => st.type === typeName);
+  const st = baseMeta.subTypesByType!.get(typeName);
   if (st) {
     const field = baseMeta.fields[baseMeta.stiDiscriminatorField!] as EnumField;
     const code = (field.enumDetailType.findById(st.stiDiscriminatorValue!) as any).code;

--- a/packages/core/src/EntityMetadata.ts
+++ b/packages/core/src/EntityMetadata.ts
@@ -61,6 +61,12 @@ export interface EntityMetadata<T extends Entity = any> {
   baseTypes: EntityMetadata[];
   /** The list of subtypes for this base type, e.g. for Animal it'd be `[Mammal, Dog]`. */
   subTypes: EntityMetadata[];
+  /** The lazy lookup of subtypes by type name, i.e. `Animal.metadata.subTypesByType.get("Dog")`. */
+  subTypesByType?: ReadonlyMap<string, EntityMetadata>;
+  /** The lazy lookup of STI subtypes by discriminator value, i.e. `Task.metadata.subTypesByStiValue.get(1)`. */
+  subTypesByStiValue?: ReadonlyMap<unknown, EntityMetadata>;
+  /** The lazy STI discriminator column name, i.e. `Task.metadata.stiDiscriminatorColumnName`. */
+  stiDiscriminatorColumnName?: string;
   /** If the schema is lacking deferred FKs, this is our insertion order. */
   nonDeferredFkOrder?: number;
 }

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -1,17 +1,23 @@
-import { Entity } from "./Entity";
-import { MaybeAbstractEntityConstructor, TaggedId } from "./EntityManager";
-import { EntityMetadata, ManyToOneField, OneToManyField, getMetadata } from "./EntityMetadata";
+import { type Entity } from "./Entity";
+import { type MaybeAbstractEntityConstructor, type TaggedId } from "./EntityManager";
+import {
+  type EntityMetadata,
+  type EnumField,
+  type ManyToOneField,
+  type OneToManyField,
+  getMetadata,
+} from "./EntityMetadata";
 import { setAfterMetadataLocked, setBooted } from "./config";
 import { AsyncDefault } from "./defaults";
 import { getProperties } from "./getProperties";
 import { maybeResolveReferenceToId, tagFromId } from "./keys";
 import { reverseReactiveHint } from "./reactiveHints";
 import { ReactiveManyToManyImpl, ReactiveReferenceImpl, Reference } from "./relations";
-import { ReactiveFieldImpl } from "./relations/ReactiveField";
 import { AsyncReactiveFieldImpl } from "./relations/AsyncReactiveField";
+import { ReactiveFieldImpl } from "./relations/ReactiveField";
 import { isCannotBeUpdatedRule } from "./rules";
 import { KeySerde } from "./serde";
-import { fail } from "./utils";
+import { defineLazyGetter, fail } from "./utils";
 
 const tagToConstructorMap = new Map<string, MaybeAbstractEntityConstructor<any>>();
 const tableToMetaMap = new Map<string, EntityMetadata>();
@@ -30,6 +36,7 @@ export function configureMetadata(metas: EntityMetadata[]): void {
   try {
     populateConstructorMaps(metas);
     hookUpBaseTypeAndSubTypes(metas);
+    installMetadataGetters(metas);
     sortMetasByBaseType(metas);
     setImmutableFields(metas);
     populatePolyComponentFields(metas);
@@ -44,6 +51,24 @@ export function configureMetadata(metas: EntityMetadata[]): void {
   } catch (e) {
     previousBootError = e;
     throw e;
+  }
+}
+
+/** Installs lazy lookup getters for metadata-derived caches. */
+function installMetadataGetters(metas: EntityMetadata[]): void {
+  for (const meta of metas) {
+    defineLazyGetter(meta, "subTypesByType", function buildSubTypesByType() {
+      return new Map(meta.subTypes.map((st) => [st.type, st]));
+    });
+    defineLazyGetter(meta, "subTypesByStiValue", function buildSubTypesByStiValue() {
+      return new Map(meta.subTypes.map((st) => [st.stiDiscriminatorValue, st]));
+    });
+    defineLazyGetter(meta, "stiDiscriminatorColumnName", function buildStiDiscriminatorColumnName() {
+      const field = meta.fields[meta.stiDiscriminatorField!];
+      if (field === undefined) throw new Error(`${meta.type} does not have an STI discriminator field`);
+      if (field.kind !== "enum") throw new Error("Discriminator field must be an enum");
+      return (field as EnumField).serde.columns[0].columnName;
+    });
   }
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -42,6 +42,18 @@ export function getOrSet<T extends Record<keyof unknown, unknown>>(
   return record[key];
 }
 
+/** Defines a getter that replaces itself with its computed value on first access. */
+export function defineLazyGetter<T extends object, K extends keyof T>(obj: T, key: K, build: () => T[K]): void {
+  Object.defineProperty(obj, key, {
+    configurable: true,
+    get: function getLazyProperty() {
+      const value = build();
+      Object.defineProperty(obj, key, { configurable: true, value });
+      return value;
+    },
+  });
+}
+
 /**
  * A utility to ensure a Promise-returning method actually returns a promise and doesn't
  * early exit. Using `async function` guarantees these semantics, but sometimes we avoid

--- a/packages/tests/integration/BENCHMARK-HYDRATION-RESULTS.md
+++ b/packages/tests/integration/BENCHMARK-HYDRATION-RESULTS.md
@@ -1,0 +1,108 @@
+# Hydration And Registration Benchmark Results
+
+Command:
+
+```bash
+cd packages/tests/integration
+../../../node_modules/.bin/env-cmd -f ../../../local.env -- node --expose-gc --import tsx -r tsconfig-paths/register benchmark-hydration-registration.ts
+```
+
+Environment:
+
+- Node: `v25.9.0`
+- `global.gc`: enabled
+- Rows are synthetic in-memory rows; no SQL is executed by the benchmark body.
+- Retained heap is measured after forced GC while each scenario result remains globally reachable.
+
+## Scenarios
+
+- `author_fresh_register`: `em.hydrate(Author, rows)` into a fresh EM, without scalar field reads.
+- `author_fresh_register_scalar_reads`: fresh Author hydration plus reads of common scalar fields.
+- `author_existing_no_overwrite`: initial Author hydrate, then duplicate hydrate with `overwriteExisting: false`.
+- `author_existing_overwrite_cold_data`: initial Author hydrate, then duplicate hydrate with `overwriteExisting: true` before scalar fields are read.
+- `author_existing_overwrite_warm_data`: initial Author hydrate, scalar reads, then duplicate hydrate with `overwriteExisting: true`.
+- `task_sti_fresh_register`: `em.hydrate(Task, rows)` with alternating STI discriminator values.
+
+## Raw Results
+
+```csv
+scenario,size,iterations,mean_ms,p50_ms,p90_ms,p99_ms,min_ms,max_ms,rsd,cpu_mean_ms,heap_delta_mb
+author_fresh_register,10000,18,10.786,10.909,12.433,14.423,7.712,14.423,0.149,24.916,4.458
+author_fresh_register_scalar_reads,10000,18,46.193,47.017,53.429,53.687,31.494,53.687,0.135,85.107,5.029
+author_existing_no_overwrite,10000,18,16.066,13.230,24.168,24.801,10.566,24.801,0.311,34.182,4.456
+author_existing_overwrite_cold_data,10000,18,14.276,13.765,17.011,17.419,10.046,17.419,0.143,34.482,4.454
+author_existing_overwrite_warm_data,10000,18,41.393,41.649,44.969,45.782,33.802,45.782,0.065,92.554,5.030
+task_sti_fresh_register,10000,18,14.232,12.295,21.513,24.729,9.882,24.729,0.312,31.181,4.521
+author_fresh_register,50000,10,49.560,48.989,52.810,53.156,46.153,53.156,0.044,87.365,20.822
+author_fresh_register_scalar_reads,50000,10,100.223,100.641,106.204,106.667,87.750,106.667,0.054,187.136,23.563
+author_existing_no_overwrite,50000,10,69.540,63.837,77.688,112.197,61.102,112.197,0.215,110.517,20.821
+author_existing_overwrite_cold_data,50000,10,73.938,67.373,72.675,124.513,63.424,124.513,0.231,116.188,20.813
+author_existing_overwrite_warm_data,50000,10,181.339,183.980,192.428,196.835,156.296,196.835,0.065,306.016,23.561
+task_sti_fresh_register,50000,10,62.680,52.489,86.822,89.511,48.577,89.511,0.251,98.783,21.158
+author_fresh_register,100000,8,102.362,100.223,106.929,106.929,98.172,106.929,0.033,142.864,40.648
+author_fresh_register_scalar_reads,100000,8,215.763,211.838,252.292,252.292,203.560,252.292,0.066,341.664,45.986
+author_existing_no_overwrite,100000,8,156.538,150.298,193.889,193.889,143.478,193.889,0.094,244.757,40.642
+author_existing_overwrite_cold_data,100000,8,238.585,235.141,290.569,290.569,192.690,290.569,0.140,500.551,40.649
+author_existing_overwrite_warm_data,100000,8,388.272,377.051,420.030,420.030,368.370,420.030,0.042,629.628,45.987
+task_sti_fresh_register,100000,8,118.582,104.335,159.260,159.260,102.556,159.260,0.191,160.004,41.309
+```
+
+## Findings
+
+- Fresh Author hydration/register is about `102 ms` for `100k` rows, or roughly `1.02 us/entity` wall time.
+- Fresh retained heap is about `40.6 MB` for `100k` Authors, or roughly `406 bytes/entity` for entities plus EM identity structures.
+- Scalar field reads roughly double 100k Author time, from `102 ms` to `216 ms`, and add about `5.3 MB` retained heap. This is expected lazy serde/data materialization cost, not registration cost.
+- Duplicate hydrate with `overwriteExisting: false` costs about `54 ms` incremental at `100k` rows after subtracting the initial fresh hydrate. This mostly isolates tagged-id construction plus `Map.get` identity lookup.
+- Duplicate hydrate with `overwriteExisting: true` is materially more expensive at `100k`: about `136 ms` incremental for cold data and `172 ms` incremental for warm scalar data after subtracting comparable initial work.
+- STI fresh hydration is about `16 ms` slower than non-inheritance Author hydration at `100k`, consistent with per-row subtype resolution via discriminator lookup.
+
+## Optimization Candidates
+
+- `EntityManager.hydrate`: hoist `const overwriteExisting = options?.overwriteExisting === true` outside the row loop. This is small but applies to every hydrated row.
+- `EntityManager.hydrate`: avoid the second `Map.get` duplicate check in `#doRegister` for hydrate-created entities. The hydrate loop already called `findExistingInstance(taggedId)` immediately before `#doRegister`.
+- `EntityManager.hydrate` / `#doRegister`: pass the already-known concrete `meta` into registration for hydrate-created entities, avoiding `getMetadata(entity)` per new row.
+- `findConcreteMeta`: cache STI discriminator value to metadata lookup instead of `baseMeta.subTypes.find(...)` per row.
+- `overwriteExisting` branch: hoist `const allFields = getMetadata(entity).allFields` outside the inner `Object.keys(data)` loop and skip `changedFields.includes(...)` when `changedFields.length === 0`.
+- `keyToTaggedId`: benchmark an inline hydrate fast path using a precomputed `${tagName}:` prefix for non-null ids. This path is on every hydrate row and every duplicate lookup.
+
+## Optimized Results
+
+Optimizations applied:
+
+- Hoisted `overwriteExisting` and tagged id prefix outside the hydration loop.
+- Inlined hydrate tagged-id construction for the required `id` column.
+- Passed known concrete metadata into `#doRegister` for hydrated entities.
+- Skipped `#doRegister`'s duplicate `Map.get` check for hydrate-created entities.
+- Cached CTI/STI subtype metadata lookups as lazy `EntityMetadata` getters.
+- Hoisted overwrite branch field metadata lookup and skipped dirty-field checks when there are no changed scalar fields.
+
+```csv
+scenario,size,iterations,mean_ms,p50_ms,p90_ms,p99_ms,min_ms,max_ms,rsd,cpu_mean_ms,heap_delta_mb
+author_fresh_register,10000,18,8.936,9.112,10.160,10.235,6.436,10.235,0.115,21.911,4.444
+author_fresh_register_scalar_reads,10000,18,36.080,35.954,40.293,49.944,13.971,49.944,0.176,96.296,5.036
+author_existing_no_overwrite,10000,18,10.842,10.103,15.243,18.896,7.827,18.896,0.229,25.194,4.450
+author_existing_overwrite_cold_data,10000,18,11.668,10.333,20.415,21.023,7.022,21.023,0.342,28.096,4.454
+author_existing_overwrite_warm_data,10000,18,32.620,33.756,36.129,36.601,20.187,36.601,0.115,74.525,5.031
+task_sti_fresh_register,10000,18,12.154,10.388,16.499,16.952,8.031,16.952,0.253,26.682,4.522
+author_fresh_register,50000,10,50.059,40.599,66.072,66.155,37.275,66.155,0.246,81.806,20.822
+author_fresh_register_scalar_reads,50000,10,87.305,83.274,89.570,123.325,76.643,123.325,0.143,151.666,23.564
+author_existing_no_overwrite,50000,10,51.627,50.731,52.804,57.844,48.704,57.844,0.048,88.110,20.820
+author_existing_overwrite_cold_data,50000,10,51.753,52.213,52.992,53.235,49.172,53.235,0.026,80.285,20.822
+author_existing_overwrite_warm_data,50000,10,139.033,134.255,153.363,167.538,116.318,167.538,0.100,247.733,23.563
+task_sti_fresh_register,50000,10,65.138,65.049,66.585,67.506,63.124,67.506,0.020,96.622,21.158
+author_fresh_register,100000,8,82.952,82.652,84.913,84.913,81.466,84.913,0.015,120.414,40.648
+author_fresh_register_scalar_reads,100000,8,186.986,185.239,193.511,193.511,177.322,193.511,0.028,300.111,45.982
+author_existing_no_overwrite,100000,8,109.782,108.463,113.833,113.833,106.949,113.833,0.019,153.448,40.647
+author_existing_overwrite_cold_data,100000,8,144.013,139.682,163.068,163.068,129.471,163.068,0.072,231.694,40.649
+author_existing_overwrite_warm_data,100000,8,307.113,304.494,357.644,357.644,276.904,357.644,0.069,527.859,45.984
+task_sti_fresh_register,100000,8,88.207,87.530,91.965,91.965,85.497,91.965,0.026,129.975,41.309
+```
+
+## Before/After Summary
+
+- `author_fresh_register` at `100k`: `102.362 ms` to `82.952 ms`, a `19.0%` wall-time reduction.
+- `author_fresh_register_scalar_reads` at `100k`: `215.763 ms` to `186.986 ms`, a `13.3%` reduction. Most remaining time is lazy scalar serde/materialization.
+- `author_existing_no_overwrite` at `100k`: `156.538 ms` to `109.782 ms`, a `29.9%` reduction. Incremental duplicate hydrate cost dropped from `54.176 ms` to `26.830 ms`, a `50.5%` reduction.
+- `author_existing_overwrite_cold_data` at `100k`: `238.585 ms` to `144.013 ms`, a `39.6%` reduction. Incremental overwrite cost dropped from `136.223 ms` to `61.061 ms`, a `55.2%` reduction.
+- `author_existing_overwrite_warm_data` at `100k`: `388.272 ms` to `307.113 ms`, a `20.9%` reduction. Incremental warm overwrite cost dropped from `172.509 ms` to `120.127 ms`, a `30.7%` reduction.
+- `task_sti_fresh_register` at `100k`: `118.582 ms` to `88.207 ms`, a `25.6%` reduction. STI overhead over non-inheritance fresh hydration dropped from `16.220 ms` to `5.255 ms`.

--- a/packages/tests/integration/benchmark-hydration-registration.ts
+++ b/packages/tests/integration/benchmark-hydration-registration.ts
@@ -1,0 +1,325 @@
+import { setDefaultEntityLimit, type Entity } from "joist-orm";
+import { performance } from "node:perf_hooks";
+import { Author, Task, type EntityManager } from "./src/entities";
+import { newEntityManager, testDriver } from "./src/testEm";
+
+type Row = Record<string, unknown>;
+
+interface ScenarioResult {
+  checksum: number;
+  em: EntityManager;
+  entities: Entity[];
+}
+
+interface Scenario {
+  name: string;
+  run(rows: readonly Row[]): ScenarioResult;
+}
+
+interface Sample {
+  cpuMs: number;
+  heapDeltaMb: number;
+  wallMs: number;
+}
+
+interface Summary {
+  cpuMeanMs: number;
+  heapMeanMb: number;
+  maxMs: number;
+  meanMs: number;
+  minMs: number;
+  p50Ms: number;
+  p90Ms: number;
+  p99Ms: number;
+  rsd: number;
+}
+
+interface BenchmarkConfig {
+  iterations: number;
+  size: number;
+  warmups: number;
+}
+
+let blackhole = 0;
+let heldResult: ScenarioResult | undefined;
+const graduated = new Date("2020-01-01T00:00:00.000Z");
+const createdAt = new Date("2020-01-01T00:00:00.000Z");
+const updatedAt = new Date("2020-01-02T00:00:00.000Z");
+
+/** Benchmarks EntityManager.hydrate registration and existing-entity overwrite paths. */
+async function main(): Promise<void> {
+  const sizes = readSizes();
+  setDefaultEntityLimit(Math.max(...sizes) + 1_000);
+  console.log(`node=${process.version} exposeGc=${typeof global.gc === "function"}`);
+  console.log("scenario,size,iterations,mean_ms,p50_ms,p90_ms,p99_ms,min_ms,max_ms,rsd,cpu_mean_ms,heap_delta_mb");
+
+  for (const size of sizes) {
+    const authorRows = makeAuthorRows(size);
+    const taskRows = makeTaskRows(size);
+    const config = configForSize(size);
+    await runScenario(authorFreshRegister(), authorRows, config);
+    await runScenario(authorFreshWithScalarReads(), authorRows, config);
+    await runScenario(authorExistingNoOverwrite(), authorRows, config);
+    await runScenario(authorExistingOverwriteColdData(), authorRows, config);
+    await runScenario(authorExistingOverwriteWarmData(), authorRows, config);
+    await runScenario(taskStiFreshRegister(), taskRows, config);
+  }
+
+  // Prevent overly-aggressive dead-code elimination in alternate JS runtimes.
+  if (blackhole === Number.MIN_SAFE_INTEGER) console.log(blackhole);
+  await testDriver.destroy();
+}
+
+/** Returns the sizes to benchmark, allowing BENCH_SIZES=10000,50000 overrides. */
+function readSizes(): number[] {
+  const input = process.env.BENCH_SIZES;
+  if (!input) return [10_000, 50_000, 100_000];
+  return input.split(",").map((value) => Number(value.trim()));
+}
+
+/** Returns iteration counts that keep 100k-entity runs high signal but practical. */
+function configForSize(size: number): BenchmarkConfig {
+  if (size >= 100_000) return { iterations: 8, size, warmups: 3 };
+  if (size >= 50_000) return { iterations: 10, size, warmups: 4 };
+  return { iterations: 18, size, warmups: 6 };
+}
+
+/** Measures one scenario after warmup and prints a CSV row. */
+async function runScenario(scenario: Scenario, rows: readonly Row[], config: BenchmarkConfig): Promise<void> {
+  for (let i = 0; i < config.warmups; i++) {
+    consume(scenario.run(rows));
+    forceGc();
+  }
+
+  const samples: Sample[] = [];
+  for (let i = 0; i < config.iterations; i++) {
+    forceGc();
+    const heapBefore = process.memoryUsage().heapUsed;
+    const cpuBefore = process.cpuUsage();
+    const start = performance.now();
+    heldResult = scenario.run(rows);
+    const wallMs = performance.now() - start;
+    const cpu = process.cpuUsage(cpuBefore);
+    forceGc();
+    const heapAfter = process.memoryUsage().heapUsed;
+    consume(heldResult);
+    heldResult = undefined;
+    samples.push({
+      cpuMs: (cpu.user + cpu.system) / 1_000,
+      heapDeltaMb: (heapAfter - heapBefore) / 1024 / 1024,
+      wallMs,
+    });
+    forceGc();
+    await new Promise<void>(resolveImmediate);
+  }
+
+  const summary = summarize(samples);
+  console.log(
+    [
+      scenario.name,
+      config.size,
+      config.iterations,
+      fmt(summary.meanMs),
+      fmt(summary.p50Ms),
+      fmt(summary.p90Ms),
+      fmt(summary.p99Ms),
+      fmt(summary.minMs),
+      fmt(summary.maxMs),
+      fmt(summary.rsd),
+      fmt(summary.cpuMeanMs),
+      fmt(summary.heapMeanMb),
+    ].join(","),
+  );
+}
+
+/** Hydrates Authors into a fresh EntityManager without touching scalar fields. */
+function authorFreshRegister(): Scenario {
+  return {
+    name: "author_fresh_register",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      const entities = em.hydrate(Author, rows);
+      return { checksum: entities.length, em, entities };
+    },
+  };
+}
+
+/** Hydrates Authors and lazily reads common scalar fields. */
+function authorFreshWithScalarReads(): Scenario {
+  return {
+    name: "author_fresh_register_scalar_reads",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      const entities = em.hydrate(Author, rows);
+      const checksum = readAuthorScalars(entities);
+      return { checksum, em, entities };
+    },
+  };
+}
+
+/** Hydrates duplicate Author rows without overwriting existing entities. */
+function authorExistingNoOverwrite(): Scenario {
+  return {
+    name: "author_existing_no_overwrite",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      em.hydrate(Author, rows);
+      const entities = em.hydrate(Author, rows, { overwriteExisting: false });
+      return { checksum: entities.length, em, entities };
+    },
+  };
+}
+
+/** Hydrates duplicate Author rows with overwriteExisting but no hydrated scalar data. */
+function authorExistingOverwriteColdData(): Scenario {
+  return {
+    name: "author_existing_overwrite_cold_data",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      em.hydrate(Author, rows);
+      const entities = em.hydrate(Author, rows, { overwriteExisting: true });
+      return { checksum: entities.length, em, entities };
+    },
+  };
+}
+
+/** Hydrates duplicate Author rows with overwriteExisting after scalar fields are in InstanceData.data. */
+function authorExistingOverwriteWarmData(): Scenario {
+  return {
+    name: "author_existing_overwrite_warm_data",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      const before = em.hydrate(Author, rows);
+      const checksum = readAuthorScalars(before);
+      const entities = em.hydrate(Author, rows, { overwriteExisting: true });
+      return { checksum: checksum + entities.length, em, entities };
+    },
+  };
+}
+
+/** Hydrates STI Task rows into TaskOld/TaskNew subtypes. */
+function taskStiFreshRegister(): Scenario {
+  return {
+    name: "task_sti_fresh_register",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      const entities = em.hydrate(Task, rows);
+      return { checksum: entities.length, em, entities };
+    },
+  };
+}
+
+/** Creates Author rows with enough columns to exercise scalar serde after reads. */
+function makeAuthorRows(size: number): Row[] {
+  const rows = new Array<Row>(size);
+  for (let i = 0; i < size; i++) {
+    rows[i] = {
+      id: i + 1,
+      first_name: `first${i}`,
+      last_name: `last${i}`,
+      ssn: `ssn${i}`,
+      initials: "fl",
+      number_of_books: i % 17,
+      is_popular: i % 2 === 0,
+      age: 20 + (i % 60),
+      graduated,
+      nick_names: [`nick${i}`],
+      is_funny: i % 3 === 0,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    };
+  }
+  return rows;
+}
+
+/** Creates alternating TaskOld/TaskNew STI rows. */
+function makeTaskRows(size: number): Row[] {
+  const rows = new Array<Row>(size);
+  for (let i = 0; i < size; i++) {
+    rows[i] = {
+      id: i + 1,
+      duration_in_days: 1 + (i % 30),
+      type_id: i % 2 === 0 ? 1 : 2,
+      special_old_field: i,
+      special_new_field: i,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    };
+  }
+  return rows;
+}
+
+/** Reads Author scalars that are common in find/list hot paths. */
+function readAuthorScalars(entities: readonly Author[]): number {
+  let checksum = 0;
+  for (const author of entities) {
+    checksum += author.id.length;
+    checksum += author.firstName.length;
+    checksum += author.lastName?.length ?? 0;
+    checksum += author.age ?? 0;
+    checksum += author.isFunny ? 1 : 0;
+    checksum += author.graduated?.getTime() ?? 0;
+    checksum += author.nickNames?.length ?? 0;
+  }
+  return checksum;
+}
+
+/** Summarizes benchmark samples. */
+function summarize(samples: Sample[]): Summary {
+  const wall = samples.map((sample) => sample.wallMs).sort((a, b) => a - b);
+  const meanMs = mean(wall);
+  return {
+    cpuMeanMs: mean(samples.map((sample) => sample.cpuMs)),
+    heapMeanMb: mean(samples.map((sample) => sample.heapDeltaMb)),
+    maxMs: wall[wall.length - 1],
+    meanMs,
+    minMs: wall[0],
+    p50Ms: percentile(wall, 0.5),
+    p90Ms: percentile(wall, 0.9),
+    p99Ms: percentile(wall, 0.99),
+    rsd: standardDeviation(wall, meanMs) / meanMs,
+  };
+}
+
+/** Returns the arithmetic mean. */
+function mean(values: readonly number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+/** Returns the nearest-rank percentile. */
+function percentile(sortedValues: readonly number[], p: number): number {
+  const index = Math.min(sortedValues.length - 1, Math.max(0, Math.ceil(sortedValues.length * p) - 1));
+  return sortedValues[index];
+}
+
+/** Returns the population standard deviation. */
+function standardDeviation(values: readonly number[], meanValue: number): number {
+  const variance = mean(values.map((value) => (value - meanValue) ** 2));
+  return Math.sqrt(variance);
+}
+
+/** Keeps benchmark results observable until after retained heap is measured. */
+function consume(result: ScenarioResult): void {
+  blackhole += result.checksum + result.em.numberOfEntities + result.entities.length;
+}
+
+/** Runs a full GC when node was started with --expose-gc. */
+function forceGc(): void {
+  global.gc?.();
+}
+
+/** Resolves on the next immediate tick. */
+function resolveImmediate(resolve: () => void): void {
+  setImmediate(resolve);
+}
+
+/** Formats numeric CSV fields. */
+function fmt(value: number): string {
+  return value.toFixed(3);
+}
+
+main().catch(async (error: unknown) => {
+  console.error(error);
+  await testDriver.destroy();
+  process.exitCode = 1;
+});


### PR DESCRIPTION
- Fresh 100k Author hydrate/register improved from 102.362 ms to 82.952 ms, about 19.0% faster.
- Duplicate 100k hydrate without overwrite improved from 156.538 ms to 109.782 ms, about 29.9% faster.
- Incremental duplicate hydrate lookup cost dropped from 54.176 ms to 26.830 ms, about 50.5% faster.
- 100k overwriteExisting cold-data hydrate improved from 238.585 ms to 144.013 ms, about 39.6% faster.
- 100k STI fresh hydrate improved from 118.582 ms to 88.207 ms, about 25.6% faster.