### PR TITLE
perf: Optimize identity-map loadAll paths

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1201,34 +1201,56 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     hint?: any,
   ): Promise<T[]> {
     const meta = getMetadata(type);
-    const ids = _ids.map((id) => tagId(meta, id));
-    const idsToLoad = ids.filter((id) => !this.findExistingInstance(id));
-    if (idsToLoad.length > 0) {
+
+    // Use pre-allocated arrays/for loops instead of `.filter`s since this can be a hot spot
+    const ids = new Array<string>(_ids.length);
+    const entities = new Array<T | undefined>(_ids.length);
+    let idsToLoad: string[] | undefined;
+    let positionsToLoad: number[] | undefined;
+
+    for (let i = 0; i < _ids.length; i++) {
+      const id = tagId(meta, _ids[i]);
+      ids[i] = id;
+      const entity = this.findExistingInstance<T>(id);
+      if (entity) {
+        entities[i] = entity;
+      } else {
+        (idsToLoad ??= []).push(id);
+        (positionsToLoad ??= []).push(i);
+      }
+    }
+
+    if (idsToLoad && idsToLoad.length > 0) {
       await loadBatchLoader(this, meta)
         .loadAll(idsToLoad.map((id) => ({ taggedId: id, hint })))
         .catch(function loadAll(err) {
           throw appendStack(err, new Error());
         });
+      for (const i of positionsToLoad!) {
+        entities[i] = this.findExistingInstance<T>(ids[i]);
+      }
     }
-    const entities: T[] = [];
-    for (const id of ids) {
-      const entity = this.findExistingInstance(id);
-      if (entity) entities.push(entity as T);
+
+    let idsNotFound: string[] | undefined;
+    for (let i = 0; i < entities.length; i++) {
+      if (entities[i] === undefined) {
+        (idsNotFound ??= []).push(ids[i]);
+      }
     }
-    if (entities.length !== ids.length) {
-      const idsNotFound = ids.filter((_, i) => entities[i] === undefined);
+    if (idsNotFound) {
       throw new NotFoundError(`${idsNotFound.join(",")} were not found`);
     }
+    const loadedEntities = entities as T[];
     if (hint) {
-      await this.populate(entities as T[], hint);
+      await this.populate(loadedEntities, hint);
     }
     if (meta.inheritanceType === "sti" && meta.baseType) {
-      const wrongType = entities.filter((e) => !(e instanceof meta.cstr));
+      const wrongType = loadedEntities.filter((e) => !(e instanceof meta.cstr));
       if (wrongType.length > 0) {
         throw new Error(`${wrongType.join(", ")} were not of type ${meta.cstr.name}`);
       }
     }
-    return entities as T[];
+    return loadedEntities;
   }
 
   /**
@@ -1247,20 +1269,41 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     hint?: any,
   ): Promise<T[]> {
     const meta = getMetadata(type);
-    const ids = _ids.map((id) => tagId(meta, id));
-    const idsToLoad = ids.filter((id) => !this.findExistingInstance(id));
-    if (idsToLoad.length > 0) {
+
+    // Use pre-allocated arrays/for loops instead of `.filter`s since this can be a hot spot
+    const ids = new Array<string>(_ids.length);
+    const entities: T[] = [];
+    let idsToLoad: string[] | undefined;
+
+    // Ensure the ids are tagged, and find any not-yet-loaded
+    for (let i = 0; i < _ids.length; i++) {
+      const id = tagId(meta, _ids[i]);
+      ids[i] = id;
+      const entity = this.findExistingInstance<T>(id);
+      if (entity) {
+        entities.push(entity);
+      } else {
+        (idsToLoad ??= []).push(id);
+      }
+    }
+
+    if (idsToLoad && idsToLoad.length > 0) {
       await loadBatchLoader(this, meta)
         .loadAll(idsToLoad.map((id) => ({ taggedId: id, hint })))
         .catch(function loadAllIfExists(err) {
           throw appendStack(err, new Error());
         });
+      // Now that everything is loaded, recalc `entities`
+      entities.length = 0;
+      for (const id of ids) {
+        const entity = this.findExistingInstance<T>(id);
+        if (entity) entities.push(entity);
+      }
     }
-    const entities = ids.map((id) => this.findExistingInstance(id)).filter(Boolean);
     if (hint) {
-      await this.populate(entities as T[], hint);
+      await this.populate(entities, hint);
     }
-    return entities as T[];
+    return entities;
   }
 
   /**

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -158,20 +158,22 @@ export function tagId(
   metaOrCstr: HasTagName | EntityConstructor<any>,
   id: string | number | null | undefined,
 ): string | undefined {
+  const tag = tagName(metaOrCstr);
   if (typeof id === "number") {
-    return `${tagName(metaOrCstr)}${tagDelimiter}${id}`;
+    return `${tag}${tagDelimiter}${id}`;
   }
   if (id === null || id === undefined) {
     return undefined;
   }
-  if (id.includes(tagDelimiter)) {
-    const [tag] = id.split(tagDelimiter);
-    if (tag !== tagName(metaOrCstr)) {
-      throw new Error(`Invalid tagged id, expected tag ${tagName(metaOrCstr)}, got ${id}`);
+  // Avoid using includes/split, for a faster indexOf + length + startsWith
+  const delimiterIndex = id.indexOf(tagDelimiter);
+  if (delimiterIndex !== -1) {
+    if (delimiterIndex !== tag.length || !id.startsWith(tag)) {
+      throw new Error(`Invalid tagged id, expected tag ${tag}, got ${id}`);
     }
     return id;
   }
-  return `${tagName(metaOrCstr)}${tagDelimiter}${id}`;
+  return `${tag}${tagDelimiter}${id}`;
 }
 
 /** Adds the tag prefixes. */

--- a/packages/tests/integration/benchmark-loadall-identity-map.ts
+++ b/packages/tests/integration/benchmark-loadall-identity-map.ts
@@ -1,0 +1,299 @@
+import { setDefaultEntityLimit, tagId, type Entity } from "joist-orm";
+import { performance } from "node:perf_hooks";
+import { Author, type EntityManager } from "./src/entities";
+import { newEntityManager, testDriver } from "./src/testEm";
+
+type Row = Record<string, unknown>;
+
+interface ScenarioContext {
+  em: EntityManager;
+  ids: readonly string[];
+}
+
+interface ScenarioResult {
+  checksum: number;
+  em: EntityManager;
+  entities: Entity[];
+}
+
+interface Scenario {
+  name: string;
+  setup(size: number): ScenarioContext;
+  run(context: ScenarioContext): Promise<ScenarioResult>;
+}
+
+interface Sample {
+  cpuMs: number;
+  heapDeltaMb: number;
+  wallMs: number;
+}
+
+interface Summary {
+  cpuMeanMs: number;
+  heapMeanMb: number;
+  maxMs: number;
+  meanMs: number;
+  minMs: number;
+  p50Ms: number;
+  p90Ms: number;
+  p99Ms: number;
+  rsd: number;
+}
+
+interface BenchmarkConfig {
+  iterations: number;
+  size: number;
+  warmups: number;
+}
+
+let blackhole = 0;
+let heldResult: ScenarioResult | undefined;
+const graduated = new Date("2020-01-01T00:00:00.000Z");
+const createdAt = new Date("2020-01-01T00:00:00.000Z");
+const updatedAt = new Date("2020-01-02T00:00:00.000Z");
+
+/** Benchmarks identity-map-only EntityManager.loadAll and loadAllIfExists paths. */
+async function main(): Promise<void> {
+  const sizes = readSizes();
+  setDefaultEntityLimit(Math.max(...sizes) + 1_000);
+  console.log(`node=${process.version} exposeGc=${typeof global.gc === "function"}`);
+  console.log("scenario,size,iterations,mean_ms,p50_ms,p90_ms,p99_ms,min_ms,max_ms,rsd,cpu_mean_ms,heap_delta_mb");
+
+  for (const size of sizes) {
+    const config = configForSize(size);
+    await runScenario(loadAllUntaggedHits(), config);
+    await runScenario(loadAllTaggedHits(), config);
+    await runScenario(loadAllIfExistsUntaggedHits(), config);
+    await runScenario(loadAllIfExistsTaggedHits(), config);
+  }
+
+  // Prevent overly-aggressive dead-code elimination in alternate JS runtimes.
+  if (blackhole === Number.MIN_SAFE_INTEGER) console.log(blackhole);
+  await testDriver.destroy();
+}
+
+/** Returns the sizes to benchmark, allowing BENCH_SIZES=10000,50000 overrides. */
+function readSizes(): number[] {
+  const input = process.env.BENCH_SIZES;
+  if (!input) return [10_000, 50_000, 100_000];
+  return input.split(",").map((value) => Number(value.trim()));
+}
+
+/** Returns iteration counts that keep 100k-entity runs high signal but practical. */
+function configForSize(size: number): BenchmarkConfig {
+  if (size >= 100_000) return { iterations: 12, size, warmups: 6 };
+  if (size >= 50_000) return { iterations: 18, size, warmups: 8 };
+  return { iterations: 40, size, warmups: 12 };
+}
+
+/** Measures one scenario after warmup and prints a CSV row. */
+async function runScenario(scenario: Scenario, config: BenchmarkConfig): Promise<void> {
+  const context = scenario.setup(config.size);
+  for (let i = 0; i < config.warmups; i++) {
+    consume(await scenario.run(context));
+    forceGc();
+  }
+
+  const samples: Sample[] = [];
+  for (let i = 0; i < config.iterations; i++) {
+    forceGc();
+    const heapBefore = process.memoryUsage().heapUsed;
+    const cpuBefore = process.cpuUsage();
+    const start = performance.now();
+    heldResult = await scenario.run(context);
+    const wallMs = performance.now() - start;
+    const cpu = process.cpuUsage(cpuBefore);
+    forceGc();
+    const heapAfter = process.memoryUsage().heapUsed;
+    consume(heldResult);
+    heldResult = undefined;
+    samples.push({
+      cpuMs: (cpu.user + cpu.system) / 1_000,
+      heapDeltaMb: (heapAfter - heapBefore) / 1024 / 1024,
+      wallMs,
+    });
+    forceGc();
+    await new Promise<void>(resolveImmediate);
+  }
+
+  const summary = summarize(samples);
+  console.log(
+    [
+      scenario.name,
+      config.size,
+      config.iterations,
+      fmt(summary.meanMs),
+      fmt(summary.p50Ms),
+      fmt(summary.p90Ms),
+      fmt(summary.p99Ms),
+      fmt(summary.minMs),
+      fmt(summary.maxMs),
+      fmt(summary.rsd),
+      fmt(summary.cpuMeanMs),
+      fmt(summary.heapMeanMb),
+    ].join(","),
+  );
+}
+
+/** Loads already-hydrated Authors by untagged ids with loadAll. */
+function loadAllUntaggedHits(): Scenario {
+  return {
+    name: "load_all_hits_untagged",
+    setup: setupUntagged,
+    async run(context: ScenarioContext): Promise<ScenarioResult> {
+      const entities = await context.em.loadAll(Author, context.ids);
+      return { checksum: checksum(entities), em: context.em, entities };
+    },
+  };
+}
+
+/** Loads already-hydrated Authors by tagged ids with loadAll. */
+function loadAllTaggedHits(): Scenario {
+  return {
+    name: "load_all_hits_tagged",
+    setup: setupTagged,
+    async run(context: ScenarioContext): Promise<ScenarioResult> {
+      const entities = await context.em.loadAll(Author, context.ids);
+      return { checksum: checksum(entities), em: context.em, entities };
+    },
+  };
+}
+
+/** Loads already-hydrated Authors by untagged ids with loadAllIfExists. */
+function loadAllIfExistsUntaggedHits(): Scenario {
+  return {
+    name: "load_all_if_exists_hits_untagged",
+    setup: setupUntagged,
+    async run(context: ScenarioContext): Promise<ScenarioResult> {
+      const entities = await context.em.loadAllIfExists(Author, context.ids);
+      return { checksum: checksum(entities), em: context.em, entities };
+    },
+  };
+}
+
+/** Loads already-hydrated Authors by tagged ids with loadAllIfExists. */
+function loadAllIfExistsTaggedHits(): Scenario {
+  return {
+    name: "load_all_if_exists_hits_tagged",
+    setup: setupTagged,
+    async run(context: ScenarioContext): Promise<ScenarioResult> {
+      const entities = await context.em.loadAllIfExists(Author, context.ids);
+      return { checksum: checksum(entities), em: context.em, entities };
+    },
+  };
+}
+
+/** Creates an EntityManager and untagged ids for the all-hit identity-map benchmark. */
+function setupUntagged(size: number): ScenarioContext {
+  const em = newEntityManager();
+  em.hydrate(Author, makeAuthorRows(size));
+  return { em, ids: makeIds(size, false) };
+}
+
+/** Creates an EntityManager and tagged ids for the all-hit identity-map benchmark. */
+function setupTagged(size: number): ScenarioContext {
+  const em = newEntityManager();
+  em.hydrate(Author, makeAuthorRows(size));
+  return { em, ids: makeIds(size, true) };
+}
+
+/** Creates Author rows with only columns needed for registration. */
+function makeAuthorRows(size: number): Row[] {
+  const rows = new Array<Row>(size);
+  for (let i = 0; i < size; i++) {
+    rows[i] = {
+      id: i + 1,
+      first_name: `first${i}`,
+      last_name: `last${i}`,
+      ssn: `ssn${i}`,
+      initials: "fl",
+      number_of_books: i % 17,
+      is_popular: i % 2 === 0,
+      age: 20 + (i % 60),
+      graduated,
+      nick_names: [`nick${i}`],
+      is_funny: i % 3 === 0,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    };
+  }
+  return rows;
+}
+
+/** Creates ids in sequential order, optionally pre-tagged. */
+function makeIds(size: number, tagged: boolean): string[] {
+  const ids = new Array<string>(size);
+  for (let i = 0; i < size; i++) {
+    ids[i] = tagged ? tagId(Author, i + 1) : `${i + 1}`;
+  }
+  return ids;
+}
+
+/** Reads stable ids so the result array remains observable. */
+function checksum(entities: readonly Author[]): number {
+  let sum = 0;
+  for (const entity of entities) {
+    sum += entity.id.length;
+  }
+  return sum;
+}
+
+/** Summarizes benchmark samples. */
+function summarize(samples: Sample[]): Summary {
+  const wall = samples.map((sample) => sample.wallMs).sort((a, b) => a - b);
+  const meanMs = mean(wall);
+  return {
+    cpuMeanMs: mean(samples.map((sample) => sample.cpuMs)),
+    heapMeanMb: mean(samples.map((sample) => sample.heapDeltaMb)),
+    maxMs: wall[wall.length - 1],
+    meanMs,
+    minMs: wall[0],
+    p50Ms: percentile(wall, 0.5),
+    p90Ms: percentile(wall, 0.9),
+    p99Ms: percentile(wall, 0.99),
+    rsd: standardDeviation(wall, meanMs) / meanMs,
+  };
+}
+
+/** Returns the arithmetic mean. */
+function mean(values: readonly number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+/** Returns the nearest-rank percentile. */
+function percentile(sortedValues: readonly number[], p: number): number {
+  const index = Math.min(sortedValues.length - 1, Math.max(0, Math.ceil(sortedValues.length * p) - 1));
+  return sortedValues[index];
+}
+
+/** Returns the population standard deviation. */
+function standardDeviation(values: readonly number[], meanValue: number): number {
+  const variance = mean(values.map((value) => (value - meanValue) ** 2));
+  return Math.sqrt(variance);
+}
+
+/** Keeps benchmark results observable until after retained heap is measured. */
+function consume(result: ScenarioResult): void {
+  blackhole += result.checksum + result.em.numberOfEntities + result.entities.length;
+}
+
+/** Runs a full GC when node was started with --expose-gc. */
+function forceGc(): void {
+  global.gc?.();
+}
+
+/** Resolves on the next immediate tick. */
+function resolveImmediate(resolve: () => void): void {
+  setImmediate(resolve);
+}
+
+/** Formats numeric CSV fields. */
+function fmt(value: number): string {
+  return value.toFixed(3);
+}
+
+main().catch(async (error: unknown) => {
+  console.error(error);
+  await testDriver.destroy();
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Benchmarked scenarios from packages/tests/integration/benchmark-loadall-identity-map.ts:
- load_all_hits_untagged
- load_all_hits_tagged
- load_all_if_exists_hits_untagged
- load_all_if_exists_hits_tagged

100k results, baseline vs final average of 3 independent final runs:
- load_all_hits_untagged: baseline 20.856ms, final avg 15.859ms, 24% faster
- load_all_hits_tagged: baseline 22.883ms, final avg 14.351ms, 37% faster
- load_all_if_exists_hits_untagged: baseline 20.440ms, final avg 17.288ms, 15% faster
- load_all_if_exists_hits_tagged: baseline 23.065ms, final avg 15.818ms, 31% faster

Validation:
- yarn tsc --noEmit
- yarn jest -- EntityManager.test.ts --runInBand
- yarn jest -- taggedIds.test.ts --runInBand