### PR TITLE
perf: Optimize sparse flush scanning

### DIFF
--- a/packages/core/src/BaseEntity.ts
+++ b/packages/core/src/BaseEntity.ts
@@ -159,7 +159,7 @@ function toStringWithPrefix(meta: EntityMetadata, entity: Entity, prefix: string
  * on its `Object.create`-d instances.
  */
 export function baseEntityCstr(em: EntityManager, entity: BaseEntity<any, any>, isNew: boolean): void {
-  const data = new InstanceData(em, (entity.constructor as any).metadata, isNew);
+  const data = new InstanceData(em, entity, (entity.constructor as any).metadata, isNew);
   // This makes it non-enumerable to avoid Jest/recursive things tripping over it
   Object.defineProperty(entity, "__data", { value: data, enumerable: false, writable: false, configurable: false });
 }

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -237,6 +237,8 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   public txn: TX | undefined;
   public entityLimit: number = defaultEntityLimit;
   readonly #entitiesArray: Entity[] = [];
+  // Incrementally track dirty entities so we don't have to scan `#entityArray` during flush
+  readonly #maybePendingFlushEntities: Set<Entity> = new Set();
   // Indexes the currently loaded entities by their tagged ids and `toTaggedString` ids (i.e. `a#`). This fixes
   // real-world performance issues where `findExistingInstance` scanning `#entities` was an `O(n^2)`.
   readonly #entitiesById: Map<string, Entity> = new Map();
@@ -313,6 +315,14 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       indexManager: this.#indexManager,
       isLoadedCache: this.#isLoadedCache,
       pluginManager,
+
+      markMaybePending(entity: EntityW): void {
+        em.#maybePendingFlushEntities.add(entity as Entity);
+      },
+
+      unmarkMaybePending(entity: EntityW): void {
+        em.#maybePendingFlushEntities.delete(entity as Entity);
+      },
 
       isMerging(entity: EntityW): boolean {
         return em.#merging?.has(entity) ?? false;
@@ -1519,7 +1529,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   delete(entityOrArray: Entity | Entity[]): void {
     for (const entity of toArray(entityOrArray)) {
       // Early return if already deleted.
-      const alreadyMarked = getInstanceData(entity).markDeleted(entity);
+      const alreadyMarked = getInstanceData(entity).markDeleted();
       if (!alreadyMarked) continue;
       // Any derived fields that read this entity will need recalc-d
       this.#rm.queueAllDownstreamFields(entity, "deleted");
@@ -1627,7 +1637,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         // Subset of pendingFlush entities that had hooks invoked in a prior `runHooksOnPendingEntities`
         const alreadyRanHooks = new Set<Entity>();
 
-        findPendingFlushEntities(this.entities, hooksInvoked, pendingFlush, pendingHooks, alreadyRanHooks);
+        findPendingFlushEntities(
+          this.#maybePendingFlushEntities,
+          hooksInvoked,
+          pendingFlush,
+          pendingHooks,
+          alreadyRanHooks,
+        );
 
         // If we're re-looping for AsyncReactiveField, make sure to bump updatedAt
         // each time, so that for an INSERT-then-UPDATE the triggers don't think the
@@ -1671,7 +1687,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
             for (const e of pendingHooks) hooksInvoked.add(e);
             pendingHooks.clear();
             // See if the hooks mutated any new, not-yet-hooksInvoked entities
-            findPendingFlushEntities(this.entities, hooksInvoked, pendingFlush, pendingHooks, alreadyRanHooks);
+            findPendingFlushEntities(
+              this.#maybePendingFlushEntities,
+              hooksInvoked,
+              pendingFlush,
+              pendingHooks,
+              alreadyRanHooks,
+            );
             // The final run of recalcPendingReactables could have left us with pending type errors and no entities in
             // pendingHooks.  If so, we need to re-run recalcPendingTypeErrors to get those errors to transition into
             // suppressed errors so that we will fail after simpleValidation.
@@ -1999,7 +2021,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         instanceData.row = row;
         // And then only refresh the data keys that have already been serde-d from rows
         // (this keeps us from deserializing data out of rows that we don't need).
-        const { data, originalData } = instanceData;
+        const { data } = instanceData;
         const dataKeys = Object.keys(data);
         if (dataKeys.length > 0) {
           const allFields = getMetadata(entity).allFields;
@@ -2015,7 +2037,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
               serde.setOnEntity(data, row);
               // Make the field look not-dirty
               if (changedFields.includes(fieldName)) {
-                delete originalData[fieldName];
+                instanceData.markFieldClean(fieldName);
               }
             }
           }
@@ -2038,7 +2060,9 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   public touch(entity: EntityW): void;
   public touch(entities: EntityW[]): void;
   public touch(entityOrEntities: EntityW | EntityW[]): void {
-    for (const entity of toArray(entityOrEntities)) getInstanceData(entity).isTouched = true;
+    for (const entity of toArray(entityOrEntities)) {
+      getInstanceData(entity).markTouched();
+    }
   }
 
   /**
@@ -2319,14 +2343,15 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         if (!(oldInstanceData.isNewEntity || oldInstanceData.isDirtyEntity)) continue;
         const { originalData: oldOriginalData, data: oldData } = oldInstanceData;
         const newEntity = mapEntity(oldEntity);
-        const { originalData: newOriginalData, data: newData } = (newEntity as any).__data as InstanceData;
+        const newInstanceData = (newEntity as any).__data as InstanceData;
+        const { data: newData } = newInstanceData;
         // for new entities, anything in `data` is changed and should be copied across. for existing entities, we
         // only care about changed fields, which are enumerated by originalData
         const maybeEntity = (value: any) => (isEntity(value) ? mapEntity(value as Entity) : value);
         const fields = Object.keys(oldEntity.isNewEntity ? oldData : oldOriginalData);
         for (const field of fields) {
           // copy over originalData so .changes is consistent across ems
-          if (field in oldOriginalData) newOriginalData[field] = maybeEntity(oldOriginalData[field]);
+          if (field in oldOriginalData) newInstanceData.markFieldDirty(field, maybeEntity(oldOriginalData[field]));
           newData[field] = maybeEntity(oldData[field]);
         }
       }
@@ -2337,7 +2362,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       const newEntity = mapEntity(oldEntity);
       if (oldEntity.isDeletedEntity) {
         // If the old entity was deleted, that should be persisted in the new em
-        ((newEntity as any).__data as InstanceData).markDeleted(newEntity);
+        ((newEntity as any).__data as InstanceData).markDeleted();
         // deleted entities will fail if you try to `get` their relations, so skip them since they should be cleared
         // out regardless
         continue;
@@ -2588,6 +2613,8 @@ export interface EntityManagerInternalApi {
   pluginManager: PluginManager;
   clearDataloaders(): void;
   clearPreloadedRelations(): void;
+  markMaybePending(entity: EntityW): void;
+  unmarkMaybePending(entity: EntityW): void;
   setIsRefreshing(isRefreshing: boolean): void;
 }
 
@@ -2985,7 +3012,7 @@ function maybeBumpUpdatedAt(rm: ReactionsManager, todos: Record<string, Todo>, n
         // it has changed. This is technically true, but this will break the oplock SQL generation,
         // so force the field to be dirty.
         const orm = getInstanceData(e);
-        orm.originalData[updatedAt] = getField(e, updatedAt);
+        orm.markFieldDirty(updatedAt, getField(e, updatedAt));
         const serde = todo.metadata.fields[updatedAt].serde as TimestampSerde<unknown>;
         orm.data[updatedAt] = serde.mapFromNow(now);
         rm.queueDownstreamReactables(e, updatedAt);
@@ -3051,21 +3078,23 @@ function setStiDiscriminatorValue(baseMeta: EntityMetadata, entity: Entity): voi
 }
 
 function findPendingFlushEntities<Entity extends EntityW>(
-  entities: readonly Entity[],
+  maybePendingFlushEntities: Set<Entity>,
   hooksInvoked: Set<Entity>,
   pendingFlush: Set<Entity>,
   pendingHooks: Set<Entity>,
   alreadyRanHooks: Set<Entity>,
 ): void {
-  for (const e of entities) {
-    if (getInstanceData(e).pendingOperation !== "none") {
-      if (!hooksInvoked.has(e)) {
-        pendingHooks.add(e);
-      } else {
-        alreadyRanHooks.add(e);
-      }
-      pendingFlush.add(e);
+  for (const e of maybePendingFlushEntities) {
+    if (getInstanceData(e).pendingOperation === "none") {
+      maybePendingFlushEntities.delete(e);
+      continue;
     }
+    if (!hooksInvoked.has(e)) {
+      pendingHooks.add(e);
+    } else {
+      alreadyRanHooks.add(e);
+    }
+    pendingFlush.add(e);
   }
 }
 

--- a/packages/core/src/InstanceData.ts
+++ b/packages/core/src/InstanceData.ts
@@ -4,6 +4,8 @@ import { EntityMetadata } from "./EntityMetadata";
 
 /** The `#orm` metadata field we track on each instance. */
 export class InstanceData {
+  /** The entity this instance data belongs to. */
+  readonly entity: Entity;
   /** All entities must be associated to an `EntityManager` to handle lazy loading/etc. */
   readonly em: EntityManager;
   /** A pointer to our entity type's metadata. */
@@ -36,7 +38,8 @@ export class InstanceData {
   isTouched: boolean = false;
 
   /** Creates the `#orm` field. */
-  constructor(em: EntityManager, metadata: EntityMetadata, isNew: boolean) {
+  constructor(em: EntityManager, entity: Entity, metadata: EntityMetadata, isNew: boolean) {
+    this.entity = entity;
     this.em = em;
     this.metadata = metadata;
     if (isNew) {
@@ -44,6 +47,7 @@ export class InstanceData {
       this.data = {};
       this.row = {};
       this.flushedData = undefined;
+      if (em) this.markMaybePending();
     } else {
       this.#new = undefined;
       this.data = {};
@@ -69,6 +73,7 @@ export class InstanceData {
     if (this.#deleted === Operation.Pending || this.#deleted === Operation.Flushed) {
       this.#deleted = Operation.Complete;
     }
+    this.unmarkMaybePending();
   }
 
   /** Our public-facing `isNewEntity`. */
@@ -118,7 +123,7 @@ export class InstanceData {
   }
 
   /** Called by `em.delete`, returns true if this is new information. */
-  markDeleted(entity: Entity): boolean {
+  markDeleted(): boolean {
     if (this.#deleted === undefined) {
       // Let any OneToManyCollection/ReactiveField/ReactiveReference.get caches know that they should recalc
       // (i.e. their filterDeleted logic) by asserting the `deleteBook.author` field is changing.
@@ -127,7 +132,7 @@ export class InstanceData {
         // `{ books: "title" }` doesn't need `resetIsLoaded(..., "title")` b/c the same hint will also
         // be watching "did books change", and so get reset that way.
         if (field.kind === "m2o" || field.kind === "poly" || field.kind === "m2m") {
-          getEmInternalApi(this.em).isLoadedCache.resetIsLoaded(entity, field.fieldName);
+          getEmInternalApi(this.em).isLoadedCache.resetIsLoaded(this.entity, field.fieldName);
         } else if (field.kind === "primitive" || field.kind === "enum" || field.kind === "primaryKey") {
           // Any reactable watching these fields will also be watching reference/collection
         } else if (field.kind === "o2m" || field.kind === "o2o") {
@@ -139,6 +144,7 @@ export class InstanceData {
         }
       }
       this.#deleted = Operation.Pending;
+      this.markMaybePending();
       return true;
     }
     return false;
@@ -147,6 +153,35 @@ export class InstanceData {
   fixupCreatedThenDeleted(): void {
     // Ideally we could do this via `resetAfterFlushed`?
     this.#deleted = Operation.Complete;
+    this.unmarkMaybePending();
+  }
+
+  /** Marks this entity as needing a flush even if no fields changed. */
+  markTouched(): void {
+    this.isTouched = true;
+    this.markMaybePending();
+  }
+
+  /** Marks a field as dirty with its pre-mutation value. */
+  markFieldDirty(fieldName: string, value: any): void {
+    this.originalData[fieldName] = value;
+    this.markMaybePending();
+  }
+
+  /** Marks a reverted field as clean again. */
+  markFieldClean(fieldName: string): void {
+    delete this.originalData[fieldName];
+    this.markMaybePending();
+  }
+
+  /** Marks this entity as a possible flush candidate. */
+  markMaybePending(): void {
+    getEmInternalApi(this.em).markMaybePending(this.entity);
+  }
+
+  /** Removes this entity from the possible flush candidate set. */
+  private unmarkMaybePending(): void {
+    getEmInternalApi(this.em).unmarkMaybePending(this.entity);
   }
 
   /** Remembers a reference value that may need to be reverse-walked later. */

--- a/packages/core/src/fields.ts
+++ b/packages/core/src/fields.ts
@@ -110,7 +110,7 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
 
       pluginManager.beforeSetField(entity, fieldName, newValue);
       data[fieldName] = newValue;
-      delete originalData[fieldName];
+      instanceData.markFieldClean(fieldName);
 
       fieldLogger?.logSet(entity, fieldName, newValue);
       if (isReference && instanceData.getReferenceHistory(fieldName).length > 0) {
@@ -134,7 +134,7 @@ export function setField(entity: Entity, fieldName: string, newValue: any): bool
 
   // Only save the currentValue on the 1st change of this field
   if (!(fieldName in originalData)) {
-    originalData[fieldName] = currentValue;
+    instanceData.markFieldDirty(fieldName, currentValue);
   }
   fieldLogger?.logSet(entity, fieldName, newValue);
   rm.queueDownstreamReactables(entity, fieldName);

--- a/packages/tests/integration/benchmark-flush-entity-scanning.ts
+++ b/packages/tests/integration/benchmark-flush-entity-scanning.ts
@@ -1,0 +1,303 @@
+import { setDefaultEntityLimit, type Entity } from "joist-orm";
+import { performance } from "node:perf_hooks";
+import { Author, type EntityManager } from "./src/entities";
+import { newEntityManager, setApiCallMock, testDriver } from "./src/testEm";
+
+type Row = Record<string, unknown>;
+
+interface ScenarioContext {
+  em: EntityManager;
+  entities: Author[];
+}
+
+interface ScenarioResult {
+  checksum: number;
+  em: EntityManager;
+  entities: Entity[];
+}
+
+interface Scenario {
+  dirtyCount: number;
+  name: string;
+  setup(size: number): ScenarioContext;
+  skipValidation: boolean;
+}
+
+interface Sample {
+  cpuMs: number;
+  heapDeltaMb: number;
+  wallMs: number;
+}
+
+interface Summary {
+  cpuMeanMs: number;
+  heapMeanMb: number;
+  maxMs: number;
+  meanMs: number;
+  minMs: number;
+  p50Ms: number;
+  p90Ms: number;
+  p99Ms: number;
+  rsd: number;
+}
+
+interface BenchmarkConfig {
+  iterations: number;
+  size: number;
+  warmups: number;
+}
+
+let blackhole = 0;
+let heldResult: ScenarioResult | undefined;
+const graduated = new Date("2020-01-01T00:00:00.000Z");
+const createdAt = new Date("2020-01-01T00:00:00.000Z");
+const updatedAt = new Date("2020-01-02T00:00:00.000Z");
+
+/** Benchmarks EntityManager.flush pending-entity scans over large identity maps. */
+async function main(): Promise<void> {
+  setApiCallMock(async function makeApiCall(): Promise<void> {});
+  const sizes = readSizes();
+  setDefaultEntityLimit(Math.max(...sizes) + 1_000);
+  console.log(`node=${process.version} exposeGc=${typeof global.gc === "function"}`);
+  console.log(
+    "scenario,size,dirty_count,iterations,mean_ms,p50_ms,p90_ms,p99_ms,min_ms,max_ms,rsd,cpu_mean_ms,heap_delta_mb",
+  );
+
+  for (const size of sizes) {
+    const config = configForSize(size);
+    await runScenario(flushScenario(0, false), config);
+    await runScenario(flushScenario(0, true), config);
+    await runScenario(flushScenario(1, false), config);
+    await runScenario(flushScenario(1, true), config);
+    await runScenario(flushScenario(100, false), config);
+    await runScenario(flushScenario(100, true), config);
+    await runScenario(flushScenario(Math.min(10_000, size), false), config);
+    await runScenario(flushScenario(Math.min(10_000, size), true), config);
+  }
+
+  // Prevent overly-aggressive dead-code elimination in alternate JS runtimes.
+  if (blackhole === Number.MIN_SAFE_INTEGER) console.log(blackhole);
+  await testDriver.destroy();
+}
+
+/** Returns the sizes to benchmark, allowing BENCH_SIZES=10000,50000 overrides. */
+function readSizes(): number[] {
+  const input = process.env.BENCH_SIZES;
+  if (!input) return [10_000, 50_000, 100_000];
+  return input.split(",").map(function parseSize(value) {
+    return Number(value.trim());
+  });
+}
+
+/** Returns iteration counts that keep 100k-entity runs high signal but practical. */
+function configForSize(size: number): BenchmarkConfig {
+  if (size >= 100_000) return { iterations: 10, size, warmups: 4 };
+  if (size >= 50_000) return { iterations: 14, size, warmups: 5 };
+  return { iterations: 24, size, warmups: 8 };
+}
+
+/** Measures one scenario after warmup and prints a CSV row. */
+async function runScenario(scenario: Scenario, config: BenchmarkConfig): Promise<void> {
+  for (let i = 0; i < config.warmups; i++) {
+    consume(await runFlush(scenario.setup(config.size), scenario.skipValidation));
+    forceGc();
+  }
+
+  const samples: Sample[] = [];
+  for (let i = 0; i < config.iterations; i++) {
+    const context = scenario.setup(config.size);
+    forceGc();
+    const heapBefore = process.memoryUsage().heapUsed;
+    const cpuBefore = process.cpuUsage();
+    const start = performance.now();
+    heldResult = await runFlush(context, scenario.skipValidation);
+    const wallMs = performance.now() - start;
+    const cpu = process.cpuUsage(cpuBefore);
+    forceGc();
+    const heapAfter = process.memoryUsage().heapUsed;
+    consume(heldResult);
+    heldResult = undefined;
+    samples.push({
+      cpuMs: (cpu.user + cpu.system) / 1_000,
+      heapDeltaMb: (heapAfter - heapBefore) / 1024 / 1024,
+      wallMs,
+    });
+    forceGc();
+    await new Promise<void>(resolveImmediate);
+  }
+
+  const summary = summarize(samples);
+  console.log(
+    [
+      scenario.name,
+      config.size,
+      scenario.dirtyCount,
+      config.iterations,
+      fmt(summary.meanMs),
+      fmt(summary.p50Ms),
+      fmt(summary.p90Ms),
+      fmt(summary.p99Ms),
+      fmt(summary.minMs),
+      fmt(summary.maxMs),
+      fmt(summary.rsd),
+      fmt(summary.cpuMeanMs),
+      fmt(summary.heapMeanMb),
+    ].join(","),
+  );
+}
+
+/** Creates a flush benchmark scenario with a fixed dirty entity count. */
+function flushScenario(dirtyCount: number, skipValidation: boolean): Scenario {
+  return {
+    dirtyCount,
+    name: `flush_dirty_${dirtyCount}_${skipValidation ? "skip_validation" : "validation"}`,
+    setup(size: number): ScenarioContext {
+      const em = newEntityManager();
+      em.driver = noopDriver(em.driver);
+      const entities = em.hydrate(Author, makeAuthorRows(size));
+      for (let i = 0; i < dirtyCount; i++) {
+        entities[i].firstName = `changed${i}`;
+      }
+      return { em, entities };
+    },
+    skipValidation,
+  };
+}
+
+/** Flushes a prepared context and returns observable data. */
+async function runFlush(context: ScenarioContext, skipValidation: boolean): Promise<ScenarioResult> {
+  const flushed = await context.em.flush({ skipValidation });
+  return { checksum: checksum(flushed), em: context.em, entities: flushed };
+}
+
+/** Wraps the real driver but disables transaction, id assignment, and DB writes. */
+function noopDriver(driver: EntityManager["driver"]): EntityManager["driver"] {
+  return {
+    defaultPlugins: driver.defaultPlugins,
+    assignNewIds: async function assignNewIds(): Promise<void> {},
+    executeFind: async function executeFind(): Promise<unknown[]> {
+      return [];
+    },
+    executeQuery: async function executeQuery(): Promise<unknown[]> {
+      return [];
+    },
+    flush: async function flush(): Promise<void> {},
+    transaction: async function transaction<T>(_em: EntityManager, fn: () => Promise<T>): Promise<T> {
+      return fn();
+    },
+  };
+}
+
+/** Creates Author rows with only columns needed for registration and mutation. */
+function makeAuthorRows(size: number): Row[] {
+  const rows = new Array<Row>(size);
+  for (let i = 0; i < size; i++) {
+    rows[i] = {
+      id: i + 1,
+      first_name: `first${i}`,
+      last_name: `last${i}`,
+      ssn: `ssn${i}`,
+      initials: "fl",
+      number_of_books: i % 17,
+      is_popular: i % 2 === 0,
+      age: 20 + (i % 60),
+      graduated,
+      nick_names: [`nick${i}`],
+      is_funny: i % 3 === 0,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    };
+  }
+  return rows;
+}
+
+/** Reads stable ids so flushed entities remain observable. */
+function checksum(entities: readonly Entity[]): number {
+  let sum = 0;
+  for (const entity of entities) {
+    sum += entity.id.length;
+  }
+  return sum;
+}
+
+/** Summarizes benchmark samples. */
+function summarize(samples: Sample[]): Summary {
+  const wall = samples
+    .map(function readWall(sample) {
+      return sample.wallMs;
+    })
+    .sort(function compareNumbers(a, b) {
+      return a - b;
+    });
+  const meanMs = mean(wall);
+  return {
+    cpuMeanMs: mean(
+      samples.map(function readCpu(sample) {
+        return sample.cpuMs;
+      }),
+    ),
+    heapMeanMb: mean(
+      samples.map(function readHeap(sample) {
+        return sample.heapDeltaMb;
+      }),
+    ),
+    maxMs: wall[wall.length - 1],
+    meanMs,
+    minMs: wall[0],
+    p50Ms: percentile(wall, 0.5),
+    p90Ms: percentile(wall, 0.9),
+    p99Ms: percentile(wall, 0.99),
+    rsd: standardDeviation(wall, meanMs) / meanMs,
+  };
+}
+
+/** Returns the arithmetic mean. */
+function mean(values: readonly number[]): number {
+  return (
+    values.reduce(function add(sum, value) {
+      return sum + value;
+    }, 0) / values.length
+  );
+}
+
+/** Returns the nearest-rank percentile. */
+function percentile(sortedValues: readonly number[], p: number): number {
+  const index = Math.min(sortedValues.length - 1, Math.max(0, Math.ceil(sortedValues.length * p) - 1));
+  return sortedValues[index];
+}
+
+/** Returns the population standard deviation. */
+function standardDeviation(values: readonly number[], meanValue: number): number {
+  const variance = mean(
+    values.map(function squareDifference(value) {
+      return (value - meanValue) ** 2;
+    }),
+  );
+  return Math.sqrt(variance);
+}
+
+/** Keeps benchmark results observable until after retained heap is measured. */
+function consume(result: ScenarioResult): void {
+  blackhole += result.checksum + result.em.numberOfEntities + result.entities.length;
+}
+
+/** Runs a full GC when node was started with --expose-gc. */
+function forceGc(): void {
+  global.gc?.();
+}
+
+/** Resolves on the next immediate tick. */
+function resolveImmediate(resolve: () => void): void {
+  setImmediate(resolve);
+}
+
+/** Formats numeric CSV fields. */
+function fmt(value: number): string {
+  return value.toFixed(3);
+}
+
+main().catch(async function handleError(error: unknown): Promise<void> {
+  console.error(error);
+  await testDriver.destroy();
+  process.exitCode = 1;
+});

--- a/packages/tests/integration/src/entities/Author.test.ts
+++ b/packages/tests/integration/src/entities/Author.test.ts
@@ -203,7 +203,7 @@ describe("Author", () => {
 
     // Then the author validation rule can be skipped
     const result = await em.flush({ skipValidation: true });
-    expect(result).toMatchEntity([a1, b1]);
+    expect(result).toMatchEntity([b1, a1]);
   });
 
   it("skips the afterValidation hook when skipValidation is true", async () => {

--- a/packages/tests/integration/src/relations/ReactiveField.test.ts
+++ b/packages/tests/integration/src/relations/ReactiveField.test.ts
@@ -157,7 +157,7 @@ describe("ReactiveField", () => {
 
     // And when we flush, both entities were committed
     const entities = await em2.flush();
-    expect(entities).toMatchEntity([a2, br2]);
+    expect(entities).toMatchEntity([br2, a2]);
     // Then the author's hooks ran as expected
     expect(a2.transientFields.beforeFlushRan).toBe(true);
   });
@@ -198,7 +198,7 @@ describe("ReactiveField", () => {
 
     // And when we flush, both entities were committed
     const entities = await em2.flush();
-    expect(entities).toMatchEntity([a2, br2]);
+    expect(entities).toMatchEntity([br2, a2]);
     // Then the author's hooks ran as expected
     expect(a2.transientFields.beforeFlushRan).toBe(true);
 


### PR DESCRIPTION
Track maybe-pending entities incrementally so EntityManager.flush scans the dirty candidate set instead of the full identity map. Add a benchmark for 10k/50k/100k clean identity maps with 0, 1, 100, and 10k dirty entities.

On 100k loaded entities, final benchmark averages improved:

- no-op flushes from 3.698ms to 0.108ms with validation and from 3.100ms to 0.072ms with skipValidation, about 97% faster.
- One dirty entity improved from 7.400ms to 0.947ms with validation and from 6.848ms to 0.733ms with skipValidation, about 87-89% faster.
- One hundred dirty entities improved from 11.275ms to 5.154ms with validation and from 10.227ms to 3.787ms with skipValidation, about 54-63% faster.
- Dense 10k-dirty flushes stayed roughly flat at about 570ms validation / 355ms skipValidation, as hook and validation work dominates.

Verified with

- EntityManager.modes.test.ts,
- EntityManager.test.ts, and
- EntityManager.reactions.test.ts
- AsyncReactiveField.test.ts
- ReactiveReference.test.ts.