### PR TITLE
perf: Optimize find filter cache keys

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,10 +23,8 @@
     "joist-utils": "workspace:*"
   },
   "dependencies": {
-    "@types/object-hash": "^3.0.6",
     "ansis": "^4.3.0",
-    "dataloader": "^2.2.3",
-    "object-hash": "^3.0.0"
+    "dataloader": "^2.2.3"
   },
   "devDependencies": {
     "@swc/core": "^1.15.33",

--- a/packages/core/src/dataloaders/fastWhereFilterHash.test.ts
+++ b/packages/core/src/dataloaders/fastWhereFilterHash.test.ts
@@ -1,0 +1,69 @@
+import { fastWhereFilterHash } from "./fastWhereFilterHash";
+
+describe("fastWhereFilterHash", () => {
+  it("returns stable hashes for object keys regardless of insertion order", () => {
+    const first = fastWhereFilterHash({ b: 2, a: "one" });
+    const second = fastWhereFilterHash({ a: "one", b: 2 });
+
+    expect(first).toEqual("o2{1:a=s3:one;1:b=d2;}");
+    expect(second).toEqual(first);
+  });
+
+  it("uses type tags to distinguish similar scalar values", () => {
+    expect([
+      fastWhereFilterHash({ value: "1" }),
+      fastWhereFilterHash({ value: 1 }),
+      fastWhereFilterHash({ value: true }),
+      fastWhereFilterHash({ value: 1n }),
+      fastWhereFilterHash({ value: null }),
+      fastWhereFilterHash({ value: undefined }),
+    ]).toEqual([
+      "o1{5:value=s1:1;}",
+      "o1{5:value=d1;}",
+      "o1{5:value=b1;}",
+      "o1{5:value=i1;}",
+      "o1{5:value=n;}",
+      "o1{5:value=u;}",
+    ]);
+  });
+
+  it("hashes nested arrays and plain objects", () => {
+    const hash = fastWhereFilterHash({ ids: [1, 2], nested: { name: "a1" } });
+
+    expect(hash).toEqual("o2{3:ids=a2[d1;d2;]6:nested=o1{4:name=s2:a1;}}");
+  });
+
+  it("hashes date values with their db representation", () => {
+    expect(fastWhereFilterHash({ at: new Date("2020-01-02T03:04:05.000Z") })).toEqual(
+      "o1{2:at=t24:2020-01-02T03:04:05.000Z;}",
+    );
+  });
+
+  it("hashes byte array values by their contents", () => {
+    expect(fastWhereFilterHash({ value: new Uint8Array([11, 22]) })).toEqual("o1{5:value=y10:Uint8Array:4:CxY=;}");
+  });
+
+  it("hashes custom value objects by constructor and enumerable values", () => {
+    expect(fastWhereFilterHash({ value: new SupportedValue("a1") })).toEqual(
+      "o1{5:value=c14:SupportedValue:1{4:name=s2:a1;}}",
+    );
+  });
+
+  it("returns undefined for unsupported object types", () => {
+    expect([
+      fastWhereFilterHash(new Map([["name", "a1"]])),
+      fastWhereFilterHash(function unsupportedFunction() {}),
+    ]).toEqual([undefined, undefined]);
+  });
+
+  it("returns undefined for circular structures", () => {
+    const value: { name: string; self?: unknown } = { name: "a1" };
+    value.self = value;
+
+    expect(fastWhereFilterHash(value)).toEqual(undefined);
+  });
+});
+
+class SupportedValue {
+  constructor(readonly name: string) {}
+}

--- a/packages/core/src/dataloaders/fastWhereFilterHash.ts
+++ b/packages/core/src/dataloaders/fastWhereFilterHash.ts
@@ -1,0 +1,158 @@
+import { isAlias } from "../Aliases";
+import { isEntity } from "../Entity";
+import { isReference } from "../relations";
+import { maybeRequireTemporal } from "../temporal";
+import { plainDateMapper, plainDateTimeMapper, plainTimeMapper, zonedDateTimeMapper } from "../temporalMappers";
+
+const Temporal = maybeRequireTemporal()?.Temporal;
+
+/**
+ * Returns a fast stable key for find filters.
+ *
+ * This avoids `object-hash` for simple find filters; the phase 8 query-prep benchmark saw 1,000-query p50s drop
+ * from ~22-26ms to ~7.6-10.9ms, with heap allocation dropping from ~24-30MB to ~10-16MB.
+ *
+ * We also benchmarked native/WASM non-cryptographic hash libraries, but they only hash bytes; they still need this
+ * deterministic serialization first. For 1,000 filter keys, this helper alone had p50s of 0.337/0.353/0.410ms vs.
+ * object-hash md5 at 7.467/7.436/7.620ms, and wrapping this key with native hashes was slower: farmhash
+ * fingerprint64 at 0.517/0.524/0.538ms, @node-rs/xxhash xxh3-128 at 0.611/0.613/0.627ms, and xxhash-addon
+ * XXH128 at 1.031/1.078/1.348ms. So the stable serialization is the necessary work, and keeping it as the cache
+ * key avoids extra native-call/digest overhead and avoids introducing probabilistic hash collisions.
+ */
+export function fastWhereFilterHash(value: unknown): string | undefined {
+  return appendStableValue("", value, new WeakSet<object>());
+}
+
+/** Appends a deterministic, type-tagged representation of `value` to `key`. */
+function appendStableValue(key: string, value: unknown, seen: WeakSet<object>): string | undefined {
+  if (value === undefined) return `${key}u;`;
+  if (value === null) return `${key}n;`;
+  switch (typeof value) {
+    case "string":
+      return `${key}s${value.length}:${value};`;
+    case "number":
+      return `${key}d${value};`;
+    case "boolean":
+      return `${key}b${value ? 1 : 0};`;
+    case "bigint":
+      return `${key}i${value.toString()};`;
+    case "object":
+      return appendStableObject(key, value, seen);
+    case "function":
+      return isAlias(value) ? `${key}xalias;` : undefined;
+    default:
+      return undefined;
+  }
+}
+
+/** Appends a deterministic, type-tagged representation of `value` to `key`. */
+function appendStableObject(key: string, value: object, seen: WeakSet<object>): string | undefined {
+  if (value instanceof Date) return `${key}t${value.toISOString().length}:${value.toISOString()};`;
+  if (ArrayBuffer.isView(value)) return appendArrayBufferView(key, value);
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return undefined;
+    seen.add(value);
+    key = `${key}a${value.length}[`;
+    for (const item of value) {
+      const nextKey = appendStableValue(key, item, seen);
+      if (nextKey === undefined) {
+        seen.delete(value);
+        return undefined;
+      }
+      key = nextKey;
+    }
+    seen.delete(value);
+    return `${key}]`;
+  }
+
+  if (isPlainObject(value)) {
+    if (seen.has(value)) return undefined;
+    seen.add(value);
+
+    const keys = Object.keys(value).sort();
+    key = `${key}o${keys.length}{`;
+    for (const property of keys) {
+      key = `${key}${property.length}:${property}=`;
+      const nextKey = appendStableValue(key, (value as Record<string, unknown>)[property], seen);
+      if (nextKey === undefined) {
+        seen.delete(value);
+        return undefined;
+      }
+      key = nextKey;
+    }
+    seen.delete(value);
+    return `${key}}`;
+  }
+
+  if (isEntity(value)) return `${key}e${value.toString().length}:${value.toString()};`;
+  const referenceKey = appendReferenceValue(key, value);
+  if (referenceKey !== undefined) return referenceKey;
+  const temporalValue = toTemporalDbValue(value);
+  if (temporalValue !== undefined) return appendTemporalValue(key, temporalValue);
+  const valueObjectKey = appendValueObject(key, value, seen);
+  if (valueObjectKey !== undefined) return valueObjectKey;
+  return undefined;
+}
+
+/** Appends an ArrayBuffer view by its exact byte contents. */
+function appendArrayBufferView(key: string, value: ArrayBufferView): string {
+  const bytes = Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString("base64");
+  return `${key}y${value.constructor.name.length}:${value.constructor.name}:${bytes.length}:${bytes};`;
+}
+
+/** Appends a Joist reference by its tagged id. */
+function appendReferenceValue(key: string, value: object): string | undefined {
+  if (!isReference(value)) return undefined;
+  const id = value.idTaggedMaybe;
+  return id === undefined ? `${key}r;` : `${key}r${id.length}:${id};`;
+}
+
+/** Appends a custom value object by constructor name and enumerable properties. */
+function appendValueObject(key: string, value: object, seen: WeakSet<object>): string | undefined {
+  if (!isValueObject(value)) return undefined;
+  if (seen.has(value)) return undefined;
+  seen.add(value);
+
+  const constructorName = value.constructor.name;
+  const keys = Object.keys(value).sort();
+  key = `${key}c${constructorName.length}:${constructorName}:${keys.length}{`;
+  for (const property of keys) {
+    key = `${key}${property.length}:${property}=`;
+    const nextKey = appendStableValue(key, (value as Record<string, unknown>)[property], seen);
+    if (nextKey === undefined) {
+      seen.delete(value);
+      return undefined;
+    }
+    key = nextKey;
+  }
+  seen.delete(value);
+  return `${key}}`;
+}
+
+/** Appends a Temporal value as a distinct scalar type. */
+function appendTemporalValue(key: string, value: string): string {
+  return `${key}t${value.length}:${value};`;
+}
+
+/** Returns the db representation for Temporal values, or undefined for non-Temporal values. */
+function toTemporalDbValue(value: object): string | undefined {
+  if (!Temporal) return undefined;
+  if (value instanceof Temporal.ZonedDateTime) return zonedDateTimeMapper.toDb(value);
+  if (value instanceof Temporal.PlainDateTime) return plainDateTimeMapper.toDb(value);
+  if (value instanceof Temporal.PlainDate) return plainDateMapper.toDb(value);
+  if (value instanceof Temporal.PlainTime) return plainTimeMapper.toDb(value);
+  return undefined;
+}
+
+/** Returns true for plain object literals used by find filters/settings. */
+function isPlainObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/** Returns true for custom value objects that can be represented by enumerable fields. */
+function isValueObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype !== Object.prototype && prototype !== null && Object.keys(value).length > 0;
+}

--- a/packages/core/src/dataloaders/findCountDataLoader.ts
+++ b/packages/core/src/dataloaders/findCountDataLoader.ts
@@ -34,65 +34,67 @@ export function findCountDataLoader<T extends Entity>(
   const prepared = { filter, query, bindings, findSettings };
   const batchKey = getBatchKeyFromGenericStructure(meta, query);
 
-  return em.getLoader<typeof prepared, number>(
-    findCountOperation,
-    batchKey,
-    async (entries) => {
-      // We're guaranteed that these queries all have the same structure
+  return em
+    .getLoader<typeof prepared, number>(
+      findCountOperation,
+      batchKey,
+      async (entries) => {
+        // We're guaranteed that these queries all have the same structure
 
-      // Don't bother with the CTE if there's only 1 query (or each query has exactly the same filter values)
-      if (entries.length === 1) {
+        // Don't bother with the CTE if there's only 1 query (or each query has exactly the same filter values)
+        if (entries.length === 1) {
+          const { query, findSettings } = entries[0];
+          const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
+          query.selects = [`count(distinct ${kq(primary.alias)}.id) as count`];
+          query.orderBys = [];
+          const rows = await em["executePreparedFind"](meta, findCountOperation, query, findSettings, false);
+          return [Number(rows[0].count)];
+        }
+
+        // WITH _find (tag, arg1, arg2) AS (
+        //  SELECT unnest($0::int[]), unnest($0::varchar[]), unnest($0::varchar[])
+        // )
+        // SELECT _find.tag, _data.count
+        // FROM _find
+        // CROSS JOIN LATERAL (
+        //   SELECT count(*) as count
+        //   FROM author a WHERE a.first_name = _find.arg1 OR a.last_name = _find.arg2
+        // ) _data
+
+        // Build the list of 'arg1', 'arg2', ... strings
         const { query, findSettings } = entries[0];
+        const argsColumns = collectAndReplaceArgs(query);
+        argsColumns.unshift({ columnName: "tag", dbType: "int" });
+
+        // We're not returning the entities, just counting them...
         const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
         query.selects = [`count(distinct ${kq(primary.alias)}.id) as count`];
         query.orderBys = [];
-        const rows = await em["executePreparedFind"](meta, findCountOperation, query, findSettings, false);
-        return [Number(rows[0].count)];
-      }
 
-      // WITH _find (tag, arg1, arg2) AS (
-      //  SELECT unnest($0::int[]), unnest($0::varchar[]), unnest($0::varchar[])
-      // )
-      // SELECT _find.tag, _data.count
-      // FROM _find
-      // CROSS JOIN LATERAL (
-      //   SELECT count(*) as count
-      //   FROM author a WHERE a.first_name = _find.arg1 OR a.last_name = _find.arg2
-      // ) _data
+        const query2: ParsedFindQuery = {
+          selects: ["_find.tag as tag", "_data.count as count"],
+          tables: [
+            { join: "primary", table: "_find", alias: "_find" },
+            // Not sure what fromAlias is for/that it matters...
+            { join: "lateral", query: query, table: meta.tableName, alias: "_data", fromAlias: "_f" },
+          ],
+          // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
+          ctes: [buildUnnestCte("_find", argsColumns, createColumnValuesFromPrepared(argsColumns, entries))],
+          orderBys: [],
+        };
 
-      // Build the list of 'arg1', 'arg2', ... strings
-      const { query, findSettings } = entries[0];
-      const argsColumns = collectAndReplaceArgs(query);
-      argsColumns.unshift({ columnName: "tag", dbType: "int" });
+        const rows = await em["executePreparedFind"](meta, findCountOperation, query2, findSettings, false);
 
-      // We're not returning the entities, just counting them...
-      const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
-      query.selects = [`count(distinct ${kq(primary.alias)}.id) as count`];
-      query.orderBys = [];
-
-      const query2: ParsedFindQuery = {
-        selects: ["_find.tag as tag", "_data.count as count"],
-        tables: [
-          { join: "primary", table: "_find", alias: "_find" },
-          // Not sure what fromAlias is for/that it matters...
-          { join: "lateral", query: query, table: meta.tableName, alias: "_data", fromAlias: "_f" },
-        ],
-        // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
-        ctes: [buildUnnestCte("_find", argsColumns, createColumnValuesFromPrepared(argsColumns, entries))],
-        orderBys: [],
-      };
-
-      const rows = await em["executePreparedFind"](meta, findCountOperation, query2, findSettings, false);
-
-      // Make an empty array for each batched query, per the dataloader contract
-      const results = entries.map(() => 0);
-      // Then put each row into the tagged query it matched
-      for (const row of rows) {
-        results[row.tag] = Number(row.count);
-      }
-      return results;
-    },
-    // Our filter/order tuple is a complex object, so object-hash it to ensure caching works
-    { cacheKeyFn: (entry) => whereFilterHash(entry.filter) },
-  ).load(prepared);
+        // Make an empty array for each batched query, per the dataloader contract
+        const results = entries.map(() => 0);
+        // Then put each row into the tagged query it matched
+        for (const row of rows) {
+          results[row.tag] = Number(row.count);
+        }
+        return results;
+      },
+      // Our filter/order tuple is a complex object, so use a stable cache key to ensure caching works.
+      { cacheKeyFn: (entry) => whereFilterHash(entry.filter) },
+    )
+    .load(prepared);
 }

--- a/packages/core/src/dataloaders/findDataLoader.ts
+++ b/packages/core/src/dataloaders/findDataLoader.ts
@@ -1,6 +1,4 @@
-import hash from "object-hash";
-import { isAlias } from "../Aliases";
-import { Entity, isEntity } from "../Entity";
+import { Entity } from "../Entity";
 import { FilterAndSettings } from "../EntityFilter";
 import { opToFn } from "../EntityGraphQLFilter";
 import { EntityManager, MaybeAbstractEntityConstructor, getEmInternalApi } from "../EntityManager";
@@ -22,10 +20,9 @@ import { visitConditions } from "../QueryVisitor";
 import { OpColumn } from "../drivers/EntityWriter";
 import { kqDot } from "../keywords";
 import { LoadHint } from "../loadHints";
-import { maybeRequireTemporal } from "../temporal";
-import { plainDateMapper, plainDateTimeMapper, plainTimeMapper, zonedDateTimeMapper } from "../temporalMappers";
 import { buildUnnestCte } from "../unnest";
 import { assertNever } from "../utils";
+import { fastWhereFilterHash } from "./fastWhereFilterHash";
 
 export const findOperation = "find";
 
@@ -50,126 +47,109 @@ export function findDataLoader<T extends Entity>(
 
   const meta = getMetadata(type);
   const query = parseFindQuery(meta, where, opts);
-  const { checkLimit, findSettings } = em["prepareFind"](meta, findOperation, query, { ...opts, limit: em.entityLimit });
+  const { checkLimit, findSettings } = em["prepareFind"](meta, findOperation, query, {
+    ...opts,
+    limit: em.entityLimit,
+  });
   const bindings: any[] = [];
   collectValues(bindings, query);
   const prepared = { filter, query, bindings, findSettings, checkLimit };
   const batchKey = getBatchKeyFromGenericStructure(meta, query);
 
-  return em.getLoader<PreparedFindEntry<T>, T[]>(
-    findOperation,
-    // It's unlikely we'll have simultaneous em.finds with the same WHERE clause structure
-    // but lots of different load hints, and it'd be complicated to implement the preloading
-    // in a way that doesn't naively over-fetch data (which our loadDataLoader does prevent,
-    // but it's simpler b/c it's given exact ids to load), so for now just include the load
-    // hint in the batch key.
-    `${batchKey}-${JSON.stringify(hint)}`,
-    async (entries) => {
-      // We're guaranteed that these queries all have the same structure
+  return em
+    .getLoader<PreparedFindEntry<T>, T[]>(
+      findOperation,
+      // It's unlikely we'll have simultaneous em.finds with the same WHERE clause structure
+      // but lots of different load hints, and it'd be complicated to implement the preloading
+      // in a way that doesn't naively over-fetch data (which our loadDataLoader does prevent,
+      // but it's simpler b/c it's given exact ids to load), so for now just include the load
+      // hint in the batch key.
+      `${batchKey}-${JSON.stringify(hint)}`,
+      async (entries) => {
+        // We're guaranteed that these queries all have the same structure
 
-      // Don't bother with the CTE if there's only 1 query (or each query has exactly the same filter values)
-      if (entries.length === 1) {
-        const { query, findSettings, checkLimit } = entries[0];
-        // Maybe add preload joins
-        const { preloader } = getEmInternalApi(em);
-        const preloadHydrator = preloader && hint && preloader.addPreloading(meta, buildHintTree(hint), query);
-        const rows = await em["executePreparedFind"](meta, findOperation, query, findSettings, checkLimit);
-        const entities = em.hydrate(type, rows);
-        preloadHydrator?.(rows, entities);
-        return [entities];
-      }
-
-      // WITH _find (tag, arg1, arg2) AS (
-      //   SELECT unnest($0::int[]), unnest($0::varchar[]), unnest($0::varchar[])
-      // )
-      // SELECT a.*, array_agg(_find.tag) AS _tags
-      // FROM authors a
-      // CROSS JOIN _find AS _find
-      // WHERE a.first_name = _find.arg0 OR a.last_name = _find.arg1
-      // GROUP BY a.id
-
-      // Build the list of 'arg1', 'arg2', ... strings
-      const { query, findSettings, checkLimit } = entries[0];
-      const { preloader } = getEmInternalApi(em);
-      const preloadJoins = preloader && hint && preloader.getPreloadJoins(meta, buildHintTree(hint), query);
-
-      const argsColumns = collectAndReplaceArgs(query);
-      argsColumns.unshift({ columnName: "tag", dbType: "int" });
-      const columnValues = createColumnValuesFromPrepared(argsColumns, entries);
-      const query2: ParsedFindQuery = {
-        ...query,
-        selects: ["array_agg(_find.tag) as _tags", ...query.selects],
-        tables: [{ join: "cross", table: "_find", alias: "_find" }, ...query.tables],
-        ctes: [buildUnnestCte("_find", argsColumns, columnValues), ...(query.ctes ?? [])],
-      };
-      if (preloadJoins) {
-        query2.selects.push(
-          ...preloadJoins.flatMap((j) =>
-            // Because we 'group by primary.id' to collapse the "a1 matched multiple finds" into
-            // a single row, we also need to pick just the first value of each preload column
-            j.selects.map((s) => `(array_agg(${s.value}))[1] AS ${s.as}`),
-          ),
-        );
-        query2.tables.push(...preloadJoins.map((j) => j.join));
-      }
-
-      // Because we want to use `array_agg(tag)`, add `GROUP BY`s to the values we're selecting
-      query2.groupBys = buildGroupBys(query2.selects);
-
-      // Also because of our `array_agg` group by, add any order bys to the group by
-      const [primary] = getTables(query2);
-      for (const { alias, column } of query2.orderBys) {
-        if (alias !== primary.alias) {
-          query2.groupBys.push({ alias, column });
+        // Don't bother with the CTE if there's only 1 query (or each query has exactly the same filter values)
+        if (entries.length === 1) {
+          const { query, findSettings, checkLimit } = entries[0];
+          // Maybe add preload joins
+          const { preloader } = getEmInternalApi(em);
+          const preloadHydrator = preloader && hint && preloader.addPreloading(meta, buildHintTree(hint), query);
+          const rows = await em["executePreparedFind"](meta, findOperation, query, findSettings, checkLimit);
+          const entities = em.hydrate(type, rows);
+          preloadHydrator?.(rows, entities);
+          return [entities];
         }
-      }
 
-      const rows = await em["executePreparedFind"](meta, findOperation, query2, findSettings, checkLimit);
+        // WITH _find (tag, arg1, arg2) AS (
+        //   SELECT unnest($0::int[]), unnest($0::varchar[]), unnest($0::varchar[])
+        // )
+        // SELECT a.*, array_agg(_find.tag) AS _tags
+        // FROM authors a
+        // CROSS JOIN _find AS _find
+        // WHERE a.first_name = _find.arg0 OR a.last_name = _find.arg1
+        // GROUP BY a.id
 
-      const entities = em.hydrate(type, rows);
-      preloadJoins?.forEach((j) => j.hydrator(rows, entities));
+        // Build the list of 'arg1', 'arg2', ... strings
+        const { query, findSettings, checkLimit } = entries[0];
+        const { preloader } = getEmInternalApi(em);
+        const preloadJoins = preloader && hint && preloader.getPreloadJoins(meta, buildHintTree(hint), query);
 
-      // Make an empty array for each batched query, per the dataloader contract
-      const results = entries.map(() => [] as T[]);
-      // Then put each row into the tagged query it matched
-      rows.forEach((row, i) => {
-        const entity = entities[i];
-        for (const tag of row._tags) results[tag].push(entity);
-        delete row._tags;
-      });
-      return results;
-    },
-    // Our filter/order tuple is a complex object, so object-hash it to ensure caching works
-    { cacheKeyFn: (entry) => whereFilterHash(entry.filter) },
-  ).load(prepared);
-}
+        const argsColumns = collectAndReplaceArgs(query);
+        argsColumns.unshift({ columnName: "tag", dbType: "int" });
+        const columnValues = createColumnValuesFromPrepared(argsColumns, entries);
+        const query2: ParsedFindQuery = {
+          ...query,
+          selects: ["array_agg(_find.tag) as _tags", ...query.selects],
+          tables: [{ join: "cross", table: "_find", alias: "_find" }, ...query.tables],
+          ctes: [buildUnnestCte("_find", argsColumns, columnValues), ...(query.ctes ?? [])],
+        };
+        if (preloadJoins) {
+          query2.selects.push(
+            ...preloadJoins.flatMap((j) =>
+              // Because we 'group by primary.id' to collapse the "a1 matched multiple finds" into
+              // a single row, we also need to pick just the first value of each preload column
+              j.selects.map((s) => `(array_agg(${s.value}))[1] AS ${s.as}`),
+            ),
+          );
+          query2.tables.push(...preloadJoins.map((j) => j.join));
+        }
 
-const Temporal = maybeRequireTemporal()?.Temporal;
+        // Because we want to use `array_agg(tag)`, add `GROUP BY`s to the values we're selecting
+        query2.groupBys = buildGroupBys(query2.selects);
 
-// If a where clause includes an entity, object-hash cannot hash it, so just use the id.
-function replacer(v: any) {
-  if (isEntity(v)) {
-    // Use toString() instead of id so that new entities are kept separate, i.e. `Author#2`
-    return v.toString();
-  } else if (isAlias(v)) {
-    // Strip out `{ as: ...alias proxy... }` from the `em.find` inline conditions
-    return "alias";
-  } else if (Temporal) {
-    if (v instanceof Temporal.ZonedDateTime) {
-      return zonedDateTimeMapper.toDb(v);
-    } else if (v instanceof Temporal.PlainDateTime) {
-      return plainDateTimeMapper.toDb(v);
-    } else if (v instanceof Temporal.PlainDate) {
-      return plainDateMapper.toDb(v);
-    } else if (v instanceof Temporal.PlainTime) {
-      return plainTimeMapper.toDb(v);
-    }
-  }
-  return v;
+        // Also because of our `array_agg` group by, add any order bys to the group by
+        const [primary] = getTables(query2);
+        for (const { alias, column } of query2.orderBys) {
+          if (alias !== primary.alias) {
+            query2.groupBys.push({ alias, column });
+          }
+        }
+
+        const rows = await em["executePreparedFind"](meta, findOperation, query2, findSettings, checkLimit);
+
+        const entities = em.hydrate(type, rows);
+        preloadJoins?.forEach((j) => j.hydrator(rows, entities));
+
+        // Make an empty array for each batched query, per the dataloader contract
+        const results = entries.map(() => [] as T[]);
+        // Then put each row into the tagged query it matched
+        rows.forEach((row, i) => {
+          const entity = entities[i];
+          for (const tag of row._tags) results[tag].push(entity);
+          delete row._tags;
+        });
+        return results;
+      },
+      // Our filter/order tuple is a complex object, so use a stable cache key to ensure caching works.
+      { cacheKeyFn: (entry) => whereFilterHash(entry.filter) },
+    )
+    .load(prepared);
 }
 
 export function whereFilterHash(where: FilterAndSettings<any>): any {
-  return hash(where, { replacer, algorithm: "md5" });
+  const key = fastWhereFilterHash(where);
+  if (key === undefined) throw new Error("fastWhereFilterHash could not serialize find filter");
+  return key;
 }
 
 class ArgCounter {
@@ -269,7 +249,9 @@ function isAggregateSelect(select: string): boolean {
 function buildGroupBys(selects: ParsedSelect[]): ParsedGroupBy[] {
   const sqlSelects = selects.map(selectSqlForGroupBy);
   const wholeRowAliases = new Set(
-    sqlSelects.filter((select) => !isAggregateSelect(select) && stripSelectAlias(select).endsWith(".*")).map(parseAlias),
+    sqlSelects
+      .filter((select) => !isAggregateSelect(select) && stripSelectAlias(select).endsWith(".*"))
+      .map(parseAlias),
   );
   return sqlSelects
     .filter((select) => !isAggregateSelect(select))

--- a/packages/core/src/dataloaders/findIdsDataLoader.ts
+++ b/packages/core/src/dataloaders/findIdsDataLoader.ts
@@ -35,64 +35,66 @@ export function findIdsDataLoader<T extends Entity>(
   const prepared = { filter, query, bindings, findSettings };
   const batchKey = getBatchKeyFromGenericStructure(meta, query);
 
-  return em.getLoader<typeof prepared, string[]>(
-    findIdsOperation,
-    batchKey,
-    async (entries) => {
-      // We're guaranteed that these queries all have the same structure
+  return em
+    .getLoader<typeof prepared, string[]>(
+      findIdsOperation,
+      batchKey,
+      async (entries) => {
+        // We're guaranteed that these queries all have the same structure
 
-      // Don't bother with the CTE if there's only 1 query (or each query has exactly the same filter values)
-      if (entries.length === 1) {
+        // Don't bother with the CTE if there's only 1 query (or each query has exactly the same filter values)
+        if (entries.length === 1) {
+          const { query, findSettings } = entries[0];
+          const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
+          query.selects = [`${kq(primary.alias)}.id as id`];
+          query.orderBys = [{ alias: primary.alias, column: "id", order: "ASC" }];
+          const rows = await em["executePreparedFind"](meta, findIdsOperation, query, findSettings, false);
+          return [rows.map((row: any) => keyToTaggedId(meta, row.id)!)];
+        }
+
+        // WITH _find (tag, arg1, arg2) AS (
+        //   SELECT unnest($0::int[]) unnest($0::varchar[]), unnest($0::varchar[])
+        // )
+        // SELECT _find.tag, _data.id
+        // FROM _find
+        // CROSS JOIN LATERAL (
+        //   SELECT distinct a.id as id
+        //   FROM author a WHERE a.first_name = _find.arg1 OR a.last_name = _find.arg2
+        // ) _data
+
+        // Build the list of 'arg1', 'arg2', ... strings
         const { query, findSettings } = entries[0];
+        const argsColumns = collectAndReplaceArgs(query);
+        argsColumns.unshift({ columnName: "tag", dbType: "int" });
+
+        // We're not returning the entities, just selecting their IDs
         const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
         query.selects = [`${kq(primary.alias)}.id as id`];
         query.orderBys = [{ alias: primary.alias, column: "id", order: "ASC" }];
-        const rows = await em["executePreparedFind"](meta, findIdsOperation, query, findSettings, false);
-        return [rows.map((row: any) => keyToTaggedId(meta, row.id)!)];
-      }
 
-      // WITH _find (tag, arg1, arg2) AS (
-      //   SELECT unnest($0::int[]) unnest($0::varchar[]), unnest($0::varchar[])
-      // )
-      // SELECT _find.tag, _data.id
-      // FROM _find
-      // CROSS JOIN LATERAL (
-      //   SELECT distinct a.id as id
-      //   FROM author a WHERE a.first_name = _find.arg1 OR a.last_name = _find.arg2
-      // ) _data
+        const query2: ParsedFindQuery = {
+          selects: ["_find.tag as tag", "_data.id as id"],
+          tables: [
+            { join: "primary", table: "_find", alias: "_find" },
+            { join: "lateral", query, table: meta.tableName, alias: "_data", fromAlias: "_f" },
+          ],
+          // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
+          ctes: [buildUnnestCte("_find", argsColumns, createColumnValuesFromPrepared(argsColumns, entries))],
+          orderBys: [],
+        };
 
-      // Build the list of 'arg1', 'arg2', ... strings
-      const { query, findSettings } = entries[0];
-      const argsColumns = collectAndReplaceArgs(query);
-      argsColumns.unshift({ columnName: "tag", dbType: "int" });
+        const rows = await em["executePreparedFind"](meta, findIdsOperation, query2, findSettings, false);
 
-      // We're not returning the entities, just selecting their IDs
-      const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
-      query.selects = [`${kq(primary.alias)}.id as id`];
-      query.orderBys = [{ alias: primary.alias, column: "id", order: "ASC" }];
-
-      const query2: ParsedFindQuery = {
-        selects: ["_find.tag as tag", "_data.id as id"],
-        tables: [
-          { join: "primary", table: "_find", alias: "_find" },
-          { join: "lateral", query, table: meta.tableName, alias: "_data", fromAlias: "_f" },
-        ],
-        // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
-        ctes: [buildUnnestCte("_find", argsColumns, createColumnValuesFromPrepared(argsColumns, entries))],
-        orderBys: [],
-      };
-
-      const rows = await em["executePreparedFind"](meta, findIdsOperation, query2, findSettings, false);
-
-      // Make an empty array for each batched query, per the dataloader contract
-      const results: string[][] = entries.map(() => []);
-      // Then put each row's ID into the tagged query it matched
-      for (const row of rows) {
-        results[row.tag].push(keyToTaggedId(meta, row.id)!);
-      }
-      return results;
-    },
-    // Our filter/order tuple is a complex object, so object-hash it to ensure caching works
-    { cacheKeyFn: (entry) => whereFilterHash(entry.filter) },
-  ).load(prepared);
+        // Make an empty array for each batched query, per the dataloader contract
+        const results: string[][] = entries.map(() => []);
+        // Then put each row's ID into the tagged query it matched
+        for (const row of rows) {
+          results[row.tag].push(keyToTaggedId(meta, row.id)!);
+        }
+        return results;
+      },
+      // Our filter/order tuple is a complex object, so use a stable cache key to ensure caching works.
+      { cacheKeyFn: (entry) => whereFilterHash(entry.filter) },
+    )
+    .load(prepared);
 }

--- a/packages/core/src/dataloaders/findOrCreateDataLoader.ts
+++ b/packages/core/src/dataloaders/findOrCreateDataLoader.ts
@@ -111,7 +111,7 @@ export function findOrCreateDataLoader<T extends Entity>(
       }
       return keys.map(() => entity);
     },
-    // Our filter tuple is a complex object, so object-hash it to ensure caching works
+    // Our filter tuple is a complex object, so use a stable cache key to ensure caching works.
     { cacheKeyFn: whereFilterHash as any },
   );
 }

--- a/packages/tests/integration/benchmark-find-query-prep.ts
+++ b/packages/tests/integration/benchmark-find-query-prep.ts
@@ -1,0 +1,298 @@
+import { setDefaultEntityLimit } from "joist-orm";
+import { performance } from "node:perf_hooks";
+import { Author, type EntityManager } from "./src/entities";
+import { newEntityManager, testDriver } from "./src/testEm";
+
+interface ScenarioContext {
+  em: EntityManager;
+  queryCount: number;
+}
+
+interface ScenarioResult {
+  checksum: number;
+  context: ScenarioContext;
+}
+
+interface Scenario {
+  name: string;
+  queryCount: number;
+  run(context: ScenarioContext): Promise<ScenarioResult>;
+}
+
+interface Sample {
+  cpuUserMs: number;
+  cpuSystemMs: number;
+  heapDeltaMb: number;
+  heapRetainedMb: number;
+  wallMs: number;
+}
+
+interface Summary {
+  cpuSystemMs: number;
+  cpuUserMs: number;
+  heapDeltaMb: number;
+  heapRetainedMb: number;
+  meanMs: number;
+  p50Ms: number;
+  p90Ms: number;
+  p99Ms: number;
+  rsdPct: number;
+}
+
+interface BenchmarkConfig {
+  iterations: number;
+  queryCount: number;
+  warmups: number;
+}
+
+type ExecuteFind = EntityManager["driver"]["executeFind"];
+
+let blackhole = 0;
+let heldResult: ScenarioResult | undefined;
+
+/** Benchmarks phase 8 find query preparation and batching hot paths. */
+async function main(): Promise<void> {
+  const originalExecuteFind = testDriver.driver.executeFind.bind(testDriver.driver) as ExecuteFind;
+  testDriver.driver.executeFind = async function executeFind(): Promise<unknown[]> {
+    return [];
+  } as ExecuteFind;
+
+  try {
+    const queryCounts = readQueryCounts();
+    setDefaultEntityLimit(Math.max(...queryCounts) + 1_000);
+    console.log(`node=${process.version} exposeGc=${typeof global.gc === "function"}`);
+    console.log(
+      "scenario,size,samples,p50_ms,p90_ms,p99_ms,mean_ms,rsd_pct,cpu_user_ms,cpu_system_ms,heap_delta_mb,heap_retained_mb",
+    );
+
+    for (const queryCount of queryCounts) {
+      const config = configForQueryCount(queryCount);
+      await runScenario(identicalStructureOneField(queryCount), config);
+      await runScenario(identicalStructureTwoFields(queryCount), config);
+      await runScenario(identicalStructureWithHint(queryCount), config);
+    }
+
+    if (blackhole === Number.MIN_SAFE_INTEGER) console.log(blackhole);
+  } finally {
+    testDriver.driver.executeFind = originalExecuteFind;
+    await testDriver.destroy();
+  }
+}
+
+/** Returns the batched query counts to benchmark, allowing BENCH_SIZES=10,100 overrides. */
+function readQueryCounts(): number[] {
+  const input = process.env.BENCH_SIZES;
+  if (!input) return [1, 10, 100, 1_000];
+  return input.split(",").map(function parseSize(value) {
+    return Number(value.trim());
+  });
+}
+
+/** Returns iteration counts that keep the 1k-query samples practical. */
+function configForQueryCount(queryCount: number): BenchmarkConfig {
+  if (queryCount >= 1_000) return { iterations: 18, queryCount, warmups: 8 };
+  if (queryCount >= 100) return { iterations: 28, queryCount, warmups: 10 };
+  return { iterations: 40, queryCount, warmups: 12 };
+}
+
+/** Measures one scenario after warmup and prints a CSV row. */
+async function runScenario(scenario: Scenario, config: BenchmarkConfig): Promise<void> {
+  for (let i = 0; i < config.warmups; i++) {
+    consume(await scenario.run(setupContext(config.queryCount)));
+    forceGc();
+  }
+
+  const samples: Sample[] = [];
+  for (let i = 0; i < config.iterations; i++) {
+    const context = setupContext(config.queryCount);
+    forceGc();
+    const heapBefore = process.memoryUsage().heapUsed;
+    const cpuBefore = process.cpuUsage();
+    const start = performance.now();
+    heldResult = await scenario.run(context);
+    const wallMs = performance.now() - start;
+    const cpu = process.cpuUsage(cpuBefore);
+    const heapAfterRun = process.memoryUsage().heapUsed;
+    forceGc();
+    const heapAfterGc = process.memoryUsage().heapUsed;
+    consume(heldResult);
+    heldResult = undefined;
+    samples.push({
+      cpuSystemMs: cpu.system / 1_000,
+      cpuUserMs: cpu.user / 1_000,
+      heapDeltaMb: (heapAfterRun - heapBefore) / 1024 / 1024,
+      heapRetainedMb: (heapAfterGc - heapBefore) / 1024 / 1024,
+      wallMs,
+    });
+    forceGc();
+    await new Promise<void>(resolveImmediate);
+  }
+
+  const summary = summarize(samples);
+  console.log(
+    [
+      scenario.name,
+      scenario.queryCount,
+      config.iterations,
+      fmt(summary.p50Ms),
+      fmt(summary.p90Ms),
+      fmt(summary.p99Ms),
+      fmt(summary.meanMs),
+      fmt(summary.rsdPct),
+      fmt(summary.cpuUserMs),
+      fmt(summary.cpuSystemMs),
+      fmt(summary.heapDeltaMb),
+      fmt(summary.heapRetainedMb),
+    ].join(","),
+  );
+}
+
+/** Measures many same-shape one-field finds batched into one tick. */
+function identicalStructureOneField(queryCount: number): Scenario {
+  return {
+    name: "find_query_prep_one_field",
+    queryCount,
+    async run(context: ScenarioContext): Promise<ScenarioResult> {
+      const results = await Promise.all(
+        Array.from({ length: queryCount }, function findByFirstName(_, i) {
+          return context.em.find(Author, { firstName: `first${i}` });
+        }),
+      );
+      return { checksum: checksum(results), context };
+    },
+  };
+}
+
+/** Measures many same-shape two-field finds batched into one tick. */
+function identicalStructureTwoFields(queryCount: number): Scenario {
+  return {
+    name: "find_query_prep_two_fields",
+    queryCount,
+    async run(context: ScenarioContext): Promise<ScenarioResult> {
+      const results = await Promise.all(
+        Array.from({ length: queryCount }, function findByNameAndAge(_, i) {
+          return context.em.find(Author, { firstName: `first${i}`, age: 20 + (i % 60) });
+        }),
+      );
+      return { checksum: checksum(results), context };
+    },
+  };
+}
+
+/** Measures repeated hint serialization and preloading setup costs. */
+function identicalStructureWithHint(queryCount: number): Scenario {
+  return {
+    name: "find_query_prep_with_hint",
+    queryCount,
+    async run(context: ScenarioContext): Promise<ScenarioResult> {
+      const results = await Promise.all(
+        Array.from({ length: queryCount }, function findByLastNameWithHint(_, i) {
+          return context.em.find(Author, { lastName: i % 2 === 0 ? "even" : "odd" }, { populate: "publisher" });
+        }),
+      );
+      return { checksum: checksum(results), context };
+    },
+  };
+}
+
+/** Creates a fresh EntityManager for one isolated sample. */
+function setupContext(queryCount: number): ScenarioContext {
+  return { em: newEntityManager(), queryCount };
+}
+
+/** Returns a checksum to keep benchmark results observable. */
+function checksum(results: readonly Author[][]): number {
+  let value = results.length;
+  for (const result of results) value += result.length;
+  return value;
+}
+
+/** Summarizes benchmark samples. */
+function summarize(samples: Sample[]): Summary {
+  const wall = samples
+    .map(function readWall(sample) {
+      return sample.wallMs;
+    })
+    .sort(function compareNumbers(a, b) {
+      return a - b;
+    });
+  const meanMs = mean(wall);
+  return {
+    cpuSystemMs: mean(
+      samples.map(function readCpuSystem(sample) {
+        return sample.cpuSystemMs;
+      }),
+    ),
+    cpuUserMs: mean(
+      samples.map(function readCpuUser(sample) {
+        return sample.cpuUserMs;
+      }),
+    ),
+    heapDeltaMb: mean(
+      samples.map(function readHeapDelta(sample) {
+        return sample.heapDeltaMb;
+      }),
+    ),
+    heapRetainedMb: mean(
+      samples.map(function readHeapRetained(sample) {
+        return sample.heapRetainedMb;
+      }),
+    ),
+    meanMs,
+    p50Ms: percentile(wall, 0.5),
+    p90Ms: percentile(wall, 0.9),
+    p99Ms: percentile(wall, 0.99),
+    rsdPct: (standardDeviation(wall, meanMs) / meanMs) * 100,
+  };
+}
+
+/** Returns the arithmetic mean. */
+function mean(values: readonly number[]): number {
+  return (
+    values.reduce(function add(sum, value) {
+      return sum + value;
+    }, 0) / values.length
+  );
+}
+
+/** Returns the nearest-rank percentile. */
+function percentile(sortedValues: readonly number[], p: number): number {
+  const index = Math.min(sortedValues.length - 1, Math.max(0, Math.ceil(sortedValues.length * p) - 1));
+  return sortedValues[index];
+}
+
+/** Returns the population standard deviation. */
+function standardDeviation(values: readonly number[], meanValue: number): number {
+  const variance = mean(
+    values.map(function squareDifference(value) {
+      return (value - meanValue) ** 2;
+    }),
+  );
+  return Math.sqrt(variance);
+}
+
+/** Keeps benchmark results observable until after retained heap is measured. */
+function consume(result: ScenarioResult): void {
+  blackhole += result.checksum + result.context.queryCount;
+}
+
+/** Runs a full GC when node was started with --expose-gc. */
+function forceGc(): void {
+  global.gc?.();
+}
+
+/** Resolves on the next immediate tick. */
+function resolveImmediate(resolve: () => void): void {
+  setImmediate(resolve);
+}
+
+/** Formats numeric CSV fields. */
+function fmt(value: number): string {
+  return value.toFixed(3);
+}
+
+main().catch(async function handleError(error: unknown): Promise<void> {
+  console.error(error);
+  await testDriver.destroy();
+  process.exitCode = 1;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4520,13 +4520,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/object-hash@npm:^3.0.6":
-  version: 3.0.6
-  resolution: "@types/object-hash@npm:3.0.6"
-  checksum: 10/2c7979d4e540af817b99c09fb4c2fed1c0b0e14342df474d8dcde4165a82c440b038341fd66fe998d9f86acdd5cccc65ba8092315e39e7c2114f945fa70aaa56
-  languageName: node
-  linkType: hard
-
 "@types/pg@npm:^8.20.0":
   version: 8.20.0
   resolution: "@types/pg@npm:8.20.0"
@@ -9625,11 +9618,9 @@ __metadata:
     "@swc/jest": "npm:^0.2.39"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.12.4"
-    "@types/object-hash": "npm:^3.0.6"
     ansis: "npm:^4.3.0"
     dataloader: "npm:^2.2.3"
     jest: "npm:30.4.2"
-    object-hash: "npm:^3.0.0"
     prettier: "npm:^3.8.3"
     prettier-plugin-organize-imports: "npm:^4.3.0"
     temporal-polyfill: "npm:^0.3.2"
@@ -12526,13 +12517,6 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: 10/fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "object-hash@npm:3.0.0"
-  checksum: 10/f498d456a20512ba7be500cef4cf7b3c183cc72c65372a549c9a0e6dd78ce26f375e9b1315c07592d3fde8f10d5019986eba35970570d477ed9a2a702514432a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add a phase 8 find query-prep benchmark and replace object-hash md5 on common find filters with fast deterministic serialization, falling back to object-hash for unsupported shapes.

In the benchmark, 1,000-query p50 dropped from ~22-26ms to ~7.6-10.9ms and heap allocation dropped from ~24-30MB to ~10-16MB. Direct cache-key microbenchmarks showed fastWhereFilterHash at 0.337/0.353/0.410ms per 1,000 keys vs object-hash md5 at 7.467/7.436/7.620ms; native hash wrappers were slower end-to-end.

Also adds dedicated fastWhereFilterHash unit tests covering stable ordering, type tags, nested objects/arrays, Date values, unsupported fallback, and cycles.