### PR TITLE
fix: Simplify previous reputationScore fix.

### DIFF
--- a/packages/core/src/batchloaders/populateBatchLoader.ts
+++ b/packages/core/src/batchloaders/populateBatchLoader.ts
@@ -14,7 +14,6 @@ import {
 import { LoadHint } from "../loadHints";
 import { hintKey } from "../normalizeHints";
 import { getRelationFromMaybePolyKey, isPolyHint } from "../reactiveHints";
-import { AbstractRelationImpl } from "../relations/AbstractRelationImpl";
 import { ReactiveFieldImpl } from "../relations/ReactiveField";
 import { toArray } from "../utils";
 import { BatchLoader } from "./BatchLoader";
@@ -45,9 +44,7 @@ export function populateBatchLoader(
   // hint, then use a batch key that includes the hint itself, which will make it unlikely
   // for non-sql relations to deadlock on each other/themselves.
   const batchKey =
-    mode === "preload"
-      ? `${meta.tagName}:${opts.forceReload}`
-      : `${meta.tagName}:${hintKey(hint)}:${opts.forceReload}`;
+    mode === "preload" ? `${meta.tagName}:${opts.forceReload}` : `${meta.tagName}:${hintKey(hint)}:${opts.forceReload}`;
   return em.getBatchLoader(populateOperation, batchKey, async (populates) => {
     async function populateLayer(layerMeta: EntityMetadata | undefined, layerNode: HintNode<Entity>): Promise<void> {
       // Skip join-based preloading if nothing in this layer needs loading. If any entity in the list
@@ -98,8 +95,7 @@ export function populateBatchLoader(
       // First pass: batch SQL relations directly, fall back to relation.load() for non-SQL
       const batchPromises = new Set<Promise<void>>();
       const relationsToPreload: { preload(): void }[] = [];
-      const fallbackRelations: AbstractRelationImpl<any, any>[] = [];
-      const fallbackProperties: Array<{ load(opts?: { forceReload?: boolean }): Promise<any> }> = [];
+      const fallbackPromises: (Promise<any> | undefined)[] = [];
 
       for (const [key, tree] of Object.entries(layerNode.hints)) {
         const field = layerMeta?.allFields[key];
@@ -153,25 +149,15 @@ export function populateBatchLoader(
               }
             }
           }
-          if (relation instanceof AbstractRelationImpl) {
-            fallbackRelations.push(relation);
-          } else {
-            fallbackProperties.push(relation);
-          }
+          fallbackPromises.push(relation.load(opts) as Promise<any>);
         }
       }
 
-      if (batchPromises.size > 0) {
-        await Promise.all([...batchPromises]);
+      if (batchPromises.size > 0 || fallbackPromises.length > 0) {
+        await Promise.all([Promise.all(batchPromises), Promise.all(fallbackPromises)]);
       }
       for (const relation of relationsToPreload) {
         relation.preload();
-      }
-      if (fallbackRelations.length > 0) {
-        await Promise.all(fallbackRelations.map((relation) => relation.load(opts)));
-      }
-      for (const property of fallbackProperties) {
-        await property.load(opts);
       }
 
       // 2nd breadth-width pass to do nested load hints, this will fan out at the sibling level.

--- a/packages/tests/integration/src/EntityManager.joins.test.ts
+++ b/packages/tests/integration/src/EntityManager.joins.test.ts
@@ -14,7 +14,7 @@ import {
 import { isPreloadingEnabled, newEntityManager, queries, resetQueryCount } from "@src/testEm";
 import { testing } from "joist-orm";
 import { jan1, jan2 } from "src/testDates";
-import { Author, Book, Critic, LargePublisher, Publisher, newAuthor } from "./entities";
+import { Author, Book, Critic, LargePublisher, Publisher } from "./entities";
 
 const { partitionHint } = testing;
 
@@ -218,18 +218,13 @@ describe("EntityManager.joins", () => {
   });
 
   it("doesn't deadlock on recursive properties", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertAuthor({ first_name: "a2", mentor_id: 1 });
     const em = newEntityManager();
-    const a1 = newAuthor(em, { firstName: "a1" });
-    const a2 = newAuthor(em, { firstName: "a2", mentor: a1 });
-    const result = await Promise.race([
-      em.populate([a1, a2], "reputationScore").then(([a1Loaded, a2Loaded]) => {
-        expect(a1Loaded.reputationScore.get).toBe(0);
-        expect(a2Loaded.reputationScore.get).toBe(0);
-        return "done";
-      }),
-      new Promise((resolve) => setTimeout(() => resolve("timeout"), 1000)),
-    ]);
-    expect(result).toBe("done");
+    const authors = await em.find(Author, {});
+    const [a1Loaded, a2Loaded] = await em.populate(authors, "reputationScore");
+    expect(a1Loaded.reputationScore.get).toBe(0);
+    expect(a2Loaded.reputationScore.get).toBe(0);
   });
 
   it("preloads em.find", async () => {


### PR DESCRIPTION
It turns out `batchPromises` and `fallbackPromises` was already doing the "SQL-only first, relations later" split the mentioned in the previous PR, so I think this bug was already fixed.

I.e. this PR largely reverts the prior PR, but keeps the reproduction test case, and it still passes, indicating that either:

a) the repro test case never actually reproduced the bug :thinking:, b) the repro test case did reproduce the bug, but we've since fixed it

The populateBatchLoader has been heavily rewritten/refactored since the original bug report, so my assumption is that it's b) and that prior refactoring happened to fix this bug.