### PR TITLE
fix: load m2m join rows via base meta for mixed STI subtypes.

### DIFF
--- a/packages/core/src/EntityMetadata.ts
+++ b/packages/core/src/EntityMetadata.ts
@@ -2,6 +2,7 @@ import { getInstanceData } from "./BaseEntity";
 import { Entity, isEntity } from "./Entity";
 import { EntityManager, MaybeAbstractEntityConstructor, TimestampFields } from "./EntityManager";
 import { type ConfigApi, type Reactable, type ReactiveRule } from "./config";
+import { getMetadataForType } from "./configure";
 import { DeepNew } from "./loadHints";
 import { FieldSerde, PolymorphicKeySerde } from "./serde";
 
@@ -15,6 +16,14 @@ export function getMetadata<T extends Entity>(
   return (
     typeof param === "function" ? (param as any).metadata : "cstr" in param ? param : getInstanceData(param).metadata
   ) as EntityMetadata;
+}
+
+/** Returns the metadata layer that declares `fieldName`, i.e. `Task.tags` for `TaskOld.tags`. */
+export function getMetadataForField(meta: EntityMetadata, fieldName: string): EntityMetadata {
+  while (!(fieldName in meta.fields) && meta.baseType) {
+    meta = getMetadataForType(meta.baseType);
+  }
+  return meta;
 }
 
 /**

--- a/packages/core/src/JoinRows.ts
+++ b/packages/core/src/JoinRows.ts
@@ -1,6 +1,6 @@
 import { Entity } from "./Entity";
 import { getEmInternalApi } from "./EntityManager";
-import { EntityMetadata, getBaseAndSelfMetas, getBaseMeta } from "./EntityMetadata";
+import { EntityMetadata, getBaseAndSelfMetas } from "./EntityMetadata";
 import { ReactionsManager } from "./ReactionsManager";
 import { JoinRowTodo } from "./Todo";
 import { keyToTaggedId } from "./keys";
@@ -153,12 +153,8 @@ export class JoinRows {
       twoIds.push(keyToTaggedId(meta2, dbRow[column2])!);
     }
 
-    // Make sure we have entities in memory for all the joined-to tables. For STI, the subtypes
-    // share the base table, so load via the base meta to let a batch hold mixed subtypes without
-    // tripping the STI guard in `em.loadAll`
-    const baseMeta1 = meta1.inheritanceType === "sti" ? getBaseMeta(meta1) : meta1;
-    const baseMeta2 = meta2.inheritanceType === "sti" ? getBaseMeta(meta2) : meta2;
-    await Promise.all([em.loadAll(baseMeta1.cstr, oneIds), em.loadAll(baseMeta2.cstr, twoIds)]);
+    // Make sure we have entities in memory for all the joined-to tables.
+    await Promise.all([em.loadAll(meta1.cstr, oneIds), em.loadAll(meta2.cstr, twoIds)]);
 
     // If we're doing a em.refresh/reload, we need to watch for rows that are no longer here
     const existingRows = new Set<JoinRow>();

--- a/packages/core/src/JoinRows.ts
+++ b/packages/core/src/JoinRows.ts
@@ -153,9 +153,12 @@ export class JoinRows {
       twoIds.push(keyToTaggedId(meta2, dbRow[column2])!);
     }
 
-    // Make sure we have entities in memory for all the joined-to tables. Load via the base
-    // meta so an STI base's join table can hold mixed subtypes without tripping the STI guard in `em.loadAll`
-    await Promise.all([em.loadAll(getBaseMeta(meta1).cstr, oneIds), em.loadAll(getBaseMeta(meta2).cstr, twoIds)]);
+    // Make sure we have entities in memory for all the joined-to tables. For STI, the subtypes
+    // share the base table, so load via the base meta to let a batch hold mixed subtypes without
+    // tripping the STI guard in `em.loadAll`
+    const baseMeta1 = meta1.inheritanceType === "sti" ? getBaseMeta(meta1) : meta1;
+    const baseMeta2 = meta2.inheritanceType === "sti" ? getBaseMeta(meta2) : meta2;
+    await Promise.all([em.loadAll(baseMeta1.cstr, oneIds), em.loadAll(baseMeta2.cstr, twoIds)]);
 
     // If we're doing a em.refresh/reload, we need to watch for rows that are no longer here
     const existingRows = new Set<JoinRow>();

--- a/packages/core/src/JoinRows.ts
+++ b/packages/core/src/JoinRows.ts
@@ -1,6 +1,6 @@
 import { Entity } from "./Entity";
 import { getEmInternalApi } from "./EntityManager";
-import { EntityMetadata, getBaseAndSelfMetas } from "./EntityMetadata";
+import { EntityMetadata, getBaseAndSelfMetas, getBaseMeta } from "./EntityMetadata";
 import { ReactionsManager } from "./ReactionsManager";
 import { JoinRowTodo } from "./Todo";
 import { keyToTaggedId } from "./keys";
@@ -153,8 +153,9 @@ export class JoinRows {
       twoIds.push(keyToTaggedId(meta2, dbRow[column2])!);
     }
 
-    // Make sure we have entities in memory for all the joined-to tables
-    await Promise.all([em.loadAll(meta1.cstr, oneIds), em.loadAll(meta2.cstr, twoIds)]);
+    // Make sure we have entities in memory for all the joined-to tables. Load via the base
+    // meta so an STI base's join table can hold mixed subtypes without tripping the STI guard in `em.loadAll`
+    await Promise.all([em.loadAll(getBaseMeta(meta1).cstr, oneIds), em.loadAll(getBaseMeta(meta2).cstr, twoIds)]);
 
     // If we're doing a em.refresh/reload, we need to watch for rows that are no longer here
     const existingRows = new Set<JoinRow>();

--- a/packages/core/src/batchloaders/manyToManyBatchLoader.ts
+++ b/packages/core/src/batchloaders/manyToManyBatchLoader.ts
@@ -1,6 +1,6 @@
 import { Entity } from "../Entity";
 import { EntityManager, getEmInternalApi } from "../EntityManager";
-import { getMetadata, keyToNumber, ManyToManyLike, ParsedFindQuery } from "../index";
+import { keyToNumber, ManyToManyLike, ParsedFindQuery } from "../index";
 import { abbreviation, getOrSet } from "../utils";
 import { BatchLoader } from "./BatchLoader";
 
@@ -33,7 +33,7 @@ async function loadBatch<U extends Entity>(collection: ManyToManyLike, keys: str
       kind: "exp",
       op: "or",
       conditions: Object.entries(columns).map(([columnId, values]) => {
-        const meta = collection.columnName == columnId ? getMetadata(collection.entity) : collection.otherMeta;
+        const meta = collection.columnName == columnId ? collection.meta : collection.otherMeta;
         return {
           kind: "column",
           alias,

--- a/packages/core/src/batchloaders/recursiveM2mBatchLoader.ts
+++ b/packages/core/src/batchloaders/recursiveM2mBatchLoader.ts
@@ -1,8 +1,8 @@
-import { getMetadataForType } from "../configure";
 import { Entity } from "../Entity";
 import { EntityManager, getEmInternalApi } from "../EntityManager";
 import {
   isLoadedCollection,
+  getMetadataForField,
   keyToTaggedId,
   kq,
   kqDot,
@@ -22,7 +22,7 @@ export function recursiveM2mBatchLoader<T extends Entity, U extends Entity>(
   collection: RecursiveM2mCollectionImpl<T, U>,
 ): BatchLoader<Entity> {
   let { meta, fieldName } = collection;
-  while (!(collection.m2mFieldName in meta.allFields) && meta.baseType) meta = getMetadataForType(meta.baseType);
+  meta = getMetadataForField(meta, collection.m2mFieldName);
   const batchKey = `${meta.tableName}-${fieldName}`;
   return em.getBatchLoader(recursiveM2mOperation, batchKey, async (entities) => {
     const m2mField = meta.allFields[collection.m2mFieldName] as ManyToManyField;

--- a/packages/core/src/relations/ManyToManyCollection.ts
+++ b/packages/core/src/relations/ManyToManyCollection.ts
@@ -6,6 +6,7 @@ import {
   EntityMetadata,
   getEmInternalApi,
   getInstanceData,
+  getMetadataForField,
   getMetadata,
   IdOf,
   ManyToManyField,
@@ -210,11 +211,11 @@ export class ManyToManyCollection<T extends Entity, U extends Entity>
   }
 
   get meta(): EntityMetadata {
-    return getMetadata(this.entity);
+    return getMetadataForField(getMetadata(this.entity), this.fieldName);
   }
 
   get otherMeta(): EntityMetadata {
-    return (getMetadata(this.entity).allFields[this.fieldName] as ManyToManyField).otherMetadata();
+    return this.#field.otherMetadata();
   }
 
   get joinTableName(): string {

--- a/packages/core/src/relations/ManyToManyLargeCollection.ts
+++ b/packages/core/src/relations/ManyToManyLargeCollection.ts
@@ -1,7 +1,7 @@
 import { manyToManyFindDataLoader } from "../dataloaders/manyToManyFindDataLoader";
 import { Entity } from "../Entity";
 import { appendStack, IdOf } from "../EntityManager";
-import { EntityMetadata } from "../EntityMetadata";
+import { EntityMetadata, getMetadataForField } from "../EntityMetadata";
 import { ensureNotDeleted, getMetadata, ManyToManyCollection, toTaggedId } from "../index";
 import { lazyField, resolveOtherMeta } from "../newEntity";
 import { remove } from "../utils";
@@ -126,7 +126,7 @@ export class ManyToManyLargeCollection<T extends Entity, U extends Entity> imple
   }
 
   public get meta(): EntityMetadata {
-    return getMetadata(this.entity);
+    return getMetadataForField(getMetadata(this.entity), this.fieldName);
   }
 
   public toString(): string {

--- a/packages/core/src/relations/OneToManyCollection.ts
+++ b/packages/core/src/relations/OneToManyCollection.ts
@@ -8,6 +8,7 @@ import {
   EntityMetadata,
   getEmInternalApi,
   getInstanceData,
+  getMetadataForField,
   getMetadata,
   IdOf,
   maybeResolveReferenceToId,
@@ -247,11 +248,11 @@ export class OneToManyCollection<T extends Entity, U extends Entity>
   }
 
   public get meta(): EntityMetadata {
-    return getMetadata(this.entity);
+    return getMetadataForField(getMetadata(this.entity), this.fieldName);
   }
 
   public get otherMeta(): EntityMetadata {
-    return (getMetadata(this.entity).allFields[this.fieldName] as OneToManyField).otherMetadata();
+    return this.#field.otherMetadata();
   }
 
   public get hasBeenSet(): boolean {

--- a/packages/core/src/relations/OneToManyLargeCollection.ts
+++ b/packages/core/src/relations/OneToManyLargeCollection.ts
@@ -1,7 +1,7 @@
 import { oneToManyFindDataLoader } from "../dataloaders/oneToManyFindDataLoader";
 import { Entity } from "../Entity";
 import { appendStack, IdOf, sameEntity } from "../EntityManager";
-import { EntityMetadata, LargeOneToManyField } from "../EntityMetadata";
+import { EntityMetadata, getMetadataForField, LargeOneToManyField } from "../EntityMetadata";
 import { ensureNotDeleted, getMetadata, ManyToOneReferenceImpl } from "../index";
 import { lazyField } from "../newEntity";
 import { remove } from "../utils";
@@ -84,7 +84,7 @@ export class OneToManyLargeCollection<T extends Entity, U extends Entity> implem
   }
 
   get meta(): EntityMetadata {
-    return getMetadata(this.entity);
+    return getMetadataForField(getMetadata(this.entity), this.fieldName);
   }
 
   // These are public to our internal implementation but not exposed in the Collection API

--- a/packages/core/src/relations/ReactiveManyToMany.ts
+++ b/packages/core/src/relations/ReactiveManyToMany.ts
@@ -5,6 +5,7 @@ import {
   fail,
   getEmInternalApi,
   getInstanceData,
+  getMetadataForField,
   getMetadata,
   isLoaded,
   ManyToManyField,
@@ -195,7 +196,7 @@ export class ReactiveManyToManyImpl<T extends Entity, U extends Entity, H extend
 
   // Properties needed for JoinRows/ManyToManyCollection compatibility
   get meta(): EntityMetadata {
-    return getMetadata(this.entity);
+    return getMetadataForField(getMetadata(this.entity), this.fieldName);
   }
 
   get fieldName(): string {

--- a/packages/core/src/relations/ReactiveManyToManyOtherSide.ts
+++ b/packages/core/src/relations/ReactiveManyToManyOtherSide.ts
@@ -4,6 +4,7 @@ import {
   EntityMetadata,
   getEmInternalApi,
   getInstanceData,
+  getMetadataForField,
   getMetadata,
   ManyToManyField,
   ReadOnlyCollection,
@@ -109,7 +110,7 @@ export class ReactiveManyToManyOtherSideImpl<T extends Entity, U extends Entity>
 
   // Properties for JoinRows/ManyToManyCollection compatibility
   get meta(): EntityMetadata {
-    return getMetadata(this.entity);
+    return getMetadataForField(getMetadata(this.entity), this.fieldName);
   }
 
   get otherMeta(): EntityMetadata {

--- a/packages/tests/integration/src/SingleTableInheritance.test.ts
+++ b/packages/tests/integration/src/SingleTableInheritance.test.ts
@@ -10,7 +10,7 @@ import {
   TaskOld,
   TaskType,
 } from "src/entities";
-import { insertTask, insertTaskItem, select } from "src/entities/inserts";
+import { insertTag, insertTask, insertTaskItem, insertTaskToTag, select } from "src/entities/inserts";
 import { newEntityManager, queries, resetQueryCount } from "src/testEm";
 
 describe("SingleTableInheritance", () => {
@@ -85,6 +85,26 @@ describe("SingleTableInheritance", () => {
     const [t1, t2] = await em.find(Task, {});
     expect(t1).toBeInstanceOf(TaskNew);
     expect(t2).toBeInstanceOf(TaskOld);
+  });
+
+  it("can load a m2m on a batch of mixed STI subtypes", async () => {
+    // Given two different subtypes that each have a tag, sharing the `task_to_tags` m2m
+    // that is declared on the STI base `Task`
+    await insertTag({ id: 1, name: "t1" });
+    await insertTask({ id: 1, type: "OLD" });
+    await insertTask({ id: 2, type: "NEW" });
+    await insertTaskToTag({ id: 1, task_id: 1, tag_id: 1 });
+    await insertTaskToTag({ id: 2, task_id: 2, tag_id: 1 });
+    const em = newEntityManager();
+    const unloaded = await em.loadAll(Task, ["task:1", "task:2"]);
+    // When we populate `tags` for both subtypes, which share a single `task_to_tags` JoinRows
+    const tasks = await em.populate(unloaded, "tags");
+    // Then the rows load via the base `Task` meta instead of `em.loadAll(<one subtype>, <both ids>)`,
+    // so the STI guard does not fire and each task gets its tag
+    expect(tasks[0]).toBeInstanceOf(TaskOld);
+    expect(tasks[1]).toBeInstanceOf(TaskNew);
+    expect(tasks[0].tags.get).toMatchEntity([{ name: "t1" }]);
+    expect(tasks[1].tags.get).toMatchEntity([{ name: "t1" }]);
   });
 
   it("keeps subtype fields off of the base type", async () => {

--- a/packages/tests/integration/src/entities/inserts.ts
+++ b/packages/tests/integration/src/entities/inserts.ts
@@ -262,6 +262,10 @@ export function insertBookToTag(row: { id?: number; book_id: number; tag_id: num
   return testDriver.insert("books_to_tags", row);
 }
 
+export function insertTaskToTag(row: { id?: number; task_id: number; tag_id: number }) {
+  return testDriver.insert("task_to_tags", row);
+}
+
 export function deleteBookToTag(id: number) {
   return testDriver.delete("books_to_tags", id);
 }


### PR DESCRIPTION
## Problem
  
Given two STI subtypes (e.g. `TaskOld` and `TaskNew`) loading the same m2m field (`tags`) in the same tick, it batches both into a single `JoinRows` keyed by the join table (`task_to_tags`). Whichever subtype touches it first wins, and its *subtype* meta is used to load every row in the batch — so it becomes `em.loadAll(TaskOld, <both TaskOld and TaskNew ids>)`. That trips the STI guard in `loadAll` ("... were not of type TaskOld"), since the batch legitimately holds ids of the other subtype.

## Fix
 
 `JoinRows.loadRows` now loads via `getBaseMeta(meta)`, so joist hydrates each row as its correct subtype (from the discriminator) without the guard firing. Non-STI metas pass through `getBaseMeta` unchanged, so existing behavior is preserved.