### PR TITLE
feat: Always define transientFields.

### DIFF
--- a/packages/core/src/BaseEntity.ts
+++ b/packages/core/src/BaseEntity.ts
@@ -133,6 +133,9 @@ export abstract class BaseEntity<EM extends EntityManager, I extends IdType = Id
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return this.toString();
   }
+
+  /** A bag of non-persisted state, typically for flags that control business logic behavior. */
+  declare readonly transientFields: Record<string, unknown>;
 }
 
 function toStringWithPrefix(meta: EntityMetadata, entity: Entity, prefix: string): string {

--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -20,6 +20,7 @@ export interface Entity {
   readonly isNewEntity: boolean;
   readonly isDeletedEntity: boolean;
   readonly isDirtyEntity: boolean;
+  readonly transientFields: Record<string, unknown>;
   set(opts: unknown): void;
   setPartial(opts: unknown): void;
   setDeepPartial(opts: unknown): Promise<void>;

--- a/packages/core/src/newEntity.ts
+++ b/packages/core/src/newEntity.ts
@@ -33,7 +33,7 @@ export function newEntity<T extends Entity>(em: EntityManager, cstr: EntityConst
 }
 
 function moveRelationsToGetters(cstr: EntityConstructor<any>): void {
-  // Reuse getProperties's detect
+  let transientFieldsValue: any = {};
   for (const [fieldName, value] of getLazyFields(getMetadata(cstr))) {
     if (value instanceof LazyField) {
       Object.defineProperty(cstr.prototype, fieldName, {
@@ -42,21 +42,23 @@ function moveRelationsToGetters(cstr: EntityConstructor<any>): void {
         },
       });
     } else if (fieldName === "transientFields") {
-      Object.defineProperty(cstr.prototype, fieldName, {
-        get(this: any) {
-          // This prototype-level `get` will only ever be called once per instance, b/c when we're
-          // called for the first/only time, we set an instance-level `this.transientFields` that, for
-          // all future calls, will resolve to the instance's own copy of the fields.
-          //
-          // This has the pleasant upshot of making the instance-level `transientFields` lazy, and
-          // they will not be created on an instance until they're actually asked for.
-          const copy = structuredClone(value);
-          Object.defineProperty(this, "transientFields", { value: copy });
-          return copy;
-        },
-      });
+      // We'll define transientFields for all entities outside the loop
+      transientFieldsValue = value;
     }
   }
+  Object.defineProperty(cstr.prototype, "transientFields", {
+    get(this: any) {
+      // This prototype-level `get` will only ever be called once per instance, b/c when we're
+      // called for the first/only time, we set an instance-level `this.transientFields` that, for
+      // all future calls, will resolve to the instance's own copy of the fields.
+      //
+      // This has the pleasant upshot of making the instance-level `transientFields` lazy, and
+      // they will not be created on an instance until they're actually asked for.
+      const copy = structuredClone(transientFieldsValue);
+      Object.defineProperty(this, "transientFields", { value: copy });
+      return copy;
+    },
+  });
 }
 
 /**

--- a/packages/tests/integration/src/Entity.test.ts
+++ b/packages/tests/integration/src/Entity.test.ts
@@ -1,4 +1,4 @@
-import { Author, newAuthor, newBook } from "@src/entities";
+import { Author, Comment, newAuthor, newBook } from "@src/entities";
 import { insertAuthor } from "@src/entities/inserts";
 import { newEntityManager } from "@src/testEm";
 import { getInstanceData } from "joist-orm";
@@ -209,6 +209,13 @@ describe("Entity", () => {
     const author = newAuthor(em);
     const result = author.thisTestProp.load();
     await expect(result).rejects.toThrow("Cannot use 'this' in a property callback");
+  });
+
+  it("always has a transientFields", async () => {
+    const em = newEntityManager();
+    const author = newAuthor(em);
+    const comment = em.create(Comment, { parent: author, text: "c1" });
+    expect(comment.transientFields).toEqual({});
   });
 });
 


### PR DESCRIPTION
This lets generic code assuming that transientFields is available, even if the entity itself does not declare any.