### PR TITLE
fix: Exclude em.deleted entities from findCount.

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -54,6 +54,7 @@ import {
   GraphQLFilterWithAlias,
   InstanceData,
   isLoadedReference,
+  keyToNumber,
   Lens,
   loadLens,
   OneToManyCollection,
@@ -326,6 +327,12 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
       hasAnyDeletes(): boolean {
         return em.#hasAnyDeletes;
+      },
+
+      pendingDeleteIds(type: MaybeAbstractEntityConstructor<Entity>): readonly IdType[] {
+        return em.#pendingDeletes
+          .filter((entity) => entity instanceof type && entity.idMaybe !== undefined)
+          .map((entity) => keyToNumber(getMetadata(entity), entity.id));
       },
 
       isMerging(entity: EntityW): boolean {
@@ -689,7 +696,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     // WIP creates/deletes. We can't do this if the WHERE clause is populated b/c
     // then we'd also have to eval each created/deleted entity against the WHERE
     // clause before knowing if it should adjust teh amount.
-    const isSelectAll = Object.keys(where).length === 0;
+    const isSelectAll = Object.keys(where).length === 0 && options.conditions === undefined;
     if (isSelectAll) {
       const tagged = this.#entitiesByTag.get(getMetadata(type).tagName) ?? [];
       for (const entity of tagged) {
@@ -2639,6 +2646,7 @@ export interface EntityManagerInternalApi {
   markMaybePending(entity: EntityW): void;
   unmarkMaybePending(entity: EntityW): void;
   hasAnyDeletes(): boolean;
+  pendingDeleteIds(type: MaybeAbstractEntityConstructor<Entity>): readonly IdType[];
   setIsRefreshing(isRefreshing: boolean): void;
 }
 

--- a/packages/core/src/dataloaders/findCountDataLoader.ts
+++ b/packages/core/src/dataloaders/findCountDataLoader.ts
@@ -1,6 +1,6 @@
-import { Entity } from "../Entity";
+import { Entity, IdType } from "../Entity";
 import { FilterAndSettings } from "../EntityFilter";
-import { EntityManager, MaybeAbstractEntityConstructor } from "../EntityManager";
+import { EntityManager, getEmInternalApi, MaybeAbstractEntityConstructor } from "../EntityManager";
 import { getMetadata } from "../EntityMetadata";
 import { kq } from "../keywords";
 import { ParsedFindQuery, parseFindQuery } from "../QueryParser";
@@ -28,10 +28,11 @@ export function findCountDataLoader<T extends Entity>(
 
   const meta = getMetadata(type);
   const query = parseFindQuery(meta, where, opts);
+  const pendingDeletedIds = appendPendingDeletedIds(em, type, query, meta.idDbType, where, opts);
   const { findSettings } = em["prepareFind"](meta, findCountOperation, query, { ...opts, checkLimit: false });
   const bindings: any[] = [];
   collectValues(bindings, query);
-  const prepared = { filter, query, bindings, findSettings };
+  const prepared = { filter, pendingDeletedIds, query, bindings, findSettings };
   const batchKey = getBatchKeyFromGenericStructure(meta, query);
 
   return em
@@ -94,7 +95,45 @@ export function findCountDataLoader<T extends Entity>(
         return results;
       },
       // Our filter/order tuple is a complex object, so use a stable cache key to ensure caching works.
-      { cacheKeyFn: (entry) => whereFilterHash(entry.filter) },
+      {
+        cacheKeyFn: (entry) => {
+          // Include pendingDeletedIds so that each new em.delete => recalcs the count
+          return whereFilterHash({ ...entry.filter, pendingDeletedIds: entry.pendingDeletedIds });
+        },
+      },
     )
     .load(prepared);
+}
+
+/** Adds `id not in pendingDeletedIds` to the count query so pending deletes are excluded in SQL. */
+function appendPendingDeletedIds<T extends Entity>(
+  em: EntityManager,
+  type: MaybeAbstractEntityConstructor<T>,
+  query: ParsedFindQuery,
+  idDbType: "bigint" | "int" | "uuid" | "text",
+  where: FilterAndSettings<T>["where"],
+  opts: Omit<FilterAndSettings<T>, "where">,
+): readonly IdType[] {
+  const pendingDeletedIds =
+    Object.keys(where).length === 0 && opts.conditions === undefined ? [] : getEmInternalApi(em).pendingDeleteIds(type);
+  if (pendingDeletedIds.length === 0) return pendingDeletedIds;
+
+  const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
+  const condition = {
+    kind: "column" as const,
+    alias: primary.alias,
+    column: "id",
+    dbType: idDbType,
+    cond: { kind: "nin" as const, value: pendingDeletedIds },
+    pruneable: true,
+  };
+
+  if (!query.condition) {
+    query.condition = { kind: "exp", op: "and", conditions: [condition] };
+  } else if (query.condition.op === "and") {
+    query.condition.conditions.push(condition);
+  } else {
+    query.condition = { kind: "exp", op: "and", conditions: [query.condition, condition] };
+  }
+  return pendingDeletedIds;
 }

--- a/packages/core/src/dataloaders/findDataLoader.ts
+++ b/packages/core/src/dataloaders/findDataLoader.ts
@@ -54,7 +54,7 @@ export function findDataLoader<T extends Entity>(
   });
   const bindings: any[] = [];
   collectValues(bindings, query);
-  const prepared = { filter, query, bindings, findSettings, checkLimit };
+  const prepared = { filter, query, bindings, findSettings, checkLimit } satisfies PreparedFindEntry<T>;
   const batchKey = getBatchKeyFromGenericStructure(meta, query);
 
   return em
@@ -149,7 +149,7 @@ export function findDataLoader<T extends Entity>(
     .load(prepared);
 }
 
-export function whereFilterHash(where: FilterAndSettings<any>): any {
+export function whereFilterHash(where: object): any {
   const key = fastWhereFilterHash(where);
   if (key === undefined) throw new Error("fastWhereFilterHash could not serialize find filter");
   return key;

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -16,17 +16,17 @@ import {
 } from "@src/entities/inserts";
 import { newEntityManager, numberOfQueries, queries, resetQueryCount } from "@src/testEm";
 import {
-  EntityFilter,
-  ExpressionFilter,
-  NotFoundError,
-  TooManyError,
-  UniqueFilter,
   alias,
   aliases,
+  EntityFilter,
+  ExpressionFilter,
   getAliasMetadata,
   getMetadata,
+  NotFoundError,
   optimizeCollectionJoins,
   parseFindQuery,
+  TooManyError,
+  UniqueFilter,
 } from "joist-orm";
 import { PasswordValue } from "src/entities/types";
 import { jan1, jan2, jan3 } from "src/testDates";
@@ -46,6 +46,9 @@ import {
   FavoriteShape,
   Image,
   ImageType,
+  newAuthor,
+  newBook,
+  newTag,
   Publisher,
   PublisherFilter,
   PublisherId,
@@ -59,9 +62,6 @@ import {
   TaskItemFilter,
   User,
   UserFilter,
-  newAuthor,
-  newBook,
-  newTag,
 } from "./entities";
 import { twoOf } from "./utils";
 
@@ -3943,6 +3943,20 @@ describe("EntityManager.queries", () => {
       expect(c2).toBe(1);
       // And we didn't make an extra query for it
       expect(numberOfQueries).toBe(1);
+    });
+
+    it("can count with filters and exclude deleted entities", async () => {
+      // Given we have two authors
+      await insertAuthor({ first_name: "a1" });
+      await insertAuthor({ first_name: "a2" });
+      const em = newEntityManager();
+      const a1 = await em.load(Author, "a:1");
+      // And initially findCount returns 1
+      expect(await em.findCount(Author, { firstName: "a1" }, opts)).toBe(1);
+      // When we delete the author
+      em.delete(a1);
+      // Then findCount returns 0
+      expect(await em.findCount(Author, { firstName: "a1" }, opts)).toBe(0);
     });
 
     it("can count with dates between", async () => {


### PR DESCRIPTION
Fixes a bug in our production app where a validation rule had to be fixed to "oh right don't count already-deleted things":

```
    this.em.findCount(TakeoffLineItem, {
        options: this,
        active: true,
        id: { nin: deletedTlis.map((tli) => tli.id) },
     }),
```

I.e. this PR auto-injects the `nin` clause.


---

I am a little hesitant about this b/c it sets the precedence for "em.find queries respect WIP deletes", i.e. scenarios like:

* There is 1 author + 1 book
* We em.delete(book) but now do
* `em.find(Author, { books: { title: "b1" } })` --> should we inject `id: { nin: deleted books }`?
* `em.findCount(Author, { books: { title: "b1" } })` --> same, should this return 0?

The current PR fixes "only findCount" and "only the top-level entity is deleted", but arguably the generalization here is "any find" and "any joined table" which seems ... technically correct, but maybe weird? 