### PR TITLE
fix: Skip preloading GraphQL fields with arguments.

### DIFF
--- a/packages/graphql-resolver-utils/src/hint.ts
+++ b/packages/graphql-resolver-utils/src/hint.ts
@@ -38,6 +38,8 @@ export function selectionSetToObject(
   const result: Record<string, any> = {};
   for (const selection of selectionSet.selections) {
     if (selection.kind === "Field") {
+      // If there are arguments, defer to the field resolver to apply them.
+      if (selection.arguments && selection.arguments.length > 0) continue;
       const fieldName = selection.name.value;
       const field = gqlType.getFields()[fieldName];
       // This might be __typename, which is a meta field

--- a/packages/tests/integration/src/entityResolver.test.ts
+++ b/packages/tests/integration/src/entityResolver.test.ts
@@ -4,9 +4,24 @@ import { Author, BookRange, type Publisher } from "@src/entities";
 import { insertAuthor, insertBook, insertPublisher, update } from "@src/entities/inserts";
 import { type Resolver } from "@src/generated/graphql-types";
 import { newEntityManager } from "@src/testEm";
-import { entityResolver } from "joist-graphql-resolver-utils";
+import {
+  type FieldNode,
+  type GraphQLResolveInfo,
+  type GraphQLSchema,
+  isOutputType,
+  Kind,
+  type SelectionNode,
+} from "graphql";
+import { convertInfoToLoadHint, entityResolver } from "joist-graphql-resolver-utils";
+import { getMetadata } from "joist-orm";
 
 describe("entityResolver", () => {
+  let schema: GraphQLSchema;
+
+  beforeAll(async () => {
+    schema = await loadSchema("./schema/**/*.graphql", { loaders: [new GraphQLFileLoader()] });
+  });
+
   it("fails type-checking a required GraphQL field backed by a nullable m2o", () => {
     // @ts-expect-error Author.publisher is nullable, so it cannot satisfy a required GraphQL Publisher field.
     const resolvers: { publisher: Resolver<Author, {}, Publisher> } = entityResolver(Author);
@@ -33,8 +48,6 @@ describe("entityResolver", () => {
   });
 
   it("m2o calls populate if selection set", async () => {
-    const schema = await loadSchema("./schema/**/*.graphql", { loaders: [new GraphQLFileLoader()] });
-
     // Given an author with a publisher
     await insertPublisher({ name: "p1" });
     await insertAuthor({ first_name: "a1", publisher_id: 1 });
@@ -61,7 +74,6 @@ describe("entityResolver", () => {
 
   it("m2o does not populate if no selection set", async () => {
     const em = newEntityManager();
-    const schema = await loadSchema("./schema/**/*.graphql", { loaders: [new GraphQLFileLoader()] });
 
     // Given an author with a publisher
     await insertPublisher({ name: "p1" });
@@ -79,8 +91,6 @@ describe("entityResolver", () => {
   });
 
   it("m2o does not call populate if there are arguments", async () => {
-    const schema = await loadSchema("./schema/**/*.graphql", { loaders: [new GraphQLFileLoader()] });
-
     // Given an author with a publisher
     await insertPublisher({ name: "p1" });
     await insertAuthor({ first_name: "a1", publisher_id: 1 });
@@ -106,9 +116,37 @@ describe("entityResolver", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it("includes nested relations without arguments in load hints", async () => {
+    // Given a nested GraphQL selection without arguments, I.e. query { author(id) { books { reviews { rating } } } }
+    const info = newResolveInfo(schema, "Author", [field("books", [field("reviews", [field("rating")])])]);
+
+    // When we convert it to a Joist load hint
+    // Then we include all nested relations
+    expect(convertInfoToLoadHint(getMetadata(Author), info)).toEqual({ books: { reviews: {} } });
+  });
+
+  it("excludes nested relations with arguments from load hints", async () => {
+    // Given a nested GraphQL selection with arguments, I.e. query { author(id) { books { reviews(first: 5) { rating } } } }
+    const info = newResolveInfo(schema, "Author", [field("books", [field("reviews", [field("rating")], ["first"])])]);
+
+    // When we convert it to a Joist load hint
+    // Then we exclude the argument-bearing relation
+    expect(convertInfoToLoadHint(getMetadata(Author), info)).toEqual({ books: {} });
+  });
+
+  it("excludes deeply nested relations with arguments while keeping parent relations in load hints", async () => {
+    // Given a deeply nested GraphQL selection with arguments, I.e. query { author(id) { books { reviews { book(first: 5) { title } } } } }
+    const info = newResolveInfo(schema, "Author", [
+      field("books", [field("reviews", [field("book", [field("title")], ["first"])])]),
+    ]);
+
+    // When we convert it to a Joist load hint
+    // Then we keep parent relations and exclude the argument-bearing relation
+    expect(convertInfoToLoadHint(getMetadata(Author), info)).toEqual({ books: { reviews: {} } });
+  });
+
   it("derived m2o calls populate if selection set", async () => {
     const em = newEntityManager();
-    const schema = await loadSchema("./schema/**/*.graphql", { loaders: [new GraphQLFileLoader()] });
 
     // Given an author with a favorite book
     await insertAuthor({ first_name: "a1" });
@@ -153,3 +191,34 @@ describe("entityResolver", () => {
     expect(result).toBe(false);
   });
 });
+
+/** Creates a minimal GraphQL resolve info for testing load hint conversion. */
+function newResolveInfo(
+  schema: GraphQLSchema,
+  returnTypeName: string,
+  selections: SelectionNode[],
+): GraphQLResolveInfo {
+  const returnType = schema.getType(returnTypeName);
+  if (returnType === undefined || !isOutputType(returnType)) {
+    throw new Error(`No GraphQL type named ${returnTypeName}`);
+  }
+  return {
+    schema,
+    returnType,
+    fieldNodes: [{ kind: Kind.FIELD, selectionSet: { kind: Kind.SELECTION_SET, selections } }],
+  } as unknown as GraphQLResolveInfo;
+}
+
+/** Creates a minimal GraphQL field AST node for testing load hint conversion. */
+function field(name: string, selections?: SelectionNode[], args?: string[]): FieldNode {
+  return {
+    kind: Kind.FIELD,
+    name: { kind: Kind.NAME, value: name },
+    arguments: args?.map((arg) => ({
+      kind: Kind.ARGUMENT,
+      name: { kind: Kind.NAME, value: arg },
+      value: { kind: Kind.INT, value: "1" },
+    })),
+    selectionSet: selections ? { kind: Kind.SELECTION_SET, selections } : undefined,
+  };
+}


### PR DESCRIPTION
I.e. they might be doing a `first: 10` or some other "do not load everything" query that we need to just defer to the custom field resolver to handle.