### PR TITLE
m2mBatchInsert throws "has no id yet" for an entity deleted mid-flush

### DIFF
--- a/packages/tests/bun-sql-pg/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/bun-sql-pg/src/entities/codegen/BookCodegen.ts
@@ -73,7 +73,6 @@ export interface BookGraphQLFilter {
   id?: ValueGraphQLFilter<BookId>;
   title?: ValueGraphQLFilter<string>;
   author?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, never>;
-  authorId?: ValueGraphQLFilter<AuthorId>;
 }
 
 export interface BookOrder {

--- a/packages/tests/bun/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/bun/src/entities/codegen/BookCodegen.ts
@@ -73,7 +73,6 @@ export interface BookGraphQLFilter {
   id?: ValueGraphQLFilter<BookId>;
   title?: ValueGraphQLFilter<string>;
   author?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, never>;
-  authorId?: ValueGraphQLFilter<AuthorId>;
 }
 
 export interface BookOrder {

--- a/packages/tests/esm/graphql-codegen-joist.mjs
+++ b/packages/tests/esm/graphql-codegen-joist.mjs
@@ -2,7 +2,6 @@ export const mappers = {
   Author: "src/entities/index#Author",
   Book: "src/entities/index#Book",
   ColorDetail: "src/entities/index#Color",
-  PageInfo: "joist-graphql-resolver-utils/index#CursorPageInfo",
 };
 
 export const enumValues = { Color: "src/entities/index#Color" };

--- a/packages/tests/esm/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/esm/src/entities/codegen/AuthorCodegen.ts
@@ -29,7 +29,6 @@ import {
   setField,
   setOpts,
   type TaggedId,
-  Temporal,
   toIdOf,
   toJSON,
   type ToJsonHint,
@@ -37,6 +36,7 @@ import {
   type ValueFilter,
   type ValueGraphQLFilter,
 } from "joist-orm";
+import { Temporal } from "temporal-polyfill";
 import type { Context } from "../../context.js";
 import {
   type Author,

--- a/packages/tests/esm/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/esm/src/entities/codegen/BookCodegen.ts
@@ -73,7 +73,6 @@ export interface BookGraphQLFilter {
   id?: ValueGraphQLFilter<BookId>;
   title?: ValueGraphQLFilter<string>;
   author?: EntityGraphQLFilter<Author, AuthorId, GraphQLFilterOf<Author>, never>;
-  authorId?: ValueGraphQLFilter<AuthorId>;
 }
 
 export interface BookOrder {

--- a/packages/tests/esm/src/entities/codegen/metadata.ts
+++ b/packages/tests/esm/src/entities/codegen/metadata.ts
@@ -1,4 +1,5 @@
-import { configureMetadata, type Entity as Entity2, EntityManager as EntityManager1, type EntityMetadata, EnumArrayFieldSerde, KeySerde, PrimitiveSerde, setRuntimeConfig, Temporal, ZonedDateTimeSerde } from "joist-orm";
+import { configureMetadata, type Entity as Entity2, EntityManager as EntityManager1, type EntityMetadata, EnumArrayFieldSerde, KeySerde, PrimitiveSerde, setRuntimeConfig, ZonedDateTimeSerde } from "joist-orm";
+import { Temporal } from "temporal-polyfill";
 import type { Context } from "../../context.js";
 import { Author } from "../Author.js";
 import { Book } from "../Book.js";

--- a/packages/tests/esm/src/generated/graphql-types.ts
+++ b/packages/tests/esm/src/generated/graphql-types.ts
@@ -1,6 +1,5 @@
 import { Temporal } from "temporal-polyfill"
 import { type GraphQLResolveInfo, GraphQLScalarType } from "graphql";
-import { CursorPageInfo } from "joist-graphql-resolver-utils/index.js";
 import type { Context } from "src/context.js";
 import { Author, Book, Color } from "src/entities/index.js";
 
@@ -9,13 +8,13 @@ export interface Resolvers {
   Book: BookResolvers;
   ColorDetail: ColorDetailResolvers;
   Mutation: MutationResolvers;
-  PageInfo: PageInfoResolvers;
   Query: QueryResolvers;
   AllEnumDetails?: AllEnumDetailsResolvers;
   AuthorsConnection?: AuthorsConnectionResolvers;
   AuthorsEdge?: AuthorsEdgeResolvers;
   BooksConnection?: BooksConnectionResolvers;
   BooksEdge?: BooksEdgeResolvers;
+  PageInfo?: PageInfoResolvers;
   SaveAuthorResult?: SaveAuthorResultResolvers;
   SaveBookResult?: SaveBookResultResolvers;
   DateTime: GraphQLScalarType;
@@ -50,14 +49,6 @@ export interface MutationResolvers {
   saveBook: Resolver<{}, MutationSaveBookArgs, SaveBookResult>;
 }
 
-export interface PageInfoResolvers {
-  endCursor: Resolver<CursorPageInfo, {}, string | null | undefined>;
-  hasNextPage: Resolver<CursorPageInfo, {}, boolean>;
-  hasPreviousPage: Resolver<CursorPageInfo, {}, boolean>;
-  startCursor: Resolver<CursorPageInfo, {}, string | null | undefined>;
-  totalCount: Resolver<CursorPageInfo, {}, number>;
-}
-
 export interface QueryResolvers {
   author: Resolver<{}, QueryAuthorArgs, Author | null | undefined>;
   authors: Resolver<{}, {}, readonly Author[]>;
@@ -72,7 +63,7 @@ export interface AllEnumDetailsResolvers {
 export interface AuthorsConnectionResolvers {
   edges: Resolver<AuthorsConnection, {}, readonly AuthorsEdge[]>;
   nodes: Resolver<AuthorsConnection, {}, readonly Author[]>;
-  pageInfo: Resolver<AuthorsConnection, {}, CursorPageInfo>;
+  pageInfo: Resolver<AuthorsConnection, {}, PageInfo>;
 }
 
 export interface AuthorsEdgeResolvers {
@@ -83,12 +74,20 @@ export interface AuthorsEdgeResolvers {
 export interface BooksConnectionResolvers {
   edges: Resolver<BooksConnection, {}, readonly BooksEdge[]>;
   nodes: Resolver<BooksConnection, {}, readonly Book[]>;
-  pageInfo: Resolver<BooksConnection, {}, CursorPageInfo>;
+  pageInfo: Resolver<BooksConnection, {}, PageInfo>;
 }
 
 export interface BooksEdgeResolvers {
   cursor: Resolver<BooksEdge, {}, string>;
   node: Resolver<BooksEdge, {}, Book>;
+}
+
+export interface PageInfoResolvers {
+  endCursor: Resolver<PageInfo, {}, string | null | undefined>;
+  hasNextPage: Resolver<PageInfo, {}, boolean>;
+  hasPreviousPage: Resolver<PageInfo, {}, boolean>;
+  startCursor: Resolver<PageInfo, {}, string | null | undefined>;
+  totalCount: Resolver<PageInfo, {}, number>;
 }
 
 export interface SaveAuthorResultResolvers {
@@ -138,7 +137,7 @@ export interface AllEnumDetails {
 export interface AuthorsConnection {
   edges: AuthorsEdge[];
   nodes: Author[];
-  pageInfo: CursorPageInfo;
+  pageInfo: PageInfo;
 }
 
 export interface AuthorsEdge {
@@ -149,12 +148,20 @@ export interface AuthorsEdge {
 export interface BooksConnection {
   edges: BooksEdge[];
   nodes: Book[];
-  pageInfo: CursorPageInfo;
+  pageInfo: PageInfo;
 }
 
 export interface BooksEdge {
   cursor: string;
   node: Book;
+}
+
+export interface PageInfo {
+  endCursor: string | null | undefined;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null | undefined;
+  totalCount: number;
 }
 
 export interface SaveAuthorResult {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T1BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T1BookCodegen.ts
@@ -73,7 +73,6 @@ export interface T1BookGraphQLFilter {
   id?: ValueGraphQLFilter<T1BookId>;
   title?: ValueGraphQLFilter<string>;
   author?: EntityGraphQLFilter<T1Author, T1AuthorId, GraphQLFilterOf<T1Author>, never>;
-  authorId?: ValueGraphQLFilter<T1AuthorId>;
 }
 
 export interface T1BookOrder {

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2AuthorCodegen.ts
@@ -79,7 +79,6 @@ export interface T2AuthorGraphQLFilter {
   id?: ValueGraphQLFilter<T2AuthorId>;
   firstName?: ValueGraphQLFilter<string>;
   favoriteBook?: EntityGraphQLFilter<T2Book, T2BookId, GraphQLFilterOf<T2Book>, null>;
-  favoriteBookId?: ValueGraphQLFilter<T2BookId>;
   t2Books?: EntityGraphQLFilter<T2Book, T2BookId, GraphQLFilterOf<T2Book>, null | undefined>;
 }
 

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T2BookCodegen.ts
@@ -79,7 +79,6 @@ export interface T2BookGraphQLFilter {
   id?: ValueGraphQLFilter<T2BookId>;
   title?: ValueGraphQLFilter<string>;
   author?: EntityGraphQLFilter<T2Author, T2AuthorId, GraphQLFilterOf<T2Author>, never>;
-  authorId?: ValueGraphQLFilter<T2AuthorId>;
   t2Authors?: EntityGraphQLFilter<T2Author, T2AuthorId, GraphQLFilterOf<T2Author>, null | undefined>;
 }
 

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3AuthorCodegen.ts
@@ -79,7 +79,6 @@ export interface T3AuthorGraphQLFilter {
   id?: ValueGraphQLFilter<T3AuthorId>;
   firstName?: ValueGraphQLFilter<string>;
   favoriteBook?: EntityGraphQLFilter<T3Book, T3BookId, GraphQLFilterOf<T3Book>, never>;
-  favoriteBookId?: ValueGraphQLFilter<T3BookId>;
   t3Books?: EntityGraphQLFilter<T3Book, T3BookId, GraphQLFilterOf<T3Book>, null | undefined>;
 }
 

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T3BookCodegen.ts
@@ -79,7 +79,6 @@ export interface T3BookGraphQLFilter {
   id?: ValueGraphQLFilter<T3BookId>;
   title?: ValueGraphQLFilter<string>;
   author?: EntityGraphQLFilter<T3Author, T3AuthorId, GraphQLFilterOf<T3Author>, never>;
-  authorId?: ValueGraphQLFilter<T3AuthorId>;
   t3Authors?: EntityGraphQLFilter<T3Author, T3AuthorId, GraphQLFilterOf<T3Author>, null | undefined>;
 }
 

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4AuthorCodegen.ts
@@ -79,7 +79,6 @@ export interface T4AuthorGraphQLFilter {
   id?: ValueGraphQLFilter<T4AuthorId>;
   firstName?: ValueGraphQLFilter<string>;
   favoriteBook?: EntityGraphQLFilter<T4Book, T4BookId, GraphQLFilterOf<T4Book>, never>;
-  favoriteBookId?: ValueGraphQLFilter<T4BookId>;
   t4Books?: EntityGraphQLFilter<T4Book, T4BookId, GraphQLFilterOf<T4Book>, null | undefined>;
 }
 

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T4BookCodegen.ts
@@ -79,7 +79,6 @@ export interface T4BookGraphQLFilter {
   id?: ValueGraphQLFilter<T4BookId>;
   title?: ValueGraphQLFilter<string>;
   author?: EntityGraphQLFilter<T4Author, T4AuthorId, GraphQLFilterOf<T4Author>, never>;
-  authorId?: ValueGraphQLFilter<T4AuthorId>;
   t4Authors?: EntityGraphQLFilter<T4Author, T4AuthorId, GraphQLFilterOf<T4Author>, null | undefined>;
 }
 

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookCodegen.ts
@@ -81,7 +81,6 @@ export interface T5BookGraphQLFilter {
   id?: ValueGraphQLFilter<T5BookId>;
   title?: ValueGraphQLFilter<string>;
   author?: EntityGraphQLFilter<T5Author, T5AuthorId, GraphQLFilterOf<T5Author>, never>;
-  authorId?: ValueGraphQLFilter<T5AuthorId>;
   reviews?: EntityGraphQLFilter<T5BookReview, T5BookReviewId, GraphQLFilterOf<T5BookReview>, null | undefined>;
 }
 

--- a/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookReviewCodegen.ts
+++ b/packages/tests/immediate-foreign-keys/src/entities/codegen/T5BookReviewCodegen.ts
@@ -73,7 +73,6 @@ export interface T5BookReviewGraphQLFilter {
   id?: ValueGraphQLFilter<T5BookReviewId>;
   title?: ValueGraphQLFilter<string>;
   book?: EntityGraphQLFilter<T5Book, T5BookId, GraphQLFilterOf<T5Book>, null>;
-  bookId?: ValueGraphQLFilter<T5BookId>;
 }
 
 export interface T5BookReviewOrder {

--- a/packages/tests/integration/src/entities/Author.ts
+++ b/packages/tests/integration/src/entities/Author.ts
@@ -22,7 +22,7 @@ import {
   isDefined,
   withLoaded,
 } from "joist-orm";
-import { AuthorCodegen, Book, BookRange, BookReview, Comment, Publisher, authorConfig as config } from "./entities";
+import { AuthorCodegen, Book, BookRange, BookReview, Comment, Publisher, Tag, authorConfig as config } from "./entities";
 
 /**
  * The Author entity represents a writer who can publish books.
@@ -134,6 +134,7 @@ export class Author extends AuthorCodegen {
     afterCommitIsDeletedEntity: false,
     setGraduatedInFlush: false,
     setPublisherInFlush: undefined as Publisher | undefined,
+    deleteTagDuringReaction: undefined as Tag | undefined,
     firstIsNotLastNameRuleInvoked: 0,
     mentorRuleInvoked: 0,
     ageRuleInvoked: 0,
@@ -528,6 +529,14 @@ config.addReaction("rr", "rootMentor", (a) => {
 // set-via-hook reaction
 config.addReaction("setViaHook", "graduated", (a) => {
   a.transientFields.reactions.setViaHook += 1;
+});
+
+// This mimics a "noop child" that was created (and hooked) earlier in the flush, had a m2m copied onto it, and is then deleted.
+config.addReaction("deleteTag", "graduated", (a) => {
+  const tag = a.transientFields.deleteTagDuringReaction;
+  if (!tag) return;
+  a.transientFields.deleteTagDuringReaction = undefined;
+  a.em.delete(tag);
 });
 
 // immutable field reaction

--- a/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
+++ b/packages/tests/integration/src/relations/ManyToManyCollection.test.ts
@@ -982,4 +982,23 @@ describe("ManyToManyCollection", () => {
     // which batch contributed which rows.
     expect(tags.map((t) => t.name)).toEqual(["t1", "t2", "t3"]);
   });
+
+  it("does not insert m2m rows for an entity deleted during a reaction", async () => {
+    const em = newEntityManager();
+    // Given an existing author and book review
+    const author = newAuthor(em);
+    const review = newBookReview(em);
+    await em.flush();
+    // And a brand-new (never-flushed) tag linked into the review's `tags` m2m
+    const tag = newTag(em, { name: "noop" });
+    review.tags.add(tag);
+    // When a hook-triggered reaction deletes that still-new tag mid-flush (after it's been hooked)
+    em.touch(author);
+    author.transientFields.setGraduatedInFlush = true;
+    author.transientFields.deleteTagDuringReaction = tag;
+    // Then the flush succeeds: the pending join row to the deleted-never-flushed tag must be pruned, not inserted
+    await em.flush();
+    // And no join row was written
+    expect(await select("book_reviews_to_tags")).toMatchObject([]);
+  });
 });


### PR DESCRIPTION
 If an entity is deleted during a reaction after it's been hooked and after it was linked into a m2m, the pending join row isn't pruned. It survives into `m2mBatchInsert`, which then reads the deleted entity's idTagged, but the entity was never inserted (created-then-deleted), so it has no id:
 
 ```
  Tag has no id yet
    at failNoIdYet (core/src/index.ts:296)
    at m2mBatchInsert (orm/src/drivers/PostgresDriver.ts:262)
 ```
 
 