### PR TITLE
fix: make Temporal usable as a type on Node < 26

### DIFF
--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -30,6 +30,24 @@ export const Temporal = new Proxy(
 ) as typeof TemporalType;
 
 /**
+ * A type-only `Temporal` namespace that merges with the `const Temporal` above.
+ *
+ * The `const` is only a value, so using `Temporal.PlainDate` / `Temporal.ZonedDateTime` as a
+ * type needs a namespace to resolve against. Node 26 has that as a global, but older Node
+ * versions don't, so we add it here by pointing the names at `temporal-polyfill`'s types.
+ */
+export declare namespace Temporal {
+  export type Instant = TemporalType.Instant;
+  export type ZonedDateTime = TemporalType.ZonedDateTime;
+  export type PlainDate = TemporalType.PlainDate;
+  export type PlainTime = TemporalType.PlainTime;
+  export type PlainDateTime = TemporalType.PlainDateTime;
+  export type PlainYearMonth = TemporalType.PlainYearMonth;
+  export type PlainMonthDay = TemporalType.PlainMonthDay;
+  export type Duration = TemporalType.Duration;
+}
+
+/**
  * Conditionally/dynamically requires `temporal-polyfill`.
  *
  * We want to avoid directly importing/requiring `temporal-polyfill` because


### PR DESCRIPTION
Codegen emits `import { Temporal } from "joist-orm"` and uses `Temporal.ZonedDateTime`, `Temporal.PlainDate`, etc. in type positions. But `joist-orm` only exports `Temporal` as a `const` value (the lazy native/polyfill Proxy), so there's no namespace to resolve those types against.

This works on Node 26, where `Temporal` exists as a global namespace, but on older Node it fails to compile:

  > 'Temporal' only refers to a type, but is being used as a namespace here. ts(2702)