### PR TITLE
fix: Align m2o & poly behavior on empty arrays.

### DIFF
--- a/packages/core/src/QueryParser.ts
+++ b/packages/core/src/QueryParser.ts
@@ -482,6 +482,13 @@ export function parseFindQuery(
             }) satisfies ColumnCondition[];
             targetCb.addParsedExpression({ kind: "exp", op: "or", conditions });
           } else if (f.kind === "in") {
+            // An empty `in` matches nothing, so emit a single always-false condition (consistent
+            // with a non-poly m2o `{ relation: [] }`); otherwise grouping by constructor would yield
+            // zero conditions and prune the filter entirely, incorrectly matching every row.
+            if (f.value.length === 0) {
+              targetCb.addValueFilter(fa, field.serde.columns[0], { kind: "in", value: [] });
+              return;
+            }
             // Split up the ids by constructor
             const idsByConstructor = groupBy(f.value, (id) => getConstructorFromTaggedId(id as string).name);
             // Or together `parent_book_id in (1,2,3) OR parent_author_id IN (4,5,6)`
@@ -500,9 +507,7 @@ export function parseFindQuery(
                 cond: mapToDb(column, { kind: "in", value: ids }),
               } satisfies ColumnCondition;
             });
-            if (conditions.length > 0) {
-              targetCb.addParsedExpression({ kind: "exp", op: "or", conditions });
-            }
+            targetCb.addParsedExpression({ kind: "exp", op: "or", conditions });
           } else {
             throw new Error(`Filters on polys for ${f.kind} are not supported`);
           }

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -495,18 +495,21 @@ describe("EntityManager.queries", () => {
 
     const em = newEntityManager();
     const where = { text: "comment", parent: [] } satisfies CommentFilter;
-    // Make sure the `parent: []` doesn't turn into an empty `()` condition
+    // `parent: []` means "parent is in the empty set", i.e. it should match nothing, just like
+    // a non-poly m2o `{ publisher: [] }` does, instead of being pruned and matching everything.
     const comments = await em.find(Comment, where);
-    expect(comments.length).toEqual(1);
-    expect(comments[0].text).toEqual("comment");
+    expect(comments.length).toEqual(0);
 
     expect(parseFindQuery(cm, where, opts)).toMatchObject({
       selects: [`c.*`],
       tables: [{ alias: "c", table: "comments", join: "primary" }],
       condition: {
         op: "and",
-        // And we prune the entire parent condition
-        conditions: [{ alias: "c", column: "text", dbType: "text", cond: { kind: "eq", value: "comment" } }],
+        // The empty `parent` becomes a single always-false `in: []` condition
+        conditions: [
+          { alias: "c", column: "text", dbType: "text", cond: { kind: "eq", value: "comment" } },
+          { alias: "c", column: "parent_author_id", dbType: "int", cond: { kind: "in", value: [] } },
+        ],
       },
       orderBys: [expect.anything()],
     });
@@ -537,6 +540,28 @@ describe("EntityManager.queries", () => {
     const em = newEntityManager();
     const where = { publisher: { id: { in: [] } } } satisfies AuthorFilter;
     const authors = await em.findGql(Author, where);
+    expect(authors.length).toEqual(0);
+
+    expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({
+      selects: [`a.*`],
+      tables: [{ alias: "a", table: "authors", join: "primary" }],
+      orderBys: [expect.anything()],
+      condition: {
+        op: "and",
+        conditions: [{ alias: "a", column: "publisher_id", dbType: "int", cond: { kind: "in", value: [] } }],
+      },
+    });
+  });
+
+  it("can find by foreign key in empty list", async () => {
+    await insertPublisher({ id: 1, name: "p1" });
+    await insertAuthor({ id: 2, first_name: "a1" });
+    await insertAuthor({ id: 3, first_name: "a2", publisher_id: 1 });
+
+    const em = newEntityManager();
+    // `publisher: []` means "publisher is in the empty set", i.e. it matches nothing (not "any publisher")
+    const where = { publisher: [] } satisfies AuthorFilter;
+    const authors = await em.find(Author, where);
     expect(authors.length).toEqual(0);
 
     expect(parseAndOptimizeFindQuery(am, where, opts)).toMatchObject({


### PR DESCRIPTION
Filtering a m2o by `{ publisher: [] }` turned into an `in: []` and would not match any rows -- we did not have a test for this, so added one.

Filtering a poly by `{ parent: [] }` would get pruned and so match _all_ rows -- very different behavior, which we've changed to match the "no rows" behavior.