### PR TITLE
fix: Avoid conflicts scope type names.

### DIFF
--- a/packages/codegen/src/EntityDbMetadata.test.ts
+++ b/packages/codegen/src/EntityDbMetadata.test.ts
@@ -1,5 +1,5 @@
 import { config } from "./config";
-import { collectionName, makeEntity, oneToOneName, referenceName } from "./EntityDbMetadata";
+import { collectionName, makeEntity, oneToOneName, referenceName, resolveScopeNameConflicts } from "./EntityDbMetadata";
 import { tableToEntityName } from "./utils";
 
 const relationDummy: any = { type: "m2o", sourceTable: { m2oRelations: [] }, foreignKey: { columns: [{}] } };
@@ -93,6 +93,30 @@ describe("EntityDbMetadata", () => {
     });
   });
 
+  describe("resolveScopeNameConflicts", () => {
+    it("defaults to conventional scope names", () => {
+      expect(makeEntity("Author")).toMatchObject({ scopeName: "AuthorScope", scopesName: "AuthorScopes" });
+    });
+
+    it("leaves names alone when there is no conflict", () => {
+      const entities = [fakeMeta("Author"), fakeMeta("Book")];
+      resolveScopeNameConflicts(asDb(entities));
+      expect(entities[0].entity).toMatchObject({ scopeName: "AuthorScope", scopesName: "AuthorScopes" });
+    });
+
+    it("falls back to underscore names when an entity is named EntityScope", () => {
+      const entities = [fakeMeta("Author"), fakeMeta("AuthorScope")];
+      resolveScopeNameConflicts(asDb(entities));
+      expect(entities[0].entity).toMatchObject({ scopeName: "Author_Scope", scopesName: "Author_Scopes" });
+    });
+
+    it("falls back to underscore names when an entity is named EntityScopes", () => {
+      const entities = [fakeMeta("Author"), fakeMeta("AuthorScopes")];
+      resolveScopeNameConflicts(asDb(entities));
+      expect(entities[0].entity).toMatchObject({ scopeName: "Author_Scope", scopesName: "Author_Scopes" });
+    });
+  });
+
   describe("referenceName", () => {
     it("returns the camel case of the column name without an id prefix", () => {
       // For `image.book_id` create `Image.book`
@@ -126,3 +150,11 @@ describe("EntityDbMetadata", () => {
     });
   });
 });
+
+function fakeMeta(name: string): any {
+  return { name, entity: makeEntity(name) };
+}
+
+function asDb(entities: any[]): any {
+  return { entities, entitiesByName: Object.fromEntries(entities.map((e) => [e.name, e])) };
+}

--- a/packages/codegen/src/EntityDbMetadata.ts
+++ b/packages/codegen/src/EntityDbMetadata.ts
@@ -65,6 +65,10 @@ export type Entity = {
   /** The symbol pointing to the entity's config const. */
   configConst: Import;
   optsType: Import;
+  /** The name of the entity's `Scope` type, i.e. `AuthorScope` (or `Author_Scope` on conflict). */
+  scopeName: string;
+  /** The name of the entity's `Scopes` type, i.e. `AuthorScopes` (or `Author_Scopes` on conflict). */
+  scopesName: string;
 };
 
 export type DatabaseColumnType =
@@ -881,7 +885,27 @@ export function makeEntity(entityName: string): Entity {
     configConst: imp(`${camelCase(entityName)}Config@./entities.ts`, {
       definedIn: `./codegen/${entityName}Codegen.ts`,
     }),
+    // The conventional names; `resolveScopeNameConflicts` rewrites these if they collide with an entity.
+    scopeName: `${entityName}Scope`,
+    scopesName: `${entityName}Scopes`,
   };
+}
+
+/**
+ * Rewrites scope type names that collide with an entity's own type name.
+ *
+ * `makeEntity` defaults `scopeName`/`scopesName` to `${name}Scope`/`${name}Scopes`, but if a separate
+ * entity is literally named e.g. `AuthorScope`, our generated `AuthorScope` scope type would collide
+ * with that entity's class, so we fall back to `Author_Scope` / `Author_Scopes`.
+ */
+export function resolveScopeNameConflicts(db: DbMetadata): void {
+  for (const meta of db.entities) {
+    const { name } = meta;
+    if (db.entitiesByName[`${name}Scope`] || db.entitiesByName[`${name}Scopes`]) {
+      meta.entity.scopeName = `${name}_Scope`;
+      meta.entity.scopesName = `${name}_Scopes`;
+    }
+  }
 }
 
 function metaName(entityName: string): string {

--- a/packages/codegen/src/findEntityScopes.ts
+++ b/packages/codegen/src/findEntityScopes.ts
@@ -3,6 +3,7 @@ import { readFile } from "fs/promises";
 import { join } from "path";
 import ts from "typescript";
 import { type Config } from "./config";
+import { type Entity } from "./EntityDbMetadata";
 
 /** Each `static active = ...` scope in an entity. */
 export interface ScopeMember {
@@ -15,13 +16,13 @@ export interface ScopeMember {
 export type ScopeMembersByEntity = Record<string, ScopeMember[]>;
 
 /** Finds static scope declarations for all entity files. */
-export async function findAllEntityScopes(config: Config, entityNames: string[]): Promise<ScopeMembersByEntity> {
-  return Object.fromEntries(await Promise.all(entityNames.map((entityName) => findEntityScopes(config, entityName))));
+export async function findAllEntityScopes(config: Config, entities: Entity[]): Promise<ScopeMembersByEntity> {
+  return Object.fromEntries(await Promise.all(entities.map((entity) => findEntityScopes(config, entity))));
 }
 
 /** Finds static scope declarations a given entity file. */
-async function findEntityScopes(config: Config, entityName: string): Promise<[string, ScopeMember[]]> {
-  const scopeTypeName = `${entityName}Scope`;
+async function findEntityScopes(config: Config, entity: Entity): Promise<[string, ScopeMember[]]> {
+  const { name: entityName, scopeName: scopeTypeName } = entity;
   // i.e. `authorScope`, the conventional renamed-to-`scope` import users put in their entity files.
   const scopeFnName = `${camelCase(entityName)}Scope`;
 

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -38,7 +38,10 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
     await syncDocs(config.entitiesDirectory, entityNames);
   }
 
-  const scopeMembersByEntity = await findAllEntityScopes(config, entityNames);
+  const scopeMembersByEntity = await findAllEntityScopes(
+    config,
+    entities.map((meta) => meta.entity),
+  );
 
   const entityFiles = entities
     .map((meta) => {

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -124,8 +124,6 @@ export function generateEntityCodegenFile(
 
   const configName = `${camelCase(entityName)}Config`;
   const scopeFnName = `${camelCase(entityName)}Scope`;
-  const scopeTypeName = `${entityName}Scope`;
-  const scopesTypeName = `${entityName}Scopes`;
   const metadata = imp(`${camelCase(entityName)}Meta@./entities.ts`);
 
   const contextType = config.contextType ? imp(`t:${config.contextType}`) : "{}";
@@ -231,15 +229,15 @@ export function generateEntityCodegenFile(
       ${generateFactoryExtrasType(meta)}
     }
 
-    export interface ${scopesTypeName} {
+    export interface ${entity.scopesName} {
       ${scopeMembers.map((member) => code`${member.name}: ${member.type};`)}
     }
 
-    export type ${scopeTypeName} = ${Scope}<${entity.type}, ${scopesTypeName}>;
+    export type ${entity.scopeName} = ${Scope}<${entity.type}, ${entity.scopesName}>;
 
     export const ${configName} = new ${ConfigApi}<${entity.type}, ${contextType}>();
 
-    export const ${scopeFnName} = ${newScopeFn}<${entity.type}, ${scopeTypeName}>("${entityName}");
+    export const ${scopeFnName} = ${newScopeFn}<${entity.type}, ${entity.scopeName}>("${entityName}");
 
     ${generateDefaultValidationRules(dbMeta, meta, configName)}
     ${generateDefaultValues(config, meta, configName)};

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -3,7 +3,7 @@ import process from "node:process";
 import { Client } from "pg";
 import pgStructure from "pg-structure";
 import { saveFiles } from "ts-poet";
-import { DbMetadata, EntityDbMetadata, failIfOverlappingFieldNames } from "./EntityDbMetadata";
+import { DbMetadata, EntityDbMetadata, failIfOverlappingFieldNames, resolveScopeNameConflicts } from "./EntityDbMetadata";
 import { assignTags } from "./assignTags";
 import { maybeRunTransforms } from "./codemods";
 import { Config, loadConfig, stripStiPlaceholders, warnInvalidConfigEntries, writeConfig } from "./config";
@@ -55,6 +55,9 @@ export async function joistCodegen() {
 
   // Look for STI tables to synthesize separate metas
   applyInheritanceUpdates(config, dbMetadata);
+
+  // Now that all entities (incl. STI subtypes) are known, fix up any colliding scope type names
+  resolveScopeNameConflicts(dbMetadata);
 
   // Assign any new tags and write them back to the config file
   assignTags(config, dbMetadata);


### PR DESCRIPTION
I.e. a schema with `authors` and `author_scopes` would collide:

- AuthorScope the real entity
- AuthorScope the scope type for the Author entity

We detect these conflicts and use `Author_Scope` as the scope type.