### PR TITLE
feat: Implement constant optimization to batched queries.

### DIFF
--- a/packages/core/src/dataloaders/findCountDataLoader.ts
+++ b/packages/core/src/dataloaders/findCountDataLoader.ts
@@ -71,8 +71,8 @@ export function findCountDataLoader<T extends Entity>(
 
         // Build the list of 'arg1', 'arg2', ... strings
         const { query, findSettings } = entries[0];
-        const argsColumns = collectAndReplaceArgs(query);
-        argsColumns.unshift({ columnName: "tag", dbType: "int" });
+        const args = collectAndReplaceArgs(query, entries);
+        const argsColumns = [{ columnName: "tag", dbType: "int" }, ...args.map((a) => a.column)];
 
         // We're not returning the entities, just counting them...
         const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
@@ -87,7 +87,7 @@ export function findCountDataLoader<T extends Entity>(
             { join: "lateral", query: query, table: meta.tableName, alias: "_data", fromAlias: "_f" },
           ],
           // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
-          ctes: [buildUnnestCte("_find", argsColumns, createColumnValuesFromPrepared(argsColumns, entries))],
+          ctes: [buildUnnestCte("_find", argsColumns, createColumnValuesFromPrepared(args, entries))],
           orderBys: [],
         };
 

--- a/packages/core/src/dataloaders/findDataLoader.ts
+++ b/packages/core/src/dataloaders/findDataLoader.ts
@@ -18,6 +18,7 @@ import {
 } from "../QueryParser";
 import { visitConditions } from "../QueryVisitor";
 import { OpColumn } from "../drivers/EntityWriter";
+import { equal, equalArrays } from "../fields";
 import { kqDot } from "../keywords";
 import { LoadHint } from "../loadHints";
 import { hintKey } from "../normalizeHints";
@@ -95,9 +96,9 @@ export function findDataLoader<T extends Entity>(
         const { preloader } = getEmInternalApi(em);
         const preloadJoins = preloader && hint && preloader.getPreloadJoins(meta, buildHintTree(hint), query);
 
-        const argsColumns = collectAndReplaceArgs(query);
-        argsColumns.unshift({ columnName: "tag", dbType: "int" });
-        const columnValues = createColumnValuesFromPrepared(argsColumns, entries);
+        const args = collectAndReplaceArgs(query, entries);
+        const argsColumns: OpColumn[] = [{ columnName: "tag", dbType: "int" }, ...args.map((a) => a.column)];
+        const columnValues = createColumnValuesFromPrepared(args, entries);
         const query2: ParsedFindQuery = {
           ...query,
           selects: ["array_agg(_find.tag) as _tags", ...query.selects],
@@ -193,35 +194,78 @@ class ArgCounter {
 }
 
 /**
- * Recursively finds args in `query` and replaces them with `_find.argX` placeholders.
- *
- * We also return the name/type of each found/rewritten arg so we can build the `_find` CTE table.
+ * A single batched arg: the `_find` CTE column to create, plus the index into each entry's `bindings`
+ * array that fills it. `bindingIndex` can differ from the column's position because inlined constants
+ * are skipped — see {@link collectAndReplaceArgs}.
  */
-export function collectAndReplaceArgs(query: ParsedFindQuery): { columnName: string; dbType: string }[] {
-  const args: { columnName: string; dbType: string }[] = [];
+export interface CteArg {
+  column: OpColumn;
+  bindingIndex: number;
+}
+
+/**
+ * Rewrites each batched arg in `query` into a `_find.argX` placeholder and returns, for each one, the
+ * CTE column to create plus the `bindings` slot that fills it.
+ *
+ * As an optimization, any condition whose value(s) are identical across every batched query is left
+ * inline (using `entries[0]`'s value) so it renders as `col = ?`, letting Postgres plan against the
+ * constant (e.g. use an index) instead of joining against an opaque `_find.argX` column. Only the
+ * genuinely-varying values flow through the CTE.
+ *
+ * The returned array is 1:1 with the CTE's non-`tag` columns — one {@link CteArg} per `_find.argX`.
+ * Because constants are skipped, an arg's column position is NOT its slot in `bindings`, so we return
+ * `bindingIndex` to bridge the two.
+ *
+ * @example
+ * // Batching `{ firstName: "a1", lastName: "l1" }` and `{ firstName: "a1", lastName: "l2" }`:
+ * //   each entry's `bindings` is ["a1", "l1"] / ["a1", "l2"] — slot 0 = firstName, slot 1 = lastName.
+ * //   firstName (slot 0) is constant, so it stays inline as `a.first_name = ?` and is skipped here.
+ * //   lastName (slot 1) varies, so it becomes CTE column `arg0`, fed from binding slot 1:
+ * collectAndReplaceArgs(query, entries);
+ * //=> [{ column: { columnName: "arg0", dbType: "character varying" }, bindingIndex: 1 }]
+ */
+export function collectAndReplaceArgs(query: ParsedFindQuery, entries: readonly { bindings: any[] }[]): CteArg[] {
+  const args: CteArg[] = [];
   const argsIndex = new ArgCounter();
+  // `bindings` were pushed in this same `visitConditions` order, so we can walk the conditions and
+  // each entry's `bindings` in lockstep, deciding per condition whether to inline or batch its value(s).
+  const constant = computeConstantBindings(entries);
+  let bindingIndex = 0;
   visitConditions(query, {
     visitCond(c: ColumnCondition) {
       if ("value" in c.cond) {
         const { kind } = c.cond;
-        if (kind === "in" || kind === "nin") {
-          args.push({ columnName: `arg${args.length}`, dbType: `${c.dbType}[]` });
-          return rewriteToRawCondition(c, argsIndex);
-        } else if (kind === "between") {
-          // between has two values
-          args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
-          args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
-          return rewriteToRawCondition(c, argsIndex);
-        } else if (kind === "jsonPathExists" || kind === "jsonPathPredicate") {
-          // The CTE needs to use `::jsonpath` instead of `::jsonb`, otherwise we'll get an invalid
-          // operator error for `jsonb @@ jsonb`. ...maybe the `ColumnCondition` should have a dbType
-          // baked into its ADT? Then we could avoid this special case handling.
-          args.push({ columnName: `arg${args.length}`, dbType: "jsonpath" });
-          return rewriteToRawCondition(c, argsIndex);
-        } else {
-          args.push({ columnName: `arg${args.length}`, dbType: c.dbType });
-          return rewriteToRawCondition(c, argsIndex);
+        // `between` consumes two bindings, everything else (incl. array `in`/`nin`) consumes one.
+        const consumed = kind === "between" ? 2 : 1;
+        const start = bindingIndex;
+        bindingIndex += consumed;
+        // If every batched query shares this condition's value(s), leave it as a normal `col = ?`
+        // condition (rendered from `entries[0]`'s value) instead of threading it through the CTE.
+        let allConstant = true;
+        for (let k = 0; k < consumed; k++) {
+          if (!constant[start + k]) {
+            allConstant = false;
+            break;
+          }
         }
+        if (allConstant) return;
+        // `arg${args.length}` keeps the CTE column names in step with the `_find.argX` references that
+        // `rewriteToRawCondition` emits, since both only advance for the args we actually batch.
+        if (kind === "between") {
+          args.push({ column: { columnName: `arg${args.length}`, dbType: c.dbType }, bindingIndex: start });
+          args.push({ column: { columnName: `arg${args.length}`, dbType: c.dbType }, bindingIndex: start + 1 });
+        } else {
+          // `in`/`nin` compare against an array column; jsonPath needs `::jsonpath` (not `::jsonb`, which
+          // would be an invalid `jsonb @@ jsonb`); everything else uses the column's own dbType.
+          const dbType =
+            kind === "in" || kind === "nin"
+              ? `${c.dbType}[]`
+              : kind === "jsonPathExists" || kind === "jsonPathPredicate"
+                ? "jsonpath"
+                : c.dbType;
+          args.push({ column: { columnName: `arg${args.length}`, dbType }, bindingIndex: start });
+        }
+        return rewriteToRawCondition(c, argsIndex);
       } else if (c.cond.kind === "is-null" || c.cond.kind === "not-null") {
         // leave it alone
       } else {
@@ -243,14 +287,22 @@ function rewriteToRawCondition(c: ColumnCondition, argsIndex: ArgCounter): RawCo
   };
 }
 
-/** Builds `_find` column values from already prepared queries. */
-export function createColumnValuesFromPrepared(columns: OpColumn[], entries: readonly { bindings: any[] }[]): any[][] {
-  const columnValues: any[][] = Array(columns.length);
-  for (let i = 0; i < columns.length; i++) columnValues[i] = [];
+/**
+ * Builds the column-major values for the `_find` CTE.
+ *
+ * Column 0 is the per-entry `tag`; the remaining columns mirror `args` 1:1, each pulling its
+ * `bindingIndex` from every entry's `bindings` (so inlined constants are naturally skipped).
+ */
+export function createColumnValuesFromPrepared(
+  args: readonly CteArg[],
+  entries: readonly { bindings: any[] }[],
+): any[][] {
+  const columnValues: any[][] = new Array(args.length + 1);
+  for (let i = 0; i < columnValues.length; i++) columnValues[i] = [];
   entries.forEach((entry, i) => {
     columnValues[0].push(i);
-    for (let j = 0; j < entry.bindings.length; j++) {
-      columnValues[j + 1].push(entry.bindings[j]);
+    for (let k = 0; k < args.length; k++) {
+      columnValues[k + 1].push(entry.bindings[args[k].bindingIndex]);
     }
   });
   return columnValues;
@@ -418,6 +470,35 @@ export function buildValuesCte(
       bindings,
     },
   };
+}
+
+/** Returns, per binding slot, whether every batched query shares the same value. */
+function computeConstantBindings(entries: readonly { bindings: any[] }[]): boolean[] {
+  const length = entries[0].bindings.length;
+  const constant = new Array<boolean>(length);
+  for (let j = 0; j < length; j++) {
+    const first = entries[0].bindings[j];
+    let same = true;
+    for (let i = 1; i < entries.length; i++) {
+      if (!argsEqual(entries[i].bindings[j], first)) {
+        same = false;
+        break;
+      }
+    }
+    constant[j] = same;
+  }
+  return constant;
+}
+
+/**
+ * Deep-equals two find-arg values (scalars, Dates, Temporals, or arrays thereof), reusing the same
+ * scalar/array equality `setField` uses for change detection.
+ *
+ * Only used to decide whether a condition can be inlined, so false negatives are safe (we just fall
+ * back to the CTE); we only return true when the values are genuinely equal.
+ */
+function argsEqual(a: any, b: any): boolean {
+  return equal(a, b) || (Array.isArray(a) && Array.isArray(b) && equalArrays(a, b));
 }
 
 export function getBatchKeyFromGenericStructure(meta: EntityMetadata, query: ParsedFindQuery): string {

--- a/packages/core/src/dataloaders/findDataLoader.ts
+++ b/packages/core/src/dataloaders/findDataLoader.ts
@@ -204,25 +204,18 @@ export interface CteArg {
 }
 
 /**
- * Rewrites each batched arg in `query` into a `_find.argX` placeholder and returns, for each one, the
- * CTE column to create plus the `bindings` slot that fills it.
+ * Rewrites each batched arg in `query` into a `_find.argX` placeholder.
  *
- * As an optimization, any condition whose value(s) are identical across every batched query is left
- * inline (using `entries[0]`'s value) so it renders as `col = ?`, letting Postgres plan against the
- * constant (e.g. use an index) instead of joining against an opaque `_find.argX` column. Only the
- * genuinely-varying values flow through the CTE.
+ * Any condition whose value(s) are identical across every batched query is left inline (using
+ * query's condition as-is from entity0), so it renders as `col = ?` for better query planning.
  *
- * The returned array is 1:1 with the CTE's non-`tag` columns — one {@link CteArg} per `_find.argX`.
- * Because constants are skipped, an arg's column position is NOT its slot in `bindings`, so we return
- * `bindingIndex` to bridge the two.
+ * The returned array has the non-constant CTE columns, one {@link CteArg} per `_find.argX`.
  *
- * @example
- * // Batching `{ firstName: "a1", lastName: "l1" }` and `{ firstName: "a1", lastName: "l2" }`:
- * //   each entry's `bindings` is ["a1", "l1"] / ["a1", "l2"] — slot 0 = firstName, slot 1 = lastName.
- * //   firstName (slot 0) is constant, so it stays inline as `a.first_name = ?` and is skipped here.
- * //   lastName (slot 1) varies, so it becomes CTE column `arg0`, fed from binding slot 1:
- * collectAndReplaceArgs(query, entries);
- * //=> [{ column: { columnName: "arg0", dbType: "character varying" }, bindingIndex: 1 }]
+ * Because constants are skipped, the 1st CTE column (i.e. for last name) might actually have a
+ * binding index of `1` if we've skipped an early constant column (i.e. first name).
+ *
+ * @param query the initial query in the batch, that all other queries structurally match
+ * @param entries the values (bindings) for each query in the batch
  */
 export function collectAndReplaceArgs(query: ParsedFindQuery, entries: readonly { bindings: any[] }[]): CteArg[] {
   const args: CteArg[] = [];

--- a/packages/core/src/dataloaders/findDataLoader.ts
+++ b/packages/core/src/dataloaders/findDataLoader.ts
@@ -248,13 +248,12 @@ export function collectAndReplaceArgs(query: ParsedFindQuery, entries: readonly 
           args.push({ column: { columnName: `arg${args.length}`, dbType: c.dbType }, bindingIndex: start });
           args.push({ column: { columnName: `arg${args.length}`, dbType: c.dbType }, bindingIndex: start + 1 });
         } else {
-          // `in`/`nin` compare against an array column; jsonPath needs `::jsonpath` (not `::jsonb`, which
-          // would be an invalid `jsonb @@ jsonb`); everything else uses the column's own dbType.
+          // Figure out the _find CTE's `unnest($n::${dbType})` so Postgres knows what we're sending in
           const dbType =
             kind === "in" || kind === "nin"
-              ? `${c.dbType}[]`
+              ? `${c.dbType}[]` // `in`/`nin` compare against an array column
               : kind === "jsonPathExists" || kind === "jsonPathPredicate"
-                ? "jsonpath"
+                ? "jsonpath" // jsonPath needs `::jsonpath` (not `::jsonb`, which would be an invalid `jsonb @@ jsonb`)
                 : c.dbType;
           args.push({ column: { columnName: `arg${args.length}`, dbType }, bindingIndex: start });
         }

--- a/packages/core/src/dataloaders/findIdsDataLoader.ts
+++ b/packages/core/src/dataloaders/findIdsDataLoader.ts
@@ -64,8 +64,8 @@ export function findIdsDataLoader<T extends Entity>(
 
         // Build the list of 'arg1', 'arg2', ... strings
         const { query, findSettings } = entries[0];
-        const argsColumns = collectAndReplaceArgs(query);
-        argsColumns.unshift({ columnName: "tag", dbType: "int" });
+        const args = collectAndReplaceArgs(query, entries);
+        const argsColumns = [{ columnName: "tag", dbType: "int" }, ...args.map((a) => a.column)];
 
         // We're not returning the entities, just selecting their IDs
         const primary = query.tables.find((t) => t.join === "primary") ?? fail("No primary");
@@ -79,7 +79,7 @@ export function findIdsDataLoader<T extends Entity>(
             { join: "lateral", query, table: meta.tableName, alias: "_data", fromAlias: "_f" },
           ],
           // For each unique query, capture its filter values in `bindings` to populate the CTE _find table
-          ctes: [buildUnnestCte("_find", argsColumns, createColumnValuesFromPrepared(argsColumns, entries))],
+          ctes: [buildUnnestCte("_find", argsColumns, createColumnValuesFromPrepared(args, entries))],
           orderBys: [],
         };
 

--- a/packages/core/src/dataloaders/findPaginatedDataLoader.ts
+++ b/packages/core/src/dataloaders/findPaginatedDataLoader.ts
@@ -75,9 +75,9 @@ export function findPaginatedDataLoader<T extends Entity>(
         const preloadHydrator = preloader && hint && preloader.addPreloading(meta, buildHintTree(hint), query);
 
         // Now craft the actual batched query
-        const argsColumns = collectAndReplaceArgs(query);
-        argsColumns.unshift({ columnName: "tag", dbType: "int" });
-        const columnValues = createColumnValuesFromPrepared(argsColumns, entries);
+        const args = collectAndReplaceArgs(query, entries);
+        const argsColumns = [{ columnName: "tag", dbType: "int" }, ...args.map((a) => a.column)];
+        const columnValues = createColumnValuesFromPrepared(args, entries);
         const query2: ParsedFindQuery = {
           selects: ["_find.tag as tag", "_data.*"],
           tables: [

--- a/packages/core/src/fields.ts
+++ b/packages/core/src/fields.ts
@@ -167,13 +167,13 @@ function equalOrSameEntity(a: any, b: any): boolean {
   );
 }
 
-function equalArrays(a: any[], b: any[]): boolean {
+export function equalArrays(a: any[], b: any[]): boolean {
   if (a.length !== b.length) return false;
   return a.every((_: any, i) => equal(a[i], b[i]));
 }
 
 const Temporal = maybeRequireTemporal()?.Temporal;
-function equal(a: any, b: any): boolean {
+export function equal(a: any, b: any): boolean {
   if (a === b) return true;
   if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
   if (Temporal) {

--- a/packages/tests/integration/src/EntityManager.find.batch.test.ts
+++ b/packages/tests/integration/src/EntityManager.find.batch.test.ts
@@ -75,6 +75,36 @@ describe("EntityManager.find.batch", () => {
     ]);
   });
 
+  it("inlines conditions whose values are shared across the batch", async () => {
+    await insertAuthor({ first_name: "a1", last_name: "l1" });
+    await insertAuthor({ first_name: "a1", last_name: "l2" });
+    resetQueryCount();
+    const em = newEntityManager();
+    // Given two queries that share the same firstName but differ on lastName
+    const q1p = em.find(Author, { firstName: "a1", lastName: "l1" });
+    const q2p = em.find(Author, { firstName: "a1", lastName: "l2" });
+    // When they are executed in the same event loop
+    const [q1, q2] = await Promise.all([q1p, q2p]);
+    // Then we issue a single SQL query
+    expect(numberOfQueries).toEqual(1);
+    // And the shared firstName is inlined as `= $3` while only the varying lastName flows through the CTE
+    expect(queries).toEqual([
+      [
+        `WITH _find (tag, arg0) AS (SELECT`,
+        ` unnest($1::int[]), unnest($2::character varying[]))`,
+        ` SELECT array_agg(_find.tag) as _tags, a.*`,
+        ` FROM authors AS a`,
+        ` CROSS JOIN _find AS _find`,
+        ` WHERE a.deleted_at IS NULL AND a.first_name = $3 AND a.last_name = _find.arg0`,
+        ` GROUP BY a.id`,
+        ` ORDER BY a.id ASC`,
+        ` LIMIT $4`,
+      ].join(""),
+    ]);
+    expect(q1).toMatchEntity([{ firstName: "a1", lastName: "l1" }]);
+    expect(q2).toMatchEntity([{ firstName: "a1", lastName: "l2" }]);
+  });
+
   it("passes the unbatched query AST to beforeFind plugins", async () => {
     class BeforeFindPlugin extends Plugin {
       tables: string[][] = [];
@@ -671,6 +701,27 @@ describe("EntityManager.find.batch", () => {
     ]);
     expect(q1).toEqual(0);
     expect(q2).toEqual(0);
+  });
+
+  it("inlines shared conditions when batching counts", async () => {
+    await insertAuthor({ first_name: "a1", last_name: "l1" });
+    await insertAuthor({ first_name: "a1", last_name: "l2" });
+    resetQueryCount();
+    const em = newEntityManager();
+    // Given two counts that share firstName but differ on lastName
+    const [c1, c2] = await Promise.all([
+      em.findCount(Author, { firstName: "a1", lastName: "l1" }),
+      em.findCount(Author, { firstName: "a1", lastName: "l2" }),
+    ]);
+    expect(numberOfQueries).toEqual(1);
+    // Then the shared firstName is inlined and only lastName flows through the CTE
+    expect(queries).toMatchInlineSnapshot(`
+     [
+       "WITH _find (tag, arg0) AS (SELECT unnest($1::int[]), unnest($2::character varying[])) SELECT _find.tag as tag, _data.count as count FROM _find AS _find CROSS JOIN LATERAL (SELECT count(distinct a.id) as count FROM authors AS a WHERE a.deleted_at IS NULL AND a.first_name = $3 AND a.last_name = _find.arg0) AS _data LIMIT $4",
+     ]
+    `);
+    expect(c1).toEqual(1);
+    expect(c2).toEqual(1);
   });
 
   it("batches finds with multi-word hasPersistedAsyncProperty", async () => {


### PR DESCRIPTION
Previously two queries like:

- `em.find(Author, { firstName: "a1", lastName: "last1" })`
- `em.find(Author, { firstName: "a1", lastName: "last2" })`

Would generate a batched query that looked like:

```sql
WITH _find (tag, arg0, arg1) AS (
  SELECT unnest($1::int[]), unnest($2::character varying[]), unnest($3::character varying[])
)
SELECT array_agg(_find.tag) as _tags, a.*
FROM authors AS a
CROSS JOIN _find AS _find
WHERE a.deleted_at IS NULL AND a.first_name = _find.arg0 AND a.last_name = _find.arg1
GROUP BY a.id
ORDER BY a.id ASC
LIMIT $4
```

I.e. every filter value went through the `_find` CTE, even `first_name` whose value (`"a1"`) is identical across both queries.

Now we detect when all batched queries share the same value for a column and inline it as a normal bound predicate, leaving only the genuinely-varying columns in the CTE:

```sql
WITH _find (tag, arg0) AS (
  SELECT unnest($1::int[]), unnest($2::character varying[])
)
SELECT array_agg(_find.tag) as _tags, a.*
FROM authors AS a
CROSS JOIN _find AS _find
WHERE a.deleted_at IS NULL AND a.first_name = $3 AND a.last_name = _find.arg0
GROUP BY a.id
ORDER BY a.id ASC
LIMIT $4
```

`a.first_name = $3` is a plain scalar comparison the planner can satisfy with an index, while only `last_name` (the column that actually differs between the two queries) flows through the CTE.

Fixes #1345