### PR TITLE
fix: Tighten op handling in upsert.

### DIFF
--- a/packages/core/src/upsert.ts
+++ b/packages/core/src/upsert.ts
@@ -171,8 +171,10 @@ export async function updatePartial<T extends Entity>(entity: T, input: DeepPart
         const otherMeta = field.otherMetadata();
         const maybeSoftDelete = otherMeta.timestampFields?.deletedAt;
 
-        // Incremental handling
-        const anyValueHasOp = values.some((v) => v && typeof v === "object" && !isEntity(v) && "op" in v);
+        // Incremental handling. Detect incremental mode by a meaningful `op` value--`op: undefined`/`op: null`
+        // is the natural shape of an optional field and must behave like "no op", consistent with how
+        // updatePartial treats `value === undefined` and how delete/remove are read by truthiness.
+        const anyValueHasOp = values.some((v: any) => v && typeof v === "object" && !isEntity(v) && v.op != null);
         if (anyValueHasOp) {
           let anyValueMissingOp = false;
           const current = (entity as any)[name];
@@ -198,6 +200,10 @@ export async function updatePartial<T extends Entity>(entity: T, input: DeepPart
                 current.add(other);
               } else if (op === "incremental") {
                 // This is a marker entry, just ignore it
+              } else {
+                // A child entered incremental mode (a sibling had a real op) but has no op of its own;
+                // never silently skip it--flag it so the guard below throws instead of dropping the row.
+                anyValueMissingOp = true;
               }
             }),
           );

--- a/packages/tests/integration/src/EntityManager.upsert.test.ts
+++ b/packages/tests/integration/src/EntityManager.upsert.test.ts
@@ -582,6 +582,37 @@ describe("EntityManager.upsert", () => {
       expect(await countOfBookToTags()).toEqual(1);
     });
 
+    it("collections create children with an undefined op", async () => {
+      const em = newEntityManager();
+      // When a child has `op: undefined`--the natural shape of an optional GraphQL field
+      const a1 = await em.upsert(Author, { firstName: "a1", books: [{ op: undefined, title: "b1" }] });
+      // Then the child is created instead of being silently dropped
+      expect(await a1.books.load()).toMatchEntity([{ title: "b1" }]);
+      await em.flush();
+      expect(await countOfBooks()).toEqual(1);
+    });
+
+    it("collections reject a mix of real and missing ops", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      // When one child has a real op but a sibling has `op: undefined`
+      await expect(
+        em.upsert(Author, { firstName: "a2", books: [{ op: "include", id: "b:1" }, { op: undefined, title: "b2" }] }),
+      ).rejects.toThrow("all children must have the `op` key");
+    });
+
+    it("collections allow the incremental marker alongside real ops", async () => {
+      await insertAuthor({ first_name: "a1" });
+      await insertBook({ title: "b1", author_id: 1 });
+      const em = newEntityManager();
+      // When we mix the `incremental` sentinel with a real `include` op
+      const a2 = await em.upsert(Author, { firstName: "a2", books: [{ op: "incremental" }, { op: "include", id: "b:1" }] });
+      await em.flush();
+      // Then the include is applied and the marker is ignored
+      expect(await a2.books.load()).toMatchEntity([{ id: "b:1" }]);
+    });
+
     it("collections can refer to entities", async () => {
       await insertAuthor({ first_name: "a1" });
       await insertBook({ title: "b1", author_id: 1 });


### PR DESCRIPTION
If `op: undefined` was passed, we entered incremental mode, but then would drop the row since it wasn't one of the expected op values.