### PR TITLE
feat: Add initial skills installation.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/joist-admin" vcs="Git" />
   </component>
 </project>

--- a/docs/src/content/docs/advanced/agent-skills.md
+++ b/docs/src/content/docs/advanced/agent-skills.md
@@ -1,0 +1,60 @@
+---
+title: Agent Skills
+description: Auto-shipped Agent Skills that teach coding agents how to use Joist
+sidebar:
+  order: 17
+---
+
+Joist ships several [Agent Skills](https://agentskills.io) to help coding agents write idiomatic Joist code.
+
+A "skill" is just a directory with a `SKILL.md` file (YAML frontmatter plus a
+markdown body) that the agent discovers and loads on demand when it detects a
+relevant task.
+
+## Enabling
+
+Skills are enabled by default: running `joist-codegen` will, as part of the normal codegen cycle, also install the latest skills bundled in the `joist-orm` artifact to `.claude/skills` and `.agents/skills`:
+
+```
+.claude/skills/
+  joist-em-basics/SKILL.md
+  joist-upsert/SKILL.md
+.agents/skills/
+  joist-em-basics/SKILL.md
+  joist-upsert/SKILL.md
+```
+
+We write both directories because different agents scan different locations:
+
+- `.claude/skills/` is read by **Claude Code** (and opencode)
+- `.agents/skills/` is read by **Codex** (and opencode)
+
+So together they give native coverage across all three tools.
+
+:::tip
+
+If you want to disable skills, you can set `skills: false` in your `joist-codegen.json`:
+
+```json
+{
+  "skills": true
+}
+```
+
+:::
+
+## Keeping them up to date
+
+The installed `SKILL.md` files are **framework-owned**: `joist-codegen` overwrites them on every run so they stay in sync with your installed version of Joist.
+
+Don't hand-edit the generated `SKILL.md` files — re-run codegen instead.
+
+If you have suggestions of how to improve the skills, PRs to improve them would be great!
+
+:::note
+
+If you author your own project-specific skills, put them in separate
+directories (i.e. not prefixed with `joist-`) so they aren't overwritten by
+codegen.
+
+:::

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -42,4 +42,7 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
   <Card title="Rich Test Support" icon="test-tube">
     Out-of-the-box [test factories](/testing/test-factories) and [fast test database resets](/testing/fast-database-resets) make your tests succinct & resilient to change, even as your domain model evolves.
   </Card>
+  <Card title="AI-Agent Ready" icon="puzzle">
+    Joist auto-ships [Agent Skills](/advanced/agent-skills) to help coding agents write idiomatic Joist code out-of-the-box, even in brand new repositories that don't have established conventions for the agents to copy/paste.
+  </Card>
 </CardGrid>

--- a/packages/codegen/config-json-schema.json
+++ b/packages/codegen/config-json-schema.json
@@ -135,6 +135,7 @@
       "anyOf": [{ "type": "string", "const": "cursor" }, { "type": "string", "const": "limit" }]
     },
     "docs": { "type": "boolean" },
+    "skills": { "type": "boolean" },
     "outputDocs": { "type": "boolean" },
     "allowImportingTsExtensions": { "type": "boolean" },
     "codemodVersion": { "default": 0, "type": "integer", "minimum": 0, "maximum": 9007199254740991 },

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --ignore-path ../../.prettierignore --write '{schema,migrations,src}/**/*.{ts,js,tsx,jsx,graphql}'"
   },
   "files": [
-    "build"
+    "build",
+    "skills"
   ],
   "peerDependencies": {
     "joist-utils": "workspace:*",

--- a/packages/codegen/skills/joist-em-basics/SKILL.md
+++ b/packages/codegen/skills/joist-em-basics/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: joist-em-basics
+description: Create, load, find, mutate, and save entities with Joist's EntityManager. Use when writing data-access or business logic in a Joist project — anything using em.create, em.load, em.find, em.flush, or walking the entity graph.
+---
+
+<!-- Managed by joist-codegen. Do not edit by hand; re-run codegen to update. -->
+
+# Joist EntityManager basics
+
+The `EntityManager` (`em`) is how entities are loaded from and saved to the
+database. It is a Unit of Work: each request gets its own `em`, which tracks
+the entities it has loaded/created and writes them all out on `em.flush()`.
+
+Entities are always loaded/created _through_ the `em`, never via static methods
+on the class (Joist is not ActiveRecord). IDs are tagged strings like `"a:1"`.
+
+## Creating
+
+`em.create` is synchronous and returns the new entity immediately:
+
+```ts
+const author = em.create(Author, { firstName: "a1" });
+// Nested/related entities can be created inline
+const author = em.create(Author, { firstName: "a1", address: { street: "123 Main" } });
+```
+
+## Loading by id
+
+Use tagged ids. These throw if the id does not exist (except the `IfExists`
+variants):
+
+```ts
+const a = await em.load(Author, "a:1");
+const as = await em.loadAll(Author, ["a:1", "a:2"]);
+const as = await em.loadAllIfExists(Author, ["a:1", "a:2"]); // skips missing ids
+```
+
+To eagerly load relations, pass a populate hint as the 3rd argument; the
+returned entity is typed as "loaded" so the relations can be read synchronously:
+
+```ts
+const a = await em.load(Author, "a:1", { books: "reviews" });
+a.books.get.flatMap((b) => b.reviews.get);
+```
+
+## Walking the graph
+
+~90% of reads are just navigating relations from an entity you already have.
+These are guaranteed N+1-safe, even in a loop:
+
+```ts
+const author = await book.author.load();        // load a single relation
+const reviews = await publisher.load((p) => p.books.reviews); // lens
+const loaded = await author.populate({ books: "reviews" });   // populate + .get
+```
+
+## Finding (filtered queries)
+
+`em.find` issues a `SELECT` with a "join literal" of nested relations plus
+inline `WHERE` conditions. It is batch/N+1-safe.
+
+```ts
+const books = await em.find(Book, { author: { firstName: "a1" } });
+const recent = await em.find(Book, { publishedAt: { gte: jan1 } });
+const some = await em.find(Author, { firstName: { in: ["a1", "a2"] } });
+
+const one = await em.findOne(Book, { title: "b1" });        // undefined if none
+const one = await em.findOneOrFail(Book, { title: "b1" });  // throws if none
+const one = await em.findOrCreate(Author, { email: "a@b.com" });
+```
+
+`undefined` values are pruned (the condition and any now-unused join are
+dropped), so filters compose cleanly. To filter for null, pass `null`
+explicitly, e.g. `{ firstName: null }`. For `OR` / nested boolean logic, use
+`alias`/`aliases` with a `conditions` argument. For aggregates or group-bys,
+drop down to Knex/Kysely — Joist's `find` only returns whole entities.
+
+## Mutating
+
+Assign fields directly, or use `.set` for a batch of changes:
+
+```ts
+author.firstName = "a2";
+author.set({ firstName: "a2", lastName: "b2" });
+```
+
+For partial/RPC-style updates (treating `null` as "unset"), and for
+incrementally updating children, see the `joist-upsert` skill.
+
+## Deleting
+
+```ts
+const a = await em.load(Author, "a:1");
+em.delete(a);
+```
+
+## Saving with `em.flush()`
+
+`em.flush()` is where everything happens. It is async and:
+
+1. Runs lifecycle hooks and validation rules,
+2. Opens a transaction,
+3. Issues batched `INSERT`/`UPDATE`/`DELETE` (one batch per entity type),
+4. Commits.
+
+You don't write individual SQL statements — let Joist batch them. `flush` can
+be called multiple times as you do more work:
+
+```ts
+const author = em.create(Author, { firstName: "a1" });
+await em.flush();
+author.firstName = "a2";
+await em.flush();
+```

--- a/packages/codegen/skills/joist-partial-updates/SKILL.md
+++ b/packages/codegen/skills/joist-partial-updates/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: joist-partial-updates
+description: Joist ORM partial updates, em.upsert, setPartial, nested collection op semantics, and GraphQL/REST/gRPC save inputs. Use when designing, implementing, reviewing, or debugging Joist partial-update or save-input APIs, especially parent-child graphs, id-less nested rows, required-parent validation errors, or accidental collection removal.
+---
+
+# Joist Partial Update APIs
+
+Use Joist's native partial-update contract from the transport through to `EntityManager.upsert` or `Entity.setPartial`. Do not load an existing graph and write custom reconciliation code when IDs and Joist collection operations can express the update.
+
+Authoritative documentation: <https://joist-orm.io/features/partial-update-apis/>
+
+## Non-Negotiable Rules
+
+1. Preserve entity IDs across read, edit, and write boundaries.
+2. Decide whether every supplied collection is exhaustive or incremental before writing the payload.
+3. Omit a field to leave it unchanged. Do not replace omission with `null`, `[]`, or a generated default.
+4. A collection array is exhaustive by default. Omitted existing children are removed from the relation.
+5. A collection becomes incremental when its child objects use `op`.
+6. If any child has `op`, every child in that collection must have `op`, including newly created children.
+7. An empty array is always exhaustive and clears the collection. It never means "no changes."
+8. Use `{ op: "incremental" }` only as a no-op sentinel when the collection key must be present. Prefer omitting the collection key.
+9. Use `include`, `delete`, and `remove` according to their actual relationship semantics.
+10. Test updates against an already-persisted graph and flush the unit of work. Mapper-only tests cannot catch detached required children.
+11. Authorize every supplied ID and operation. Joist enforces persistence rules, not API permissions or tenant boundaries.
+
+## Partial Field Semantics
+
+Joist distinguishes omission, `undefined`, and `null`:
+
+| Input | Scalar or relation behavior | Collection behavior |
+| --- | --- | --- |
+| Omitted | Leave unchanged | Leave unchanged |
+| `undefined` | Leave unchanged | Leave unchanged |
+| `null` | Unset optional value; required value fails validation | Clear the collection |
+| Value or array | Set/update | Exhaustively replace unless `op` enables incremental behavior |
+
+Do not globally normalize `null` to `undefined`. That destroys the caller's ability to explicitly unset an optional field. Adapt only fields whose transport representation differs from the entity graph.
+
+Transport-specific presence rules:
+
+- GraphQL: preserve the difference between an omitted input field and an explicit `null`. Codegen commonly produces `T | null | undefined`; this is what `DeepPartialOrNull` and the partial APIs are designed to accept.
+- REST/JSON: omission means no change; JSON has no `undefined`, so do not synthesize absent keys while decoding or mapping.
+- gRPC/Protobuf: scalar presence can use `optional`, wrappers, or `oneof`, but ordinary repeated fields do not distinguish omitted from empty. Wrap repeated fields in a present message, use a `oneof`, or use a field mask so "unchanged" cannot decode to `[]`.
+
+## Choose the Collection Contract
+
+### Exhaustive Replacement
+
+Use an exhaustive collection only when the caller intentionally sends the complete desired membership:
+
+```ts
+await em.upsert(Author, {
+  id: "a:1",
+  books: [
+    { id: "b:1", title: "Retained and updated" },
+    { title: "New book" },
+  ],
+});
+```
+
+This removes every omitted existing book from `author.books`. It does not imply hard deletion. If the inverse relation is required, detaching an omitted child can produce validation errors such as `Book author is required`.
+
+Do not use exhaustive replacement when:
+
+- The client does not know every existing child.
+- The UI discarded child IDs.
+- Omitted children should remain untouched.
+- Removed children must be hard-deleted rather than merely detached.
+
+### Incremental Update
+
+Use incremental operations when the request describes additions, updates, removals, or deletions without replacing the whole collection:
+
+```ts
+await em.upsert(Author, {
+  id: "a:1",
+  books: [
+    { id: "b:1", op: "include", title: "Updated title" },
+    { op: "include", title: "New book" },
+    { id: "b:2", op: "delete" },
+  ],
+});
+```
+
+Operation meanings:
+
+| Operation | Behavior |
+| --- | --- |
+| `include` | Create or update the child, and ensure it belongs to the collection |
+| `delete` | Remove the child from the collection and call `EntityManager.delete` |
+| `remove` | Detach the child without deleting it |
+| `incremental` | No-op sentinel that enables incremental semantics for an otherwise empty list |
+
+Use `remove` only when the child can validly exist without this parent or is being reparented in the same unit of work. For a required parent relation, `remove` alone usually creates an invalid entity. Use `delete` when the child should cease to exist.
+
+An actual empty array still clears:
+
+```ts
+await em.upsert(Author, { id: "a:1", books: [] });
+```
+
+For an incremental no-op, prefer:
+
+```ts
+await em.upsert(Author, { id: "a:1" });
+```
+
+If a generic payload builder must emit `books`, use:
+
+```ts
+await em.upsert(Author, {
+  id: "a:1",
+  books: [{ op: "incremental" }],
+});
+```
+
+## Stable Identity End to End
+
+IDs are the reliable identity contract for active nested updates. A nested object without an ID is normally a request to create a new entity.
+
+For an editable parent-child graph:
+
+1. Query IDs for the parent and every editable nested entity.
+2. Include those IDs in API response types.
+3. Store IDs in form or draft state.
+4. Send retained rows as `{ id, op: "include", ...changes }`.
+5. Keep deleted persisted IDs in a deletion list and send `{ id, op: "delete" }`.
+6. Send new rows without an ID but with `op: "include"`.
+7. Keep the same discipline recursively for grandchildren.
+
+A robust UI row model looks like:
+
+```ts
+interface EditableBook {
+  id?: string;
+  title: string;
+}
+
+interface AuthorDraft {
+  books: EditableBook[];
+  deletedBookIds: string[];
+}
+```
+
+Do not key editable rows only by array index. Reordering or deleting an earlier row can assign an existing ID to the wrong logical row. Prefer structured row state with stable IDs. If a textarea represents multiple database rows, either maintain line identity explicitly or document why positional identity is safe for that domain.
+
+Do not infer identity from `sortOrder`, names, unique constraints, or array position. Joist may use configured uniqueness for specific upsert cases such as soft-deleted rows, but do not assume `uniqueBy` will match active id-less children. Send the ID unless the current Joist behavior is intentionally relied on and covered by an integration test.
+
+## GraphQL Shape
+
+Make GraphQL inputs mirror Joist's native graph shape:
+
+```graphql
+enum UpsertOp {
+  include
+  remove
+  delete
+  incremental
+}
+
+input SaveAuthorInput {
+  id: ID
+  firstName: String
+  books: [SaveBookInput!]
+}
+
+input SaveBookInput {
+  id: ID
+  op: UpsertOp
+  title: String
+}
+```
+
+The corresponding output query must expose nested IDs:
+
+```graphql
+query EditAuthor($id: ID!) {
+  author(id: $id) {
+    id
+    firstName
+    books {
+      id
+      title
+    }
+  }
+}
+```
+
+Keep the resolver thin when the schema already matches the entity graph:
+
+```ts
+import { type DeepPartialOrNull } from "joist-orm";
+
+async function saveAuthor(input: SaveAuthorInput, em: EntityManager): Promise<Author> {
+  return em.upsert(Author, input as DeepPartialOrNull<Author>);
+}
+```
+
+The cast is appropriate only after checking that relation names, IDs, scalar fields, and nested collection operations align with Joist's expected graph. A cast does not make an incompatible payload safe.
+
+Thin does not mean unchecked. Before calling `upsert`, authorize the parent and every nested ID for the caller's tenant/scope, and validate that each requested attach, reparent, remove, or delete operation is allowed. This security validation is separate from persistence reconciliation.
+
+If the API also accepts convenience fields, such as a textarea that expands into child rows, use a small boundary mapper:
+
+```ts
+type SaveAuthorConvenienceInput = SaveAuthorInput & { booksText?: string | null };
+
+function toAuthorUpsertInput(input: SaveAuthorConvenienceInput): DeepPartialOrNull<Author> {
+  return {
+    id: input.id,
+    firstName: input.firstName,
+    books: mapBooks(input),
+  } as DeepPartialOrNull<Author>;
+}
+
+function mapBooks(input: SaveAuthorConvenienceInput) {
+  if (input.books !== undefined) return input.books;
+  if (input.booksText === undefined) return undefined;
+  return parseLegacyBooks(input.booksText ?? "");
+}
+```
+
+The mapper should transform representation, not reconcile persistence. It must preserve `books: null` as an explicit clear and preserve omission as `undefined`; do not use `??` when `null` and omission have different meanings.
+
+## REST and gRPC Shapes
+
+Use the same graph contract regardless of transport. For example, a REST PATCH body can be:
+
+```json
+{
+  "id": "a:1",
+  "books": [
+    { "id": "b:1", "op": "include", "title": "Updated title" },
+    { "id": "b:2", "op": "delete" }
+  ]
+}
+```
+
+A gRPC message should model the same operations with an enum and explicit collection presence. A plain `repeated SaveBookInput books` field is unsafe for a partial update because its decoded empty list cannot distinguish "omitted" from "clear." Use a wrapper message inside a `oneof`, or an equivalent field-mask convention:
+
+```proto
+message BookChanges {
+  repeated SaveBookInput values = 1;
+}
+
+message SaveAuthorRequest {
+  optional string id = 1;
+  oneof books_update {
+    BookChanges books = 2;
+    bool clear_books = 3;
+  }
+}
+```
+
+An unset `books_update` means unchanged; a present `books` wrapper carries incremental or exhaustive values; `clear_books: true` explicitly clears. Convert generated enum values to Joist's lowercase strings at the boundary if necessary.
+
+Do not invent transport-specific reconciliation semantics. GraphQL, REST, and gRPC should all produce the same `DeepPartialOrNull<Entity>` graph before calling Joist.
+
+## Implementation Workflow
+
+1. Read the entity metadata and identify required inverse relations and delete behavior.
+2. Trace the complete read-edit-write path, not only the resolver.
+3. Verify every editable output type and query includes stable nested IDs.
+4. Verify client state retains those IDs after parsing, normalization, and form edits.
+5. Choose exhaustive or incremental semantics independently for every nested collection.
+6. Make transport inputs match Joist's graph and expose `op` where incremental updates are needed.
+7. Add only the smallest representation mapper required by the transport.
+8. Call `em.upsert`, `entity.setPartial`, or a thin shared helper that delegates to them.
+9. Flush in an integration test and assert identity, membership, deletion, and untouched fields.
+
+## Failure Signatures
+
+### `<Child> <parent> is required` after updating a parent
+
+Likely cause: an id-less or incomplete child array was interpreted as exhaustive replacement. Joist created new children and detached omitted persisted children, whose required parent relation then failed validation.
+
+Fix: preserve child IDs and either send the complete exhaustive graph or use `op: "include"`/`"delete"` incrementally.
+
+### Duplicate children after each save
+
+Likely cause: existing child IDs are missing from the write payload, so each row is treated as new.
+
+Fix: query, retain, and resend IDs. Do not match by sort order or content on the server.
+
+### All children disappear on a no-change save
+
+Likely cause: a payload builder emitted `children: []`, which is an exhaustive clear.
+
+Fix: omit `children`, or emit `[{ op: "incremental" }]` only if the key is mandatory.
+
+### Incremental update is rejected or behaves exhaustively
+
+Likely cause: only some children have `op`.
+
+Fix: give every child in that collection an operation, including new children.
+
+### GraphQL input does not type-check against Joist
+
+Likely cause: generated nullable input types do not directly match strict entity setters, or the API has convenience fields not present on the entity.
+
+Fix: target `DeepPartialOrNull<Entity>` and use a narrow boundary mapper. Do not weaken unrelated types or write a persistence reconciliation layer.
+
+## Anti-Patterns
+
+Never solve a partial-update mismatch by defaulting to these approaches:
+
+- Loading all existing children in the resolver to assign IDs by array position.
+- Diffing old and new child arrays manually.
+- Appending custom delete markers after comparing database state.
+- Matching active children by `sortOrder`, name, or another mutable field.
+- Assuming a database unique constraint supplies identity to an id-less upsert.
+- Dropping nested IDs from API output, DTOs, parsers, or form state.
+- Mapping an omitted collection to `[]`.
+- Mixing children with and without `op` in one collection.
+- Using `remove` for a child whose parent relation is required.
+- Treating an empty array as an incremental no-op.
+- Converting every GraphQL `null` to `undefined`.
+- Adding backward-compatibility reconciliation without a concrete shipped caller that requires it.
+
+Custom reconciliation is justified only when the API contract fundamentally cannot carry stable identity or Joist operations, and changing that contract is impossible. Document that constraint before adding such code.
+
+## Regression Tests
+
+For a nested update bug, build a persisted graph before invoking the real API boundary:
+
+1. Create a parent with at least three children.
+2. Give one child at least two grandchildren.
+3. Update retained entities using their IDs and `op: "include"`.
+4. Add one new id-less entity with `op: "include"`.
+5. Delete one persisted entity with `op: "delete"`.
+6. Omit another relation and prove it remains unchanged.
+7. Flush and reload.
+8. Assert retained IDs are unchanged, new IDs were created, deleted entities are gone, and no duplicates exist.
+
+Also cover these semantics where relevant:
+
+- Omitted collection leaves membership unchanged.
+- Explicit `[]` clears membership.
+- `[{ op: "incremental" }]` is a no-op.
+- `remove` detaches but does not delete an optional child.
+- `delete` hard-deletes.
+- Mixed missing/present `op` values are rejected.
+- GraphQL or transport-level tests prove nested IDs and operations reach the resolver.
+
+Do not stop at payload snapshots. The original class of failure often appears only during validation or flush.
+
+## Review Checklist
+
+- Are IDs selected for every editable nested entity?
+- Are IDs retained in client or caller state?
+- Does each supplied collection intentionally use exhaustive or incremental semantics?
+- If incremental, does every child have `op`?
+- Are new children marked `include`?
+- Are deleted persisted IDs sent as `delete`?
+- Is `remove` valid for the inverse relation's nullability?
+- Can any no-change path emit `[]` accidentally?
+- Are omitted fields preserved as omitted or `undefined`?
+- Are explicit `null` values preserved where they mean unset?
+- Is the resolver a thin `upsert`/`setPartial` boundary instead of a reconciliation engine?
+- Does an integration test update a persisted graph and verify stable IDs after flush?

--- a/packages/codegen/skills/joist-partial-updates/SKILL.md
+++ b/packages/codegen/skills/joist-partial-updates/SKILL.md
@@ -124,23 +124,25 @@ For an editable parent-child graph:
 2. Include those IDs in API response types.
 3. Store IDs in form or draft state.
 4. Send retained rows as `{ id, op: "include", ...changes }`.
-5. Keep deleted persisted IDs in a deletion list and send `{ id, op: "delete" }`.
+5. Mark deleted persisted rows in place by switching their `op` to `delete` (or `remove`); keep them in the same array rather than moving their IDs to a separate deletion list.
 6. Send new rows without an ID but with `op: "include"`.
 7. Keep the same discipline recursively for grandchildren.
 
-A robust UI row model looks like:
+A robust UI row model carries `op` on the row itself, so a deleted book flips to `op: "delete"`/`"remove"` in place instead of moving to a separate collection:
 
 ```ts
 interface EditableBook {
   id?: string;
+  op?: "include" | "remove" | "delete";
   title: string;
 }
 
 interface AuthorDraft {
   books: EditableBook[];
-  deletedBookIds: string[];
 }
 ```
+
+Because each row already mirrors `SaveBookInput` (`id`, `op`, scalars), the draft state can go directly onto the wire as the GraphQL input, with no separate deletion list to reconcile back in. Keep the collection incremental (every row has `op`) once any row does.
 
 Do not key editable rows only by array index. Reordering or deleting an earlier row can assign an existing ID to the wrong logical row. Prefer structured row state with stable IDs. If a textarea represents multiple database rows, either maintain line identity explicitly or document why positional identity is safe for that domain.
 
@@ -332,17 +334,7 @@ For a nested update bug, build a persisted graph before invoking the real API bo
 7. Flush and reload.
 8. Assert retained IDs are unchanged, new IDs were created, deleted entities are gone, and no duplicates exist.
 
-Also cover these semantics where relevant:
-
-- Omitted collection leaves membership unchanged.
-- Explicit `[]` clears membership.
-- `[{ op: "incremental" }]` is a no-op.
-- `remove` detaches but does not delete an optional child.
-- `delete` hard-deletes.
-- Mixed missing/present `op` values are rejected.
-- GraphQL or transport-level tests prove nested IDs and operations reach the resolver.
-
-Do not stop at payload snapshots. The original class of failure often appears only during validation or flush.
+Do not re-test `em.upsert`'s own collection semantics (omitted vs `[]` vs `[{ op: "incremental" }]`, `remove` vs `delete`, mixed-`op` rejection) — Joist owns and tests those. Test what is yours: that nested IDs and operations survive the transport boundary and reach the resolver. Do not stop at payload snapshots; the original class of failure often appears only during validation or flush.
 
 ## Review Checklist
 

--- a/packages/codegen/skills/joist-reactive-hints/SKILL.md
+++ b/packages/codegen/skills/joist-reactive-hints/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: joist-reactive-hint
+description: Explains the load cost of Joist reactive hints — specifically how followReverseHint walks reverse paths and when a reactive rule/field on a child entity reverse-loads its parent's ENTIRE children collection. Use when reasoning about the performance of a reactive rule/field/property (addRule, hasReactiveField, hasReactiveProperty, hasReactiveReference), when a validation rule seems to load far more rows than expected, when deciding whether to put a field in a reactive hint vs load it on-demand, or when a hot-path mutation (e.g. a bulk job) triggers surprise N×M loads. Keywords: reactive hint, reverse reactivity, followReverseHint, reverseSubHint, m2o vs o2m reactivity, over-invalidation, "reacting to a parent field reloads all siblings".
+---
+
+# Joist reactive-hint load cost (`followReverseHint`)
+
+## TL;DR
+
+A reactive rule/field is declared on a **root entity** with a hint. When any field in that hint
+changes, Joist must find the root entities to re-run — it does this by **walking the hint in
+reverse** (`followReverseHint` in `joist-core/build/reactiveHints.js`). The reverse walk **loads
+the relations it traverses**. The trap:
+
+> A reactive rule/field rooted on the **"many" side** (e.g. a `...Version`) that depends on a
+> field of its **m2o parent** (e.g. `identity.draftVersion`) will, **every time that parent field
+> changes, reverse-load the parent's ENTIRE children collection** (`identity.versions`) and
+> re-validate all of them. That's `O(children)` load per parent-field change — and if the parent
+> field changes once per child in a bulk job, the whole job is `O(children × siblings)`.
+
+This is easy to introduce accidentally and does **not** show up in tests (behavior is correct; only
+throughput/memory suffer). It bites bulk/hot-path jobs at scale.
+
+## Why: how the reverse path is built and walked
+
+Two functions in `joist-core/build/reactiveHints.js`:
+
+- **`reverseSubHint`** builds the reverse path by reversing each *traversed relation*:
+  - Traverse an **m2o** (`child.parent`, e.g. `Version.identity`) → reverse is the **o2m**
+    (`parent.children`, e.g. `Identity.versions`). The reverse path segment is that collection.
+  - A **leaf field** in the hint (primitive / enum / **m2o read as a value**, e.g.
+    `["activeVersion", "draftVersion"]`) is pushed as a "react to this field changing" trigger — it
+    is **not** traversed into; the reverse path back to the root is still via the o2m above.
+- **`followReverseHint`** starts at the changed entity and walks each reverse segment with
+  `relation.load()`. For an **o2m/collection** step that means **loading the whole collection**.
+
+So a hint like `{ identity: ["draftVersion"] }` on a `Version` compiles to a reactive target
+`{ entity: Identity, fields: ["draftVersion"], path: ["versions"] }`: "when `Identity.draftVersion`
+changes, load `Identity.versions` and re-validate each." Every sibling version is re-checked, even
+though only the old/new target of the FK could possibly change outcome (Joist over-invalidates for
+correctness).
+
+## The old/new-value shortcut — and when it does NOT apply
+
+`followReverseHint` has a reference-history optimization (`getInstanceData(c).getReferenceHistory`)
+that pulls in **old + new** values — but only when the **step being walked is itself an m2o/poly**
+(the "`Book.author` moved to a new `Author`" reparent case). It exists so a reparent re-validates
+both the old and new parent.
+
+It does **not** turn a child→`parent.field` reaction into a cheap old/new lookup: there, the walked
+step is the `versions` **o2m**, so Joist takes the `relation.load()` (full-collection) branch. The
+`draftVersion` field's own m2o-ness is irrelevant — it's reacted to *as a field*, not *traversed*.
+
+Rule of thumb for the cost of one changed field:
+- reverse step is an **o2m/o2o** (you're on the child, parent-field changed) → **loads the full
+  sibling collection**.
+- reverse step is an **m2o/poly** being reparented → loads a couple entities (current + history).
+
+## How to spot / avoid it
+
+- **Root the rule where the frequently-changing field lives.** A rule on `Version` reacting to
+  `identity.draftVersion` reloads all siblings; the same check rooted on `Identity` reacting to its
+  own `["draftVersion"]` needs no reverse collection-load (but then detecting anything about the
+  *children* forces you to scan them anyway — so this only helps if the check is about the parent).
+- **Only react to fields that change rarely.** Put a field in the reactive hint only if you truly
+  need to re-run when it changes. If you just need to *read* a value, `await rel.load()` it on
+  demand inside the rule and leave it out of the hint. Reserve the hint for the rare-change trigger
+  that actually needs to fire the rule.
+- **Watch bulk/hot-path mutations.** If a job sets some `parent.fk` once per child (e.g.
+  `pushToDraft` setting `identity.draftVersion`), any child-rooted rule reacting to that fk reloads
+  every child's siblings — the same `O(children × siblings)` you'd get from an explicit
+  `parent.children.load()` in the loop.
+
+## Worked example (the one that motivated this skill)
+
+Invariant wanted: "an open (`final=null`) aggregate member version must be its identity's
+`activeVersion` or `draftVersion`."
+
+```ts
+// ❌ Simple but O(children × versions) on the copy-job hot path:
+// pushToDraft sets identity.draftVersion per child -> reverse-loads identity.versions each time.
+versionConfig.addRule({ final: {}, identity: ["activeVersion", "draftVersion"] }, (v) => { ... });
+
+// ✅ React only to activeVersion (which changes rarely — on publish, not per draft edit);
+// read draftVersion on-demand so it's not a reactive dependency.
+versionConfig.addRule({ final: {}, identity: ["activeVersion"] }, async (v) => {
+  if (v.final.isSet) return;
+  const identity = v.identity.get;
+  const active = identity.activeVersion.get;
+  const draft = await identity.draftVersion.load(); // read, don't react
+  if (v !== active && v !== draft) return `${v} is open but neither active nor draft`;
+});

--- a/packages/codegen/skills/joist-reactive-hints/SKILL.md
+++ b/packages/codegen/skills/joist-reactive-hints/SKILL.md
@@ -1,44 +1,67 @@
 ---
 name: joist-reactive-hint
-description: Explains the load cost of Joist reactive hints — specifically how followReverseHint walks reverse paths and when a reactive rule/field on a child entity reverse-loads its parent's ENTIRE children collection. Use when reasoning about the performance of a reactive rule/field/property (addRule, hasReactiveField, hasReactiveProperty, hasReactiveReference), when a validation rule seems to load far more rows than expected, when deciding whether to put a field in a reactive hint vs load it on-demand, or when a hot-path mutation (e.g. a bulk job) triggers surprise N×M loads. Keywords: reactive hint, reverse reactivity, followReverseHint, reverseSubHint, m2o vs o2m reactivity, over-invalidation, "reacting to a parent field reloads all siblings".
+description: Explains how Joist reactive hints work and what they cost to run — a hint is both a reverse-reactivity trigger (which roots re-run when a hinted field changes) and a forward load hint (what gets populated before the lambda runs), so a rule can pull an entire child collection into memory even when its lambda only reads a parent field. Covers followReverseHint, the two rule shapes (child-rooted reacting up to a parent vs parent-rooted reacting down into a child collection), and how to avoid surprise O(children) loads. Use when reasoning about the performance of a reactive rule/field/property (addRule, hasReactiveField, hasReactiveProperty, hasReactiveReference), when a validation rule seems to load far more rows than expected, when deciding whether to put a field in a reactive hint vs load it on-demand, or when a hot-path mutation (e.g. a bulk job) triggers surprise N×M loads. Keywords: reactive hint, load hint, reverse reactivity, followReverseHint, reverseSubHint, m2o vs o2m reactivity, over-invalidation, populate, "a parent rule that hints a child collection loads the whole collection".
 ---
 
-# Joist reactive-hint load cost (`followReverseHint`)
+# Joist reactive hints
+
+Reactive hints declare the fields a rule, `ReactiveField`, `ReactiveProperty`, or `ReactiveReference`
+depends on. A hint does **double duty**: Joist walks it in **reverse** to find *which* roots to re-run
+when a hinted field changes, then uses it **forward as a load hint** to populate that data on each root
+before the lambda runs. Most hints are cheap — but either direction can pull an entire child collection
+into memory, and the *forward* load is the surprising one, so both are the focus below.
 
 ## TL;DR
 
-A reactive rule/field is declared on a **root entity** with a hint. When any field in that hint
-changes, Joist must find the root entities to re-run — it does this by **walking the hint in
-reverse** (`followReverseHint` in `joist-core/build/reactiveHints.js`). The reverse walk **loads
-the relations it traverses**. The trap:
+A reactive rule/field is declared on a **root entity** with a hint. There are two shapes, and they
+cost very differently.
 
-> A reactive rule/field rooted on the **"many" side** (e.g. a `...Version`) that depends on a
-> field of its **m2o parent** (e.g. `identity.draftVersion`) will, **every time that parent field
-> changes, reverse-load the parent's ENTIRE children collection** (`identity.versions`) and
-> re-validate all of them. That's `O(children)` load per parent-field change — and if the parent
-> field changes once per child in a bulk job, the whole job is `O(children × siblings)`.
+**Shape #1 — rule on the child, hint reaches *up* to the parent** (e.g. a rule on `Book` with
+`{ author: ["currentDraftBook"] }`). When `Author.currentDraftBook` changes, Joist walks the hint in
+reverse (`followReverseHint`), reversing the `Book.author` m2o into the `Author.books` o2m and
+**loading the whole collection** to enumerate the child roots, then re-runs each book's rule.
+`O(children)` per parent-field change. This is **intuitive**: "change the author, and all of its books
+re-check."
 
-This is easy to introduce accidentally and does **not** show up in tests (behavior is correct; only
-throughput/memory suffer). It bites bulk/hot-path jobs at scale.
+**Shape #2 — rule on the parent, hint reaches *down* into a child collection** (e.g. a rule on `Author`
+with `{ books: ["title"] }`). When a single `Book.title` changes, the reverse walk is **cheap** — one
+`book.author` m2o hop to the one author. But the reactive hint is **also a load hint**: before running
+the author's lambda, Joist populates `author.books`, pulling the **entire** collection into memory —
+*even if the lambda only reads `author.status` and never touches the books*.
 
-## Why: how the reverse path is built and walked
+> The surprising one is **Shape #2**. `{ books: ["title"] }` reads like "react to book titles," but it
+> *also* means "load all of this author's books every time this rule fires." A lambda whose body is just
+> `return a.status === "active" ? undefined : "…"` still pays to load `author.books`, because the
+> **hint, not the lambda body, decides what gets loaded**.
 
-Two functions in `joist-core/build/reactiveHints.js`:
+Neither shows up in tests (behavior is correct; only throughput/memory suffer). Both bite bulk/hot-path
+jobs at scale — Shape #2 especially, because it looks cheap from the reverse-reactivity side.
 
-- **`reverseSubHint`** builds the reverse path by reversing each *traversed relation*:
-  - Traverse an **m2o** (`child.parent`, e.g. `Version.identity`) → reverse is the **o2m**
-    (`parent.children`, e.g. `Identity.versions`). The reverse path segment is that collection.
-  - A **leaf field** in the hint (primitive / enum / **m2o read as a value**, e.g.
-    `["activeVersion", "draftVersion"]`) is pushed as a "react to this field changing" trigger — it
-    is **not** traversed into; the reverse path back to the root is still via the o2m above.
-- **`followReverseHint`** starts at the changed entity and walks each reverse segment with
-  `relation.load()`. For an **o2m/collection** step that means **loading the whole collection**.
+## Why: reverse reactivity *and* load hints
 
-So a hint like `{ identity: ["draftVersion"] }` on a `Version` compiles to a reactive target
-`{ entity: Identity, fields: ["draftVersion"], path: ["versions"] }`: "when `Identity.draftVersion`
-changes, load `Identity.versions` and re-validate each." Every sibling version is re-checked, even
-though only the old/new target of the FK could possibly change outcome (Joist over-invalidates for
-correctness).
+A hinted-field change triggers two steps, both in `joist-core/build/reactiveHints.js`:
+
+**Step 1 — find the roots (reverse walk).** `followReverseHint` starts at the changed entity and walks
+the hint in reverse, reversing each *traversed relation* (via `reverseSubHint`):
+
+- Reverse of an **m2o** (`Book.author`) is the **o2m** (`Author.books`) — so a **child-rooted** rule
+  reacting to a parent field loads the whole sibling collection just to list the roots (Shape #1).
+- Reverse of an **o2m** (`Author.books`) is the **m2o** (`Book.author`) — so a **parent-rooted** rule
+  reacting to a child field finds exactly one root per changed child (Shape #2's reverse is cheap).
+- A **leaf field** (primitive / enum / m2o read as a value, e.g. `["title"]`, `["currentDraftBook"]`) is
+  only a "react to this field changing" trigger; it is **not** traversed into.
+
+**Step 2 — load the hint (forward populate).** Before running each root's lambda, Joist populates the
+reactive hint *as a load hint* on that root so the lambda can read it synchronously. For a parent-rooted
+rule with `{ books: [...] }`, that is effectively `author.populate("books")` — the **full collection** —
+**regardless of what the lambda actually reads**. This is why Shape #2 is expensive even though its
+reverse walk touched only one author: the cost is in the forward load, not the reverse walk.
+
+So `{ author: ["currentDraftBook"] }` on `Book` compiles to a reactive target
+`{ entity: Author, fields: ["currentDraftBook"], path: ["books"] }` — "when `Author.currentDraftBook`
+changes, load `Author.books` and re-validate each" — while `{ books: ["title"] }` on `Author` loads
+`author.books` on every fire so the rule can run at all. Either way Joist over-invalidates for
+correctness: every sibling is re-checked/loaded even when only one could change the outcome.
 
 ## The old/new-value shortcut — and when it does NOT apply
 
@@ -48,8 +71,8 @@ that pulls in **old + new** values — but only when the **step being walked is 
 both the old and new parent.
 
 It does **not** turn a child→`parent.field` reaction into a cheap old/new lookup: there, the walked
-step is the `versions` **o2m**, so Joist takes the `relation.load()` (full-collection) branch. The
-`draftVersion` field's own m2o-ness is irrelevant — it's reacted to *as a field*, not *traversed*.
+step is the `books` **o2m**, so Joist takes the `relation.load()` (full-collection) branch. The
+`currentDraftBook` field's own m2o-ness is irrelevant — it's reacted to *as a field*, not *traversed*.
 
 Rule of thumb for the cost of one changed field:
 - reverse step is an **o2m/o2o** (you're on the child, parent-field changed) → **loads the full
@@ -58,35 +81,70 @@ Rule of thumb for the cost of one changed field:
 
 ## How to spot / avoid it
 
-- **Root the rule where the frequently-changing field lives.** A rule on `Version` reacting to
-  `identity.draftVersion` reloads all siblings; the same check rooted on `Identity` reacting to its
-  own `["draftVersion"]` needs no reverse collection-load (but then detecting anything about the
+- **The hint decides the load, not the lambda body.** A parent rule with `{ books: [...] }` loads
+  *every* book on *every* fire, even if the lambda only reads the parent's own fields. If the rule does
+  not actually need the collection, do not hint it; if it does, know you are paying `O(children)` memory
+  per fire.
+- **For SQL-derived fields, split the hint with `hasAsyncReactiveField`.** It takes two hints — a
+  `loadHint`, whose data is populated into memory and passed to the lambda, and a `reactiveHint`, whose
+  data only *triggers* recalculation but is **not** loaded into memory (the lambda recomputes from SQL
+  instead). Put the large child collections you merely need to react to in the `reactiveHint` so a
+  child-field change still recomputes the value without pulling every sibling into memory.
+- **Root the rule where the frequently-changing field lives.** A rule on `Book` reacting to
+  `author.currentDraftBook` reloads all siblings; the same check rooted on `Author` reacting to its
+  own `["currentDraftBook"]` needs no reverse collection-load (but then detecting anything about the
   *children* forces you to scan them anyway — so this only helps if the check is about the parent).
 - **Only react to fields that change rarely.** Put a field in the reactive hint only if you truly
   need to re-run when it changes. If you just need to *read* a value, `await rel.load()` it on
   demand inside the rule and leave it out of the hint. Reserve the hint for the rare-change trigger
   that actually needs to fire the rule.
-- **Watch bulk/hot-path mutations.** If a job sets some `parent.fk` once per child (e.g.
-  `pushToDraft` setting `identity.draftVersion`), any child-rooted rule reacting to that fk reloads
-  every child's siblings — the same `O(children × siblings)` you'd get from an explicit
+- **Watch bulk/hot-path mutations.** If a job sets some `parent.fk` once per child (e.g. a bulk
+  copy job setting `author.currentDraftBook` per book), any child-rooted rule reacting to that fk
+  reloads every child's siblings — the same `O(children × siblings)` you'd get from an explicit
   `parent.children.load()` in the loop.
 
-## Worked example (the one that motivated this skill)
+## Worked examples
 
-Invariant wanted: "an open (`final=null`) aggregate member version must be its identity's
-`activeVersion` or `draftVersion`."
+### Shape #2 — the surprising one: a parent rule hinting into a child collection
 
 ```ts
-// ❌ Simple but O(children × versions) on the copy-job hot path:
-// pushToDraft sets identity.draftVersion per child -> reverse-loads identity.versions each time.
-versionConfig.addRule({ final: {}, identity: ["activeVersion", "draftVersion"] }, (v) => { ... });
-
-// ✅ React only to activeVersion (which changes rarely — on publish, not per draft edit);
-// read draftVersion on-demand so it's not a reactive dependency.
-versionConfig.addRule({ final: {}, identity: ["activeVersion"] }, async (v) => {
-  if (v.final.isSet) return;
-  const identity = v.identity.get;
-  const active = identity.activeVersion.get;
-  const draft = await identity.draftVersion.load(); // read, don't react
-  if (v !== active && v !== draft) return `${v} is open but neither active nor draft`;
+// ❌ Rooted on Author. The hint `{ books: ["title"] }` reads like "react to book titles" — but it is
+// ALSO a load hint, so every time ANY book's title changes, Joist loads the author's ENTIRE `books`
+// collection into memory to run this rule, even though the lambda only looks at the author's status.
+authorConfig.addRule(["status", { books: ["title"] }], (a) => {
+  return a.status === "active" ? undefined : "inactive authors need review";
 });
+
+// ✅ The rule only depends on the author's own status, so hint only that — no books are loaded.
+authorConfig.addRule("status", (a) => {
+  return a.status === "active" ? undefined : "inactive authors need review";
+});
+```
+
+If the rule genuinely must react to a child field, keep the hint — but know each fire loads the whole
+collection, so reserve it for collections the lambda actually reads and for child fields that change
+rarely.
+
+### Shape #1 — intuitive but still O(children): a child rule reacting to a parent field
+
+Invariant wanted: "an unpublished book must be one of its author's tracked books — its `favoriteBook` or
+`currentDraftBook`."
+
+```ts
+// ❌ Simple but O(books × siblings) on the bulk copy-job hot path:
+// the job sets author.currentDraftBook per book -> reverse-loads author.books each time.
+bookConfig.addRule(
+  ["publishedAt", { author: ["favoriteBook", "currentDraftBook"] }],
+  (b) => { ... },
+);
+
+// ✅ React only to favoriteBook (which changes rarely — on publish, not per draft edit);
+// read currentDraftBook on-demand so it's not a reactive dependency.
+bookConfig.addRule(["publishedAt", { author: ["favoriteBook"] }], async (b) => {
+  if (b.publishedAt) return;
+  const author = b.author.get;
+  const favorite = author.favoriteBook.get;
+  const draft = await author.currentDraftBook.load(); // read, don't react
+  if (b !== favorite && b !== draft) return `${b} is unpublished but neither the favorite nor current draft`;
+});
+```

--- a/packages/codegen/skills/joist-test-factories/SKILL.md
+++ b/packages/codegen/skills/joist-test-factories/SKILL.md
@@ -18,7 +18,7 @@ Authoritative references:
 
 ## Non-Negotiable Rules
 
-1. Create ordinary Given state with test factories. Never use the same function
+1. Create initial Given state with test factories. Never use the same function
    or API operation under test to arrange its own preconditions.
 2. Set only fields and relationships that define the boundary case. Let the
    factories supply unrelated required values and dependencies.
@@ -34,27 +34,32 @@ Authoritative references:
 7. Prefer focused tests for one behavior over a single scenario that exercises
    unrelated updates at several graph levels.
 
-## Arrange, Act, Assert
+## Given, When, Then
 
-Follow this shape:
+Structure every test as "Given the state of the world is X, When action Y
+happens, Then the state of the world is Z": the factory-created graph is the
+Given, the code under test is the When, and `toMatchEntity` proves the Then.
+Mark the three phases with `// Given`, `// When`, `// Then` comments:
 
 ```ts
 it.withCtx("updates a book", async (ctx) => {
+  // Given an author with one book
   const author = newAuthor(ctx.em, {
     books: [{ title: "Before" }],
   });
   const [book] = author.books.get;
 
-  // updateBook owns and flushes its production unit of work.
+  // When we update the book's title (updateBook owns and flushes its production unit of work)
   await run(ctx, (ctx) => updateBook(ctx, { id: book.id, title: "After" }));
 
+  // Then the book's title is changed
   expect(author).toMatchEntity({ books: [{ title: "After" }] });
 });
 ```
 
-The factory owns setup defaults. `run` provides production isolation and
+The factory owns the Given defaults. `run` provides production isolation and
 mirrors flushed writes. The callback still owns its production unit of work.
-`toMatchEntity` owns entity-aware assertions.
+`toMatchEntity` owns the Then's entity-aware assertions.
 
 ## Factories Own Given State
 
@@ -380,6 +385,8 @@ reuse decisions instead of replacing factories with manual setup.
 
 ## Review Checklist
 
+- Test reads as Given, When, Then, with the code under test isolated as a single
+  When.
 - Given state uses minimal factory opts and does not invoke the behavior under
   test.
 - Important entities have direct, role-based `const` names.

--- a/packages/codegen/skills/joist-test-factories/SKILL.md
+++ b/packages/codegen/skills/joist-test-factories/SKILL.md
@@ -48,8 +48,7 @@ it.withCtx("updates a book", async (ctx) => {
   // updateBook owns and flushes its production unit of work.
   await run(ctx, (ctx) => updateBook(ctx, { id: book.id, title: "After" }));
 
-  expect(author).toMatchEntity({ books: [book] });
-  expect(book).toMatchEntity({ title: "After" });
+  expect(author).toMatchEntity({ books: [{ title: "After" }] });
 });
 ```
 
@@ -279,11 +278,11 @@ avoid unnecessary flushes.
 
 ## Register toMatchEntity
 
-Examples assume `joist-test-utils` is a development dependency and the matcher
-is registered in the project's test setup:
+Examples assume `toMatchEntity` is imported from the `joist-orm/tests`
+entry point and registered in the project's test setup:
 
 ```ts
-import { toMatchEntity } from "joist-test-utils";
+import { toMatchEntity } from "joist-orm/tests";
 
 expect.extend({ toMatchEntity });
 ```

--- a/packages/codegen/skills/joist-test-factories/SKILL.md
+++ b/packages/codegen/skills/joist-test-factories/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: joist-test-factories
+description: Use when writing or refactoring Joist ORM tests with newTestInstance factories, DeepNew, run or makeRun, toMatchEntity, and nested Given graphs.
+---
+
+# Joist Test Factories
+
+Write isolated, succinct tests that use Joist's factories for setup, retain
+typed entity references through the action, and assert those same entities
+with `toMatchEntity`.
+
+Authoritative references:
+
+- <https://joist-orm.io/testing/test-factories/>
+- <https://joist-orm.io/testing/entity-matcher/>
+- <https://joist-orm.io/testing/test-utils/>
+- <https://joist-orm.io/goals/great-tests/>
+
+## Non-Negotiable Rules
+
+1. Create ordinary Given state with test factories. Never use the same function
+   or API operation under test to arrange its own preconditions.
+2. Set only fields and relationships that define the boundary case. Let the
+   factories supply unrelated required values and dependencies.
+3. Keep direct `const` references to entities that participate in the action or
+   assertions.
+4. Keep using the factory-created `DeepNew` graph after same-`EntityManager`
+   actions or actions run through Joist's test `run` helper. Do not reload the
+   same rows merely to assert against them.
+5. Use `run` or the project's `makeRun` wrapper when production code needs an
+   isolated `EntityManager`; it flushes Given state and mirrors the callback's
+   flushed Joist writes into the original test graph.
+6. Assert entity state and relationships with `toMatchEntity`.
+7. Prefer focused tests for one behavior over a single scenario that exercises
+   unrelated updates at several graph levels.
+
+## Arrange, Act, Assert
+
+Follow this shape:
+
+```ts
+it.withCtx("updates a book", async (ctx) => {
+  const author = newAuthor(ctx.em, {
+    books: [{ title: "Before" }],
+  });
+  const [book] = author.books.get;
+
+  // updateBook owns and flushes its production unit of work.
+  await run(ctx, (ctx) => updateBook(ctx, { id: book.id, title: "After" }));
+
+  expect(author).toMatchEntity({ books: [book] });
+  expect(book).toMatchEntity({ title: "After" });
+});
+```
+
+The factory owns setup defaults. `run` provides production isolation and
+mirrors flushed writes. The callback still owns its production unit of work.
+`toMatchEntity` owns entity-aware assertions.
+
+## Factories Own Given State
+
+Do not call the same code under test to arrange its own preconditions:
+
+```ts
+// Wrong: saveAuthor is both setup and the behavior under test.
+const created = await saveAuthor(ctx, {
+  firstName: "a1",
+  books: [{ title: "Before" }],
+});
+const author = await created.author;
+```
+
+This couples setup to the behavior under test, can reproduce the same bug in
+both phases, and loses the ergonomic `DeepNew` type.
+
+Use a factory instead:
+
+```ts
+const author = newAuthor(ctx.em, {
+  books: [{ title: "Before" }],
+});
+const [book] = author.books.get;
+```
+
+Factories are test-only tools. Never call them from production code.
+Using another production API for Given state can be valid in an integration
+test when that API's authorization, hooks, defaults, or events are part of the
+scenario. This should be intentional, not the default way to create rows.
+
+## Keep Given State Minimal
+
+Every explicit factory option should answer: "Why does this test need this
+value?"
+
+```ts
+// Wrong: most values are unrelated to changing one title.
+const author = newAuthor(ctx.em, {
+  firstName: "Ann",
+  lastName: "Smith",
+  age: 40,
+  books: [
+    {
+      title: "Before",
+      order: 1,
+      published: false,
+      reviews: [],
+    },
+  ],
+});
+```
+
+```ts
+// Right: only the value being changed is specified.
+const author = newAuthor(ctx.em, {
+  books: [{ title: "Before" }],
+});
+```
+
+Specify additional values only when they establish the scenario. Examples:
+
+- Two `{}` children establish collection cardinality.
+- Distinct sort orders may be necessary for a parent/sort-order unique key.
+- An initial value is necessary when the assertion proves that it changed.
+- A relation override is necessary when the identity of that relation matters.
+
+Do not copy production payloads into factory opts. Factory opts describe the
+minimum database state before the action, not every field the action accepts.
+
+## Build Graphs in One Factory Call
+
+Prefer a top-level factory with nested opts when it clearly describes the
+scenario:
+
+```ts
+const author = newAuthor(ctx.em, {
+  books: [{ title: "First", reviews: [{ rating: 5 }] }, { title: "Second" }],
+});
+const [firstBook, secondBook] = author.books.get;
+const [review] = firstBook.reviews.get;
+```
+
+This is usually clearer than creating each row separately and wiring every
+required relation by hand. Separate factory calls are appropriate when the
+test's behavior is specifically about how independently created entities
+relate.
+
+Factories recursively fill required primitives and relations. They also reuse
+an obvious existing entity when exactly one candidate exists. Use factory
+controls intentionally:
+
+- Pass an entity directly to force a specific relation.
+- Pass `{ use: entity }` to nominate an existing entity throughout a factory
+  scope.
+- Pass `{}` for a relation when a new related entity is required.
+- Use `useFactoryDefaults: false` sparingly; frequent use means the factory
+  defaults may be too opinionated.
+- Use `useFactoryDefaults: "none"` only for tests explicitly exercising invalid
+  or incomplete state.
+
+## Retain Entity References
+
+Immediately name entities used by the action or assertions:
+
+```ts
+const author = newAuthor(ctx.em, {
+  books: [{}, {}],
+});
+const [updatedBook, deletedBook] = author.books.get;
+```
+
+Do not unnecessarily rediscover Given entities later by index, query, ID, or
+mutation result. Newly created entities can come from the action result, and a
+query result is appropriate when querying is the behavior under test.
+
+For complicated cross-references in one factory graph, use factory IDs:
+
+```ts
+const author = newAuthor(ctx.em, {
+  books: [
+    { is: "b#1", title: "First" },
+    { is: "b#2", prequel: "b#1", title: "Second" },
+  ],
+});
+const [firstBook, secondBook] = author.books.get;
+
+expect(secondBook).toMatchEntity({ prequel: firstBook });
+```
+
+The `factories` proxy is also available when direct relation destructuring is
+awkward:
+
+```ts
+newAuthor(ctx.em, { books: [{}, {}] });
+const { a1, b1, b2 } = factories;
+```
+
+The proxy resolves against the most recently used `EntityManager`, so avoid it
+in tests with multiple active test entity managers.
+
+Prefer ordinary named constants when the graph is small; they make the test's
+roles clearer than numeric factory IDs.
+
+## DeepNew Means Async-Free Graph Access
+
+Follow the signature generated by the project's Joist version. Factories that
+return `DeepNew<Entity>` provide the loaded graph ergonomics used here:
+
+```ts
+export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): DeepNew<Author> {
+  return newTestInstance(em, Author, opts, {});
+}
+```
+
+`DeepNew` is a loadedness type for the factory-created graph, so setup and
+assertions can use `.get` without `await`:
+
+```ts
+const author = newAuthor(ctx.em, { books: [{}] });
+const [book] = author.books.get;
+
+expect(author).toMatchEntity({ books: [book] });
+```
+
+Avoid this boilerplate:
+
+```ts
+const books = await author.books.load();
+const reloadedAuthor = await ctx.em.load(Author, author.id);
+const reloadedBooks = await reloadedAuthor.books.load();
+```
+
+`DeepNew` does not synchronize writes from another `EntityManager`. If a
+relation was not part of the factory-created graph, use an intentional
+populate, or use Joist's `run` helper when testing a separate production unit
+of work. Do not silence a legitimate unloaded-relation boundary with arbitrary
+test-only loads.
+
+## Use run for Production Isolation
+
+Joist's `run(ctx, fn)` executes `fn` with a fresh production-style context and
+`EntityManager`. Before the callback, it flushes the test factory graph. As the
+callback flushes Joist writes, `RunPlugin` mirrors those writes into the
+original test `EntityManager`. It does not call `EntityManager.refresh`. The
+callback result is also mapped back to entities from the original test
+`EntityManager`.
+
+```ts
+const author = newAuthor(ctx.em, { books: [{ title: "Before" }] });
+const [book] = author.books.get;
+
+// updateBook must own and flush its production unit of work.
+await run(ctx, (ctx) => updateBook(ctx, { id: book.id, title: "After" }));
+
+expect(book).toMatchEntity({ title: "After" });
+```
+
+Many applications expose a project-specific helper created with `makeRun`,
+such as `runMutation` or `runService`. Use that helper instead of manually
+constructing a second `EntityManager`.
+
+`run` deliberately does not flush the callback's `EntityManager`; production
+code under test must own its normal unit-of-work boundary. Unflushed changes,
+direct SQL, and writes outside Joist are not guaranteed to be mirrored into the
+test graph.
+
+Do not write:
+
+```ts
+const result = await runMutation(ctx, () => updateBookInput(book.id));
+const savedBook = await result.book;
+const books = await savedBook.author.load().then((author) => author.books.load());
+```
+
+Keep using `author` and `book`. They are the stable test references.
+
+Call `em.flush()` directly only when the test intentionally needs a persistence
+boundary and its helper does not provide one. Pure entity tests should usually
+avoid unnecessary flushes.
+
+## Register toMatchEntity
+
+Examples assume `joist-test-utils` is a development dependency and the matcher
+is registered in the project's test setup:
+
+```ts
+import { toMatchEntity } from "joist-test-utils";
+
+expect.extend({ toMatchEntity });
+```
+
+Use the runner-specific setup and types from the installed Joist version.
+
+## Assert with toMatchEntity
+
+`toMatchEntity` provides `toMatchObject`-style subset assertions while
+understanding Joist references, collections, properties, reactive fields, and
+entity identity. It also produces concise entity IDs in diffs.
+
+`toMatchEntity` synchronously unwraps loaded relations through `.get`; it does
+not query or asynchronously load missing relations. Ensure the asserted graph
+is loaded by the factory, an intentional populate, or `RunPlugin`.
+
+```ts
+expect(author).toMatchEntity({
+  firstName: "Ann",
+  books: [book],
+});
+expect(book).toMatchEntity({ title: "After" });
+```
+
+Pass retained entity constants directly for relationship identity. Use nested
+object literals when the nested values themselves are the assertion:
+
+```ts
+expect(author).toMatchEntity({
+  books: [{ title: "First" }, { title: "Second" }],
+});
+```
+
+For a hard delete, assert both the surviving collection and deletion state
+when deletion semantics matter:
+
+```ts
+expect(author).toMatchEntity({ books: [updatedBook] });
+expect(deletedBook).toMatchEntity({ isDeletedEntity: true });
+```
+
+Do not map entity graphs into temporary POJOs just to use `toEqual`:
+
+```ts
+// Wrong.
+expect((await author.books.load()).map((book) => ({ id: book.id, title: book.title }))).toEqual([
+  { id: updatedBook.id, title: "After" },
+]);
+```
+
+## Keep Tests Focused
+
+One test should describe one coherent boundary. Split a large graph mutation
+into separate tests when failures would otherwise have several unrelated
+causes:
+
+- Updating/deleting members of a parent collection.
+- Updating/deleting grandchildren.
+- Creating a new nested entity.
+- Clearing a collection.
+- Preserving an omitted relation.
+
+Combining an update and delete can be appropriate when they jointly exercise
+one incremental-collection contract. Avoid a kitchen-sink test that performs
+step updates, ingredient updates, note updates, and several unrelated scalar
+changes in one action.
+
+Focused tests produce smaller Given graphs, clearer constants, and useful
+failure messages.
+
+## Factory Defaults
+
+Customize a generated factory only for defaults that make entities valid by
+default across the suite:
+
+```ts
+export function newAuthor(em: EntityManager, opts: FactoryOpts<Author> = {}): DeepNew<Author> {
+  return newTestInstance(em, Author, opts, {
+    age: 40,
+  });
+}
+```
+
+Use `testIndex` for deterministic unique values when a database unique
+constraint requires them. Add collection defaults only for genuine suite-wide
+validity rules, such as every valid author requiring at least one book.
+
+Custom options such as `withSignedContract` can package a commonly repeated
+graph, but use them sparingly. A reader should not need to inspect a factory to
+understand the values directly asserted by the test.
+
+If factory behavior is surprising, enable `useLogging: true` for that call or
+temporarily enable global factory logging. Diagnose the factory scope and
+reuse decisions instead of replacing factories with manual setup.
+
+## Review Checklist
+
+- Given state uses minimal factory opts and does not invoke the behavior under
+  test.
+- Important entities have direct, role-based `const` names.
+- Separate production units of work use `run`/`makeRun` and flush normally.
+- Assertions reuse loaded factory entities with `toMatchEntity`.
+- No unnecessary reloads, `load()` calls, assertion awaits, or direct flushes
+  remain.
+- Each test covers one coherent boundary.

--- a/packages/codegen/skills/joist-upsert/SKILL.md
+++ b/packages/codegen/skills/joist-upsert/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: joist-upsert
+description: Implement partial-update / RPC / GraphQL save endpoints with Joist using setPartial, createPartial, em.upsert, and incremental collection ops. Use when a create/update accepts a subset of fields, treats null as "unset", or saves a parent plus a mix of new and existing children.
+---
+
+<!-- Managed by joist-codegen. Do not edit by hand; re-run codegen to update. -->
+
+# Joist partial updates & upsert
+
+These APIs exist for "partial update" endpoints (REST/GraphQL/gRPC) where the
+input is loosely typed (`string | null | undefined`) and follows the
+conventions:
+
+- A subset of fields may be sent; omitted fields are left as-is.
+- `null` means "unset this field".
+- Children collections can be updated incrementally.
+
+Joist's normal `em.create` / `Entity.set` are intentionally strict and won't
+accept `string | null | undefined`. The partial variants opt into the looser
+semantics.
+
+## `setPartial`
+
+```ts
+// firstName is typed `string | null | undefined` (e.g. from a GraphQL input)
+const author = await em.load(Author, "a:1");
+author.setPartial({ firstName }); // compiles; `set` would not
+```
+
+Semantics, per field:
+
+- Required field (`firstName`): value updates it; `undefined` does nothing;
+  `null` is a **validation error** (required field can't be unset).
+- Optional field (`lastName`): value updates it; `undefined` does nothing;
+  `null` unsets it (sets to `undefined`).
+- Collection (`books`): `[b1]` sets it to exactly `[b1]`; `null` sets it to
+  `[]`; `undefined` does nothing.
+
+`em.createPartial(Author, ...)` and `em.upsert(Author, ...)` share these
+semantics.
+
+## `em.upsert` — parent plus children
+
+`em.upsert` saves a parent and a mix of new/existing children in one call. It is
+**async** (unlike `em.create`) because it may issue `SELECT`s to resolve
+existing child ids.
+
+```ts
+await em.upsert(Author, {
+  id: "a:1",                       // update author 1
+  books: [
+    { title: "new book" },         // no id -> create
+    { id: "b:1" },                 // existing, unchanged
+    { id: "b:2", title: "updated" }, // existing, updated
+  ],
+});
+```
+
+By default a collection is set **exhaustively** — any existing child not listed
+is removed.
+
+## Incremental collections (`op`)
+
+To change only some children without sending the whole collection, add an `op`
+hint to each child:
+
+```ts
+author.setPartial({
+  books: [{ op: "include", title: "b3" }], // adds b3, leaves existing books
+});
+```
+
+- `{ op: "include", id }` — add if needed, or update an existing child
+- `{ op: "remove", id }` — remove from the collection (no delete)
+- `{ op: "delete", id }` — remove and `em.delete` the child
+
+Rules and gotchas:
+
+- If **any** child has an `op`, **all** children must have one.
+- `op` is not a real entity field — it's only a hint on the input type.
+- An **empty** list always clears the collection (it looks like an exhaustive
+  set), so to send "no changes" omit the collection key entirely. Alternatively
+  include a single `{ op: "incremental" }` sentinel child to force incremental
+  semantics without adding/removing anything.
+
+## Legacy keys (soft-deprecated)
+
+Older code used `delete: true` / `remove: true` instead of `op`; still
+supported, but prefer `op` for new code:
+
+```ts
+author.setPartial({
+  books: [{ id: "b:1", delete: true }, { id: "b:2", remove: true }, { id: "b:4" }],
+});
+```

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -152,7 +152,7 @@ export const config = z
     paginationStyle: z.optional(z.union([z.literal("cursor"), z.literal("limit")])).default("cursor"),
     /** Enables documentation syncing between .md files and JSDocs. */
     docs: z.optional(z.boolean()),
-    /** Installs Joist's bundled Agent Skills into `.claude/skills` and `.agents/skills`. */
+    /** Installs Joist's bundled Agent Skills into `.claude/skills` and `.agents/skills`; on by default, set `false` to disable. */
     skills: z.optional(z.boolean()),
     /** Output a metadata-docs.ts file with entity/field documentation available at runtime. */
     outputDocs: z.optional(z.boolean()),

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -152,6 +152,8 @@ export const config = z
     paginationStyle: z.optional(z.union([z.literal("cursor"), z.literal("limit")])).default("cursor"),
     /** Enables documentation syncing between .md files and JSDocs. */
     docs: z.optional(z.boolean()),
+    /** Installs Joist's bundled Agent Skills into `.claude/skills` and `.agents/skills`. */
+    skills: z.optional(z.boolean()),
     /** Output a metadata-docs.ts file with entity/field documentation available at runtime. */
     outputDocs: z.optional(z.boolean()),
     /** Auto-set by probing the project's `tsconfig.json` file. */

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -86,8 +86,8 @@ export async function joistCodegen() {
   // Finally actually generate the files (even if we found a fatal error)
   await generateAndSaveFiles(config, dbMetadata);
 
-  // Install our bundled Agent Skills so coding agents can find them
-  if (config.skills) await installSkills();
+  // Install our bundled Agent Skills so coding agents can find them, unless explicitly disabled
+  if (config.skills !== false) await installSkills();
 
   stripStiPlaceholders(config, entities);
   await writeConfig(config);

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -12,6 +12,7 @@ import { Config, loadConfig, stripStiPlaceholders, warnInvalidConfigEntries, wri
 import { maybeSetForeignKeyOrdering } from "./foreignKeyOrdering";
 import { generateFiles } from "./generate";
 import { createFlushFunction } from "./generateFlushFunction";
+import { installSkills } from "./installSkills";
 import { applyInheritanceUpdates } from "./inheritance";
 import { loadEnumMetadata, loadPgEnumMetadata } from "./loadMetadata";
 import { LOG_LEVELS, loggerMaxWarningLevelHit } from "./logger";
@@ -84,6 +85,9 @@ export async function joistCodegen() {
 
   // Finally actually generate the files (even if we found a fatal error)
   await generateAndSaveFiles(config, dbMetadata);
+
+  // Install our bundled Agent Skills so coding agents can find them
+  if (config.skills) await installSkills();
 
   stripStiPlaceholders(config, entities);
   await writeConfig(config);

--- a/packages/codegen/src/installSkills.test.ts
+++ b/packages/codegen/src/installSkills.test.ts
@@ -1,0 +1,39 @@
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { installSkills } from "./installSkills";
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await fs.mkdtemp(join(tmpdir(), "joist-skills-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+describe("installSkills", () => {
+  it("copies bundled skills into both .claude and .agents", async () => {
+    await installSkills(testDir);
+
+    for (const target of [".claude/skills", ".agents/skills"]) {
+      const names = (await fs.readdir(join(testDir, target))).sort();
+      expect(names).toMatchObject(["joist-em-basics", "joist-upsert"]);
+    }
+
+    const skill = await fs.readFile(join(testDir, ".claude/skills/joist-em-basics/SKILL.md"), "utf-8");
+    expect(skill).toContain("name: joist-em-basics");
+  });
+
+  it("overwrites a previously-installed skill", async () => {
+    const dest = join(testDir, ".claude/skills/joist-em-basics");
+    await fs.mkdir(dest, { recursive: true });
+    await fs.writeFile(join(dest, "SKILL.md"), "stale", "utf-8");
+
+    await installSkills(testDir);
+
+    const skill = await fs.readFile(join(dest, "SKILL.md"), "utf-8");
+    expect(skill).toContain("name: joist-em-basics");
+  });
+});

--- a/packages/codegen/src/installSkills.ts
+++ b/packages/codegen/src/installSkills.ts
@@ -1,0 +1,42 @@
+import { promises as fs } from "fs";
+import { join, resolve } from "path";
+
+/** The bundled skills live at the package root, alongside `build`/`src`. */
+const bundledSkillsDir = resolve(__dirname, "../skills");
+
+/**
+ * Targets that each get a full copy of every skill directory.
+ *
+ * `.claude/skills` is read by Claude Code (and opencode); `.agents/skills` is read
+ * by Codex (and opencode), so writing both gives native coverage across all three.
+ */
+const skillTargets = [".claude/skills", ".agents/skills"];
+
+/**
+ * Copies Joist's bundled Agent Skills into the project so coding agents can
+ * discover them.
+ *
+ * The skills are framework-owned and rewritten on every codegen run, so users
+ * should not hand-edit them (re-run codegen to pick up new Joist versions).
+ */
+export async function installSkills(rootDir: string = "."): Promise<void> {
+  let skillNames: string[];
+  try {
+    const entries = await fs.readdir(bundledSkillsDir, { withFileTypes: true });
+    skillNames = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch {
+    // The bundled skills are missing (e.g. running against an unbuilt package); nothing to do.
+    return;
+  }
+  if (skillNames.length === 0) return;
+
+  await Promise.all(
+    skillTargets.flatMap((target) =>
+      skillNames.map((name) =>
+        fs.cp(join(bundledSkillsDir, name), join(rootDir, target, name), { recursive: true, force: true }),
+      ),
+    ),
+  );
+
+  console.log(`Installed ${skillNames.length} Joist skill(s) into ${skillTargets.join(" and ")}`);
+}

--- a/packages/core/src/relations/AsyncReactiveField.ts
+++ b/packages/core/src/relations/AsyncReactiveField.ts
@@ -13,18 +13,20 @@ import { PropertyT } from "./hasProperty";
  * a `ReactiveField`, but when the value needs to be calculated from SQL because
  * it would be too expensive to calculate in-memory.
  *
- * The `fn` lambda will be called when any data referred to by either the `paramHint` or
- * `dbHint` reactive hints have changed, but only the `paramHint`'s data will be pulled
- * into memory.
+ * Its hint is split in two: the `loadHint` names data that is both reacted-to *and*
+ * loaded into memory (and passed to `fn`), while the `reactiveHint` names data that is
+ * only reacted-to (its changes recompute the value) but is left in the database rather
+ * than pulled into memory. The `fn` lambda re-runs when data referred to by either hint
+ * changes, but only the `loadHint`'s data is populated.
  */
 export function hasAsyncReactiveField<
   T extends Entity,
   const H1 extends ReactiveHint<T>,
   const H2 extends ReactiveHint<T>,
   V,
->(paramHint: H1, dbHint: H2, fn: (entity: Reacted<T, H1>) => Promise<V>): ReactiveField<T, V> {
+>(loadHint: H1, reactiveHint: H2, fn: (entity: Reacted<T, H1>) => Promise<V>): ReactiveField<T, V> {
   return lazyField((entity: T, fieldName) => {
-    return new AsyncReactiveFieldImpl(entity, fieldName as keyof T & string, paramHint, dbHint, fn);
+    return new AsyncReactiveFieldImpl(entity, fieldName as keyof T & string, loadHint, reactiveHint, fn);
   });
 }
 
@@ -32,8 +34,8 @@ export class AsyncReactiveFieldImpl<T extends Entity, H1 extends ReactiveHint<T>
   extends AbstractPropertyImpl<T>
   implements ReactiveField<T, V>
 {
-  readonly #paramHint: H1;
-  readonly #dbHint: H2;
+  readonly #loadHint: H1;
+  readonly #reactiveHint: H2;
   #loadPromise: any;
   #loaded: boolean;
   #useFactoryValue = false;
@@ -41,22 +43,27 @@ export class AsyncReactiveFieldImpl<T extends Entity, H1 extends ReactiveHint<T>
   constructor(
     entity: T,
     public fieldName: keyof T & string,
-    public paramHint: H1,
-    public dbHint: H2,
+    loadHint: H1,
+    reactiveHint: H2,
     private fn: (entity: Reacted<T, H1>) => Promise<V>,
   ) {
     super(entity);
-    this.#paramHint = paramHint;
-    this.#dbHint = dbHint;
+    this.#loadHint = loadHint;
+    this.#reactiveHint = reactiveHint;
     this.#loaded = false;
   }
 
-  /** Our combined param + db reactivity hint, so that we react to changes within both. */
+  /**
+   * Our combined load + reactive-only hint, so that we react to changes within both.
+   *
+   * The `loadHint` half is populated into memory (and passed to `fn`); the `reactiveHint`
+   * half only triggers recalculation, so its data stays in the database.
+   */
   get reactiveHint(): ReactiveHint<any> {
     // We do this in a getter (instead of the constructor) b/c it might be a little expensive,
     // and I'm pretty sure this is only called on boot, when hooking up the reactivity.
-    const hint = deepNormalizeHint(this.#paramHint);
-    mergeNormalizedHints(hint, deepNormalizeHint(this.#dbHint));
+    const hint = deepNormalizeHint(this.#loadHint);
+    mergeNormalizedHints(hint, deepNormalizeHint(this.#reactiveHint));
     return hint;
   }
 
@@ -113,9 +120,9 @@ export class AsyncReactiveFieldImpl<T extends Entity, H1 extends ReactiveHint<T>
   }
 
   get loadHint(): any {
-    // Only convert the paramHint, so we don't pull the dbHint-referenced data into memory
+    // Only convert the loadHint, so we don't pull the reactiveHint-referenced data into memory
     const meta = getMetadata(this.entity);
-    return (meta.config.__data.cachedReactiveLoadHints[this.fieldName] ??= convertToLoadHint(meta, this.#paramHint));
+    return (meta.config.__data.cachedReactiveLoadHints[this.fieldName] ??= convertToLoadHint(meta, this.#loadHint));
   }
 
   setFactoryValue(newValue: any): void {


### PR DESCRIPTION
Running `joist-codegen` will auto-install skills that will hopefully let agents write less wtf code.

Currently there are 4 skills:

- 1. em basics
- 2. em upsert
- 3. factories & test patterns
- 4. partial APIs

Admittedly 2 & 4 are somewhat overlapping -- will see how it works out.

Projects can opt-out with `skills: false` in the `joist-codegen.json`.

We auto-install the skills to both `~/.claude/skills` and `~/.agents/skills` to get Claude & OpenCode coverage.