### PR TITLE
feat: Add addDeleteRule and addCommitDeleteRule.

### DIFF
--- a/docs/src/content/docs/modeling/validation-rules.md
+++ b/docs/src/content/docs/modeling/validation-rules.md
@@ -131,6 +131,35 @@ Like `addRule`, commit rules can be either:
 - **Simple** — `config.addCommitRule(fn)`, run on every insert/update of the entity, or
 - **Reactive** — `config.addCommitRule(hint, fn)`, run whenever any field in the [reactive hint](#reactive-hints) changes (walking back to the owning entity), with the lambda passed the same `Reacted<Entity, Hint>` view as reactive validation rules.
 
+## Delete Rules
+
+Use `config.addDeleteRule` for validation that should run only when an entity is being deleted:
+
+```typescript
+config.addDeleteRule((author) => {
+  if (author.isProtected) {
+    return "Protected authors cannot be deleted";
+  }
+});
+```
+
+Delete rules return the same validation results as regular rules, but do not run for inserts or updates. They run before Joist issues the `DELETE`, and a failure prevents the entire flush from being written.
+
+Like `addRule`, `addDeleteRule` cannot call `em.find` or the other `em.findX` methods because the database still contains the pre-flush state. For deletion rules that need to query the changed transaction state, use `config.addCommitDeleteRule`:
+
+```typescript
+config.addCommitDeleteRule(async (author) => {
+  if (author.isAdmin) {
+    const remainingAdmins = await author.em.find(Author, { isAdmin: true });
+    if (remainingAdmins.length === 0) {
+      return "The last admin cannot be deleted";
+    }
+  }
+});
+```
+
+Commit delete rules run after the `DELETE` and any other pending `INSERT`s and `UPDATE`s have been flushed to the open transaction, but before it commits. Consequently, `em.find` sees the latest transaction state: the deleted row is absent, and other changes from the same flush are visible. If the rule fails, Joist rolls back the entire transaction.
+
 ## Built-in Rules
 
 ### Required Fields

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -252,8 +252,8 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   // Provides field-based indexing for entity types with >1000 entities to optimize findWithNewOrChanged
   readonly #indexManager = new IndexManager();
   #isValidating: boolean = false;
-  // Set while regular (pre-flush) validation rules run, so `em.find*` can fail fast (see #assertFindAllowed)
-  #findRestricted: boolean = false;
+  // Set while pre-flush validation rules run, so `em.find*` can fail fast (see #assertFindAllowed)
+  #findRestricted: "addRule" | "addDeleteRule" | false = false;
   readonly #pendingPercolate: Map<string, Map<string, { adds: Entity[]; removes: Entity[] }>> = new Map();
   #preloadedRelations: Map<string, Map<string, Entity[]>> = new Map();
   /**
@@ -489,12 +489,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     return result;
   }
 
-  /** Fails fast if `em.${method}` is called from a regular validation rule, i.e. steers to `config.addCommitRule`. */
+  /** Fails fast if `em.${method}` is called from a pre-flush validation rule. */
   #assertFindAllowed(method: string): void {
     if (this.#findRestricted) {
+      const commitRule = this.#findRestricted === "addDeleteRule" ? "addCommitDeleteRule" : "addCommitRule";
       throw new Error(
-        `em.${method} cannot be called from a validation rule (added via config.addRule), because rules run ` +
-          `before the flush and would query stale, pre-flush data. Use config.addCommitRule instead, which runs ` +
+        `em.${method} cannot be called from a validation rule (added via config.${this.#findRestricted}), because rules run ` +
+          `before the flush and would query stale, pre-flush data. Use config.${commitRule} instead, which runs ` +
           `after the INSERT/UPDATE/DELETEs are flushed (within the same transaction) and so sees the changed state.`,
       );
     }
@@ -1778,7 +1779,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
             // Regular rules run pre-flush, so `em.find*` would query stale data; block it and steer
             // users to `config.addCommitRule` (which runs post-flush). Only rules are restricted —
             // `afterValidation` hooks & plugins below are left free to query.
-            this.#findRestricted = true;
+            this.#findRestricted = "addRule";
             try {
               // Run simple rules first b/c it includes not-null/required rules, so that then when we run
               // `validateReactiveRules` next, the app's lambdas won't see fundamentally invalid entities & NPE.
@@ -1789,6 +1790,8 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
               // that the user should see.
               if (suppressedDefaultTypeErrors.length > 0) throw suppressedDefaultTypeErrors[0];
               await validateReactiveRules(this, this.#rm.logger, entityTodos, joinRowTodos);
+              this.#findRestricted = "addDeleteRule";
+              await validateDeleteRules(entityTodos);
             } finally {
               this.#findRestricted = false;
             }
@@ -1816,7 +1819,14 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
           // `isValidating` keeps derived-field reads from creating (now-unflushable) dirty state.
           this.#isValidating = true;
           await validateSimpleRules(entityTodos, (config) => config.commitRules);
-          await validateReactiveRules(this, this.#rm.logger, entityTodos, joinRowTodos, (meta) => meta.reactiveCommitRules!);
+          await validateReactiveRules(
+            this,
+            this.#rm.logger,
+            entityTodos,
+            joinRowTodos,
+            (meta) => meta.reactiveCommitRules!,
+          );
+          await validateDeleteRules(entityTodos, (config) => config.commitDeleteRules);
         } finally {
           this.#isValidating = false;
         }
@@ -2939,6 +2949,23 @@ async function validateSimpleRules(
           .filter((rule) => rule.hint === undefined)
           .flatMap(async ({ fn }) => coerceError(entity, await fn(entity)));
       });
+  });
+  const errors = failIfAnyRejected(await Promise.allSettled(p)).flat();
+  if (errors.length > 0) {
+    throw new ValidationErrors(errors);
+  }
+}
+
+/** Runs delete-specific rules for the deleted entities in `todos`. */
+async function validateDeleteRules(
+  todos: Record<string, Todo>,
+  getRules: (config: ConfigData<any, any>) => ValidationRuleInternal<any>[] = (config) => config.deleteRules,
+): Promise<void> {
+  const p = Object.values(todos).flatMap(({ deletes }) => {
+    return deletes.flatMap((entity) => {
+      const rules = getBaseAndSelfMetas(getMetadata(entity)).flatMap((m) => getRules(m.config.__data));
+      return rules.flatMap(async ({ fn }) => coerceError(entity, await fn(entity)));
+    });
   });
   const errors = failIfAnyRejected(await Promise.allSettled(p)).flat();
   if (errors.length > 0) {

--- a/packages/core/src/EntityMetadata.ts
+++ b/packages/core/src/EntityMetadata.ts
@@ -76,7 +76,7 @@ export interface EntityMetadata<T extends Entity = any> {
   reactiveRules?: ReactiveRule[];
   /** The lazy list of reactive *commit* rules (post-flush/pre-commit) for this metadata and its subtypes. */
   reactiveCommitRules?: ReactiveRule[];
-  /** Lazily-cached: whether flushing an entity of this type could trigger any `addCommitRule` work. */
+  /** Lazily-cached: whether flushing this type could trigger commit or commit-delete rule work. */
   hasCommitRules?: boolean;
   orderBy: string | undefined;
   /** Flat field names that can be used to find existing rows before creating. I.e. [["email"], ["author", "title"]]. */

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -137,6 +137,24 @@ export class ConfigApi<T extends Entity, C> {
     pushValidationRule(this.__data.commitRules, name, ruleOrHint, maybeRule);
   }
 
+  /** Adds a validation rule that runs only when this entity is being deleted. */
+  addDeleteRule(rule: ValidationRule<T>): void {
+    const name = `addDeleteRule(${getCallerName()})`;
+    this.ensurePreBoot(name, "addDeleteRule");
+    this.__data.deleteRules.push({ name, fn: rule, hint: undefined });
+  }
+
+  /**
+   * Adds a delete rule that runs after the entity's `DELETE` has been flushed but before the transaction commits.
+   *
+   * Unlike {@link addDeleteRule}, this rule may use `em.find` to query the changed state within the transaction.
+   */
+  addCommitDeleteRule(rule: ValidationRule<T>): void {
+    const name = `addCommitDeleteRule(${getCallerName()})`;
+    this.ensurePreBoot(name, "addCommitDeleteRule");
+    this.__data.commitDeleteRules.push({ name, fn: rule, hint: undefined });
+  }
+
   /** If both this entity, and `cstr` entities, are in the same `em.flush`, run us first. */
   runHooksBefore(cstr: EntityConstructor<any>): void {
     this.__data.runHooksBefore.push(cstr);
@@ -459,6 +477,10 @@ export class ConfigData<T extends Entity, C> {
   rules: ValidationRuleInternal<T>[] = [];
   /** The "commit rules" for this entity type, i.e. validation rules that run post-flush/pre-commit. */
   commitRules: ValidationRuleInternal<T>[] = [];
+  /** Validation rules that run only when an entity of this type is deleted. */
+  deleteRules: ValidationRuleInternal<T>[] = [];
+  /** Delete rules that run post-flush/pre-commit. */
+  commitDeleteRules: ValidationRuleInternal<T>[] = [];
   /** The reactions for this entity type. */
   reactions: ReactionInternal<T, any, C>[] = [];
   /** The hooks for this entity type. */

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -106,8 +106,8 @@ function installReactiveMetadataGetters(metas: EntityMetadata[]): void {
     });
     defineLazyGetter(meta, "hasCommitRules", function buildHasCommitRules() {
       // True if flushing an entity of this type could trigger commit-rule work, so `em.flush` can
-      // skip the whole commit-rule pass otherwise. We need *both* checks because hinted and
-      // non-hinted commit rules are stored in different places:
+      // skip the whole commit-rule pass otherwise. Hinted, non-hinted, and delete commit rules
+      // are stored in different places:
       //
       // 1. Hinted commit rules are reverse-indexed onto their *trigger* entity's `reactiveCommitRules`,
       //    which is often a *different* entity than the one the rule is declared on. I.e. a rule
@@ -120,9 +120,15 @@ function installReactiveMetadataGetters(metas: EntityMetadata[]): void {
       //    `Author` only ever shows up in `Author.config.__data.commitRules` with `hint === undefined`,
       //    so `reactiveCommitRules` would miss it. (We filter to `hint === undefined` because hinted
       //    rules are already covered by check #1.)
+      //
+      // 3. Commit delete rules are non-reactive and stored separately on `commitDeleteRules`.
       return (
         meta.reactiveCommitRules!.length > 0 ||
-        getBaseSelfAndSubMetas(meta).some((m) => m.config.__data.commitRules.some((r) => r.hint === undefined))
+        getBaseSelfAndSubMetas(meta).some(
+          (m) =>
+            m.config.__data.commitDeleteRules.length > 0 ||
+            m.config.__data.commitRules.some((r) => r.hint === undefined),
+        )
       );
     });
   }

--- a/packages/tests/integration/src/entities/AuthorSchedule.test.ts
+++ b/packages/tests/integration/src/entities/AuthorSchedule.test.ts
@@ -1,60 +1,112 @@
 import { Author, AuthorSchedule, newAuthor, newAuthorSchedule } from "../entities";
-import { select } from "./inserts";
 import { newEntityManager } from "../testEm";
+import { select } from "./inserts";
 
-describe("AuthorSchedule commit rules", () => {
-  it("runs a commit rule whose em.find sees the just-flushed siblings", async () => {
-    const em = newEntityManager();
-    // Create an author + 3 schedules in a single flush; the commit rule's `em.find` runs *after* the
-    // 3 INSERTs have hit the db (but before COMMIT), so it sees all 3 and rejects.
-    const author = newAuthor(em);
-    const schedules = [
-      em.create(AuthorSchedule, { author }),
-      em.create(AuthorSchedule, { author }),
-      em.create(AuthorSchedule, { author }),
-    ];
-    await expect(em.flush()).rejects.toThrow("An author cannot have more than 2 schedules");
-    // The commit rule saw the changed (post-flush) state: all 3 sibling rows...
-    expect(schedules[0].transientFields.commitRuleFindCount).toBe(3);
-    // ...hydrated back to the same in-memory instances (not duplicates).
-    expect(schedules[0].transientFields.commitRuleFoundSelf).toBe(true);
-    // And because the commit rule threw before COMMIT, the transaction rolled back.
-    expect(await select("author_schedules")).toMatchObject([]);
+describe("AuthorSchedule", () => {
+  describe("commit rules", () => {
+    it("runs a commit rule whose em.find sees the just-flushed siblings", async () => {
+      const em = newEntityManager();
+      // Create an author + 3 schedules in a single flush; the commit rule's `em.find` runs *after* the
+      // 3 INSERTs have hit the db (but before COMMIT), so it sees all 3 and rejects.
+      const author = newAuthor(em);
+      const schedules = [
+        em.create(AuthorSchedule, { author }),
+        em.create(AuthorSchedule, { author }),
+        em.create(AuthorSchedule, { author }),
+      ];
+      await expect(em.flush()).rejects.toThrow("An author cannot have more than 2 schedules");
+      // The commit rule saw the changed (post-flush) state: all 3 sibling rows...
+      expect(schedules[0].transientFields.commitRuleFindCount).toBe(3);
+      // ...hydrated back to the same in-memory instances (not duplicates).
+      expect(schedules[0].transientFields.commitRuleFoundSelf).toBe(true);
+      // And because the commit rule threw before COMMIT, the transaction rolled back.
+      expect(await select("author_schedules")).toMatchObject([]);
+    });
+
+    it("bars a regular validation rule from calling em.find", async () => {
+      const em = newEntityManager();
+      const schedule = newAuthorSchedule(em);
+      // Opt the regular rule into attempting an `em.find`, which Joist should reject.
+      schedule.transientFields.tryFindInRegularRule = true;
+      await expect(em.flush()).rejects.toThrow(
+        "em.find cannot be called from a validation rule (added via config.addRule)",
+      );
+    });
+
+    it("allows a flush that stays within the commit rule's limit", async () => {
+      const em = newEntityManager();
+      const author = newAuthor(em);
+      em.create(AuthorSchedule, { author });
+      em.create(AuthorSchedule, { author });
+      await em.flush();
+      expect(await select("author_schedules")).toMatchObject([{ id: 1 }, { id: 2 }]);
+    });
+
+    it("sees previously-committed rows plus the newly-flushed row", async () => {
+      const em1 = newEntityManager();
+      const author = newAuthor(em1);
+      em1.create(AuthorSchedule, { author });
+      em1.create(AuthorSchedule, { author });
+      await em1.flush();
+
+      // A second flush adds a 3rd schedule; the commit rule's `em.find` sees the 2 committed rows
+      // plus the 1 just-flushed row = 3, and rejects.
+      const em2 = newEntityManager();
+      const author2 = await em2.load(Author, author.idTagged);
+      const schedule = em2.create(AuthorSchedule, { author: author2 });
+      await expect(em2.flush()).rejects.toThrow("An author cannot have more than 2 schedules");
+      expect(schedule.transientFields.commitRuleFindCount).toBe(3);
+      expect(await select("author_schedules")).toMatchObject([{ id: 1 }, { id: 2 }]);
+    });
   });
 
-  it("bars a regular validation rule from calling em.find", async () => {
-    const em = newEntityManager();
-    const schedule = newAuthorSchedule(em);
-    // Opt the regular rule into attempting an `em.find`, which Joist should reject.
-    schedule.transientFields.tryFindInRegularRule = true;
-    await expect(em.flush()).rejects.toThrow(
-      "em.find cannot be called from a validation rule (added via config.addRule)",
-    );
-  });
+  describe("delete rules", () => {
+    it("runs an addDeleteRule only when the entity is deleted", async () => {
+      const em = newEntityManager();
+      const schedule = newAuthorSchedule(em);
+      await em.flush();
+      expect(schedule.transientFields.deleteRuleRuns).toBe(0);
 
-  it("allows a flush that stays within the commit rule's limit", async () => {
-    const em = newEntityManager();
-    const author = newAuthor(em);
-    em.create(AuthorSchedule, { author });
-    em.create(AuthorSchedule, { author });
-    await em.flush();
-    expect(await select("author_schedules")).toMatchObject([{ id: 1 }, { id: 2 }]);
-  });
+      schedule.transientFields.preventDelete = true;
+      em.delete(schedule);
+      await expect(em.flush()).rejects.toThrow("This schedule cannot be deleted");
+      expect(schedule.transientFields.deleteRuleRuns).toBe(1);
+      expect(await select("author_schedules")).toMatchObject([{ id: 1 }]);
+    });
 
-  it("sees previously-committed rows plus the newly-flushed row", async () => {
-    const em1 = newEntityManager();
-    const author = newAuthor(em1);
-    em1.create(AuthorSchedule, { author });
-    em1.create(AuthorSchedule, { author });
-    await em1.flush();
+    it("bars an addDeleteRule from calling em.find", async () => {
+      const em = newEntityManager();
+      const schedule = newAuthorSchedule(em);
+      await em.flush();
 
-    // A second flush adds a 3rd schedule; the commit rule's `em.find` sees the 2 committed rows
-    // plus the 1 just-flushed row = 3, and rejects.
-    const em2 = newEntityManager();
-    const author2 = await em2.load(Author, author.idTagged);
-    const schedule = em2.create(AuthorSchedule, { author: author2 });
-    await expect(em2.flush()).rejects.toThrow("An author cannot have more than 2 schedules");
-    expect(schedule.transientFields.commitRuleFindCount).toBe(3);
-    expect(await select("author_schedules")).toMatchObject([{ id: 1 }, { id: 2 }]);
+      schedule.transientFields.tryFindInDeleteRule = true;
+      em.delete(schedule);
+      await expect(em.flush()).rejects.toThrow(
+        "em.find cannot be called from a validation rule (added via config.addDeleteRule)",
+      );
+    });
+
+    it("allows an addCommitDeleteRule to query the just-flushed transaction state", async () => {
+      const em1 = newEntityManager();
+      const author = newAuthor(em1);
+      const deleted = em1.create(AuthorSchedule, { author, overview: "deleted" });
+      em1.create(AuthorSchedule, { author, overview: "kept" });
+      await em1.flush();
+
+      const em2 = newEntityManager();
+      const author2 = await em2.load(Author, author.idTagged);
+      const deleted2 = await em2.load(AuthorSchedule, deleted.idTagged);
+      em2.create(AuthorSchedule, { author: author2, overview: "replacement" });
+      deleted2.transientFields.preventDeleteAtCommit = true;
+      em2.delete(deleted2);
+
+      await expect(em2.flush()).rejects.toThrow("This schedule cannot be deleted at commit");
+      expect(deleted2.transientFields.commitDeleteRuleFindOverviews).toEqual(["kept", "replacement"]);
+      expect(deleted2.transientFields.commitDeleteRuleFoundSelf).toBe(false);
+      expect(await select("author_schedules")).toMatchObject([
+        { id: 1, overview: "deleted" },
+        { id: 2, overview: "kept" },
+      ]);
+    });
   });
 });

--- a/packages/tests/integration/src/entities/AuthorSchedule.ts
+++ b/packages/tests/integration/src/entities/AuthorSchedule.ts
@@ -8,6 +8,18 @@ export class AuthorSchedule extends AuthorScheduleCodegen {
     commitRuleFoundSelf: false,
     /** Opt-in to have the regular rule attempt an (illegal) `em.find`, to exercise the guard. */
     tryFindInRegularRule: false,
+    /** How many times this entity's delete rule has run. */
+    deleteRuleRuns: 0,
+    /** Opt-in to have the delete rule attempt an (illegal) `em.find`. */
+    tryFindInDeleteRule: false,
+    /** Opt-in to reject deletion from the pre-flush delete rule. */
+    preventDelete: false,
+    /** The rows that the commit delete rule's `em.find` saw. */
+    commitDeleteRuleFindOverviews: [] as (string | undefined)[],
+    /** Whether the commit delete rule's `em.find` returned the deleted entity. */
+    commitDeleteRuleFoundSelf: false,
+    /** Opt-in to run and reject from the commit delete rule. */
+    preventDeleteAtCommit: false,
   };
 }
 
@@ -30,5 +42,26 @@ config.addCommitRule("author", async (as) => {
   as.transientFields.commitRuleFoundSelf = found.includes(as.fullNonReactiveAccess);
   if (found.length > 2) {
     return "An author cannot have more than 2 schedules";
+  }
+});
+
+// A regular delete rule that cannot call `em.find*` because it runs pre-flush.
+config.addDeleteRule(async (as) => {
+  as.transientFields.deleteRuleRuns++;
+  if (as.transientFields.tryFindInDeleteRule) {
+    await as.em.find(AuthorSchedule, {});
+  }
+  if (as.transientFields.preventDelete) {
+    return "This schedule cannot be deleted";
+  }
+});
+
+// A commit delete rule that runs post-flush/pre-commit, so its `em.find` sees the changed state.
+config.addCommitDeleteRule(async (as) => {
+  if (as.transientFields.preventDeleteAtCommit) {
+    const found = await as.em.find(AuthorSchedule, {});
+    as.transientFields.commitDeleteRuleFindOverviews = found.map((schedule) => schedule.overview).sort();
+    as.transientFields.commitDeleteRuleFoundSelf = found.includes(as);
+    return "This schedule cannot be deleted at commit";
   }
 });


### PR DESCRIPTION
Adds a first-class way to valid "can this entity be deleted?"

Similar to regular validation rules, we have an `addCommitDeleteRule`, so that the query can run against the "after-the-fact" state of the database.

...but, that said, if an entity is being hard-deleted, that means it's `addCommitDeleteRule` runs after the `DELETE` has been issued to the database, which means the entity/row itself is now gone.

This makes it seem like it would be hard/awkward to validate business rules like "prevent deletion if I was (hooked up like this)" because now the row isn't hooked up at all.

...like maybe delete rules would want to run from `addDeleteRule` i.e. pre-flush, so they could see the "prior" state of the db? 