### PR TITLE
fix: Use a tagDelimiter knob for "slug ids".

### DIFF
--- a/docs/src/content/docs/advanced/tagged-ids.md
+++ b/docs/src/content/docs/advanced/tagged-ids.md
@@ -114,17 +114,20 @@ const a = await em.load(Author, id);
 
 ## Slug Ids
 
-For URL-friendly tagged ids without the `:` delimiter, set `idType` to `slug`:
+For URL-friendly tagged ids without the `:` delimiter, set `tagDelimiter` to an empty string:
 
 ```json
 {
-  "idType": "slug"
+  "idType": "tagged-string",
+  "tagDelimiter": ""
 }
 ```
 
 An author whose database id is `1` will then have an id of `"a1"`. Tags must contain only letters and primary keys must be non-negative `int` or `bigint` values, making every slug unambiguously parseable as an alphabetic tag followed by digits. For example, `tagFromId("author123")` returns `"author"`.
 
-Slug ids retain the same entity-tag validation as regular tagged ids. Metadata-free utilities such as `isTaggedId(id)`, `tagFromId(id)`, and `unsafeDeTagIds(ids)` recognize both regular and slug tagged ids.
+Slug ids retain the same entity-tag validation as regular tagged ids. Metadata-free utilities such as `isTaggedId(id)`, `tagFromId(id)`, and `unsafeDeTagIds(ids)` use the configured delimiter.
+
+You can also choose a custom delimiter. For example, `"tagDelimiter": "_"` produces ids such as `"a_1"`. Omitting `tagDelimiter` retains the default `:`. A custom delimiter cannot occur in or overlap the end of an entity tag, so every tagged id remains unambiguous.
 
 ## Disabling Tagged Ids
 

--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -38,11 +38,11 @@ If this is not set, `npm run joist-codegen` will also look for a `DATABASE_URL` 
 
 Controls the type of the domain model's `id` properties, i.e. `Author.id` or `author1.id`.
 
-Available values: `tagged-string`, `slug`, `untagged-string`, `number`.
+Available values: `tagged-string`, `untagged-string`, `number`.
 
 Joist's default behavior is `tagged-string` which means the type of `Author.id` will be a `string`, and the value will be `"a:1"` where `a` is the "tag" established for all `Author` entities, and `1` is the numeric primary key value of that row.
 
-The `slug` setting keeps the tag's runtime safety but omits the delimiter, producing URL-friendly ids such as `"author123"`. Slug ids require alphabetic tags and non-negative `int` or `bigint` primary keys.
+The delimiter can be customized separately with `tagDelimiter`. For example, `"tagDelimiter": "_"` produces `"a_1"`, while an empty delimiter produces URL-friendly ids such as `"author123"`. Delimiterless ids require alphabetic tags and non-negative `int` or `bigint` primary keys.
 
 If you do not want the `a:` tagged prefix, you can use `untagged-string` or `number`:
 

--- a/packages/codegen/config-json-schema.json
+++ b/packages/codegen/config-json-schema.json
@@ -60,12 +60,7 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "derived": {
-                  "anyOf": [
-                    { "type": "string", "const": "sync" },
-                    { "type": "string", "const": "async" }
-                  ]
-                },
+                "derived": { "anyOf": [{ "type": "string", "const": "sync" }, { "type": "string", "const": "async" }] },
                 "protected": { "type": "boolean" },
                 "ignore": { "type": "boolean" },
                 "superstruct": { "type": "string" },
@@ -92,13 +87,13 @@
               "properties": {
                 "derived": { "type": "string", "const": "async" },
                 "polymorphic": {
-                  "anyOf": [
-                    { "type": "string", "const": "notNull" },
-                    { "type": "boolean", "const": true }
-                  ]
+                  "anyOf": [{ "type": "string", "const": "notNull" }, { "type": "boolean", "const": true }]
                 },
                 "large": { "type": "boolean" },
                 "orderBy": { "type": "string" },
+                "softDeletes": {
+                  "anyOf": [{ "type": "string", "const": "include" }, { "type": "string", "const": "exclude" }]
+                },
                 "stiType": { "type": "string" },
                 "subType": { "type": "string" },
                 "skipRecursiveRelations": { "type": "boolean" },
@@ -126,11 +121,11 @@
     "idType": {
       "anyOf": [
         { "type": "string", "const": "tagged-string" },
-        { "type": "string", "const": "slug" },
         { "type": "string", "const": "untagged-string" },
         { "type": "string", "const": "number" }
       ]
     },
+    "tagDelimiter": { "type": "string" },
     "nonDeferredForeignKeys": {
       "anyOf": [
         { "type": "string", "const": "error" },
@@ -141,10 +136,7 @@
     "esm": { "type": "boolean" },
     "paginationStyle": {
       "default": "cursor",
-      "anyOf": [
-        { "type": "string", "const": "cursor" },
-        { "type": "string", "const": "limit" }
-      ]
+      "anyOf": [{ "type": "string", "const": "cursor" }, { "type": "string", "const": "limit" }]
     },
     "docs": { "type": "boolean" },
     "skills": { "type": "boolean" },

--- a/packages/codegen/src/config.test.ts
+++ b/packages/codegen/src/config.test.ts
@@ -9,6 +9,11 @@ describe("config", () => {
     expect(config.parse({}).codemodVersion).toEqual(0);
   });
 
+  it("accepts custom and delimiterless tagged ids", () => {
+    expect(config.parse({ tagDelimiter: "_" }).tagDelimiter).toEqual("_");
+    expect(config.parse({ tagDelimiter: "" }).tagDelimiter).toEqual("");
+  });
+
   it("loads and rewrites legacy configs without the deprecated version key", async () => {
     const originalCwd = process.cwd();
     const dir = await mkdtemp(path.join(tmpdir(), "joist-config-"));

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -143,9 +143,9 @@ export const config = z
     entities: z.record(z.string(), entityConfig).default({}),
     ignoredTables: z.optional(z.array(z.string())),
     /** The type of entity `id` fields; defaults to `tagged-string`. */
-    idType: z.optional(
-      z.union([z.literal("tagged-string"), z.literal("slug"), z.literal("untagged-string"), z.literal("number")]),
-    ),
+    idType: z.optional(z.union([z.literal("tagged-string"), z.literal("untagged-string"), z.literal("number")])),
+    /** The separator between entity tags and ids; defaults to `:`, and `""` disables the separator. */
+    tagDelimiter: z.optional(z.string()),
     /** How we should support non-deferred foreign keys. */
     nonDeferredForeignKeys: z.optional(z.union([z.literal("error"), z.literal("warn"), z.literal("ignore")])),
     /** Enables esm output. */

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -1,18 +1,18 @@
 import { readdir } from "fs/promises";
 import { code, CodegenFile, def, imp } from "ts-poet";
+import { generateMetadataDocsFile, syncDocs } from "./docs";
+import { findAllEntityScopes } from "./findEntityScopes";
 import { generateEntitiesFile } from "./generateEntitiesFile";
 import { generateEntityCodegenFile, getIdType } from "./generateEntityCodegenFile";
 import { generateEntityFile } from "./generateEntityFile";
 import { generateEntityTestFile } from "./generateEntityTestFile";
 import { generateEnumFile } from "./generateEnumFile";
 import { generateFactoriesFiles } from "./generateFactoriesFiles";
-import { findAllEntityScopes } from "./findEntityScopes";
 import { generateMetadataFile } from "./generateMetadataFile";
 import { generatePgEnumFile } from "./generatePgEnumFile";
 import { Config, DbMetadata } from "./index";
 import { configureMetadata, Entity, JoistEntityManager, setRuntimeConfig } from "./symbols";
 import { merge, tableToEntityName } from "./utils";
-import { generateMetadataDocsFile, syncDocs } from "./docs";
 
 export type DPrintOptions = Record<string, unknown>;
 
@@ -89,12 +89,17 @@ export async function generateFiles(config: Config, dbMeta: DbMetadata): Promise
 
   const contextType = config.contextType ? imp(`t:${config.contextType}`) : "{}";
   const txnType = config.transactionType ? imp(`t:${config.transactionType}`) : "unknown";
+  const maybeTagDelimiter =
+    config.tagDelimiter === undefined
+      ? code``
+      : code`tagDelimiter: ${config.tagDelimiter === "" ? "undefined" : JSON.stringify(config.tagDelimiter)},`;
 
   const metadataFile: CodegenFile = {
     name: "./codegen/metadata.ts",
     contents: code`
       ${setRuntimeConfig}({
         temporal: ${config.temporal ? { timeZone: typeof config.temporal === "boolean" ? "UTC" : config.temporal.timeZone } : "false"},
+        ${maybeTagDelimiter}
       });
       
       export class ${def("EntityManager")} extends ${JoistEntityManager}<${contextType}, Entity, ${txnType}> {}

--- a/packages/codegen/src/generateEntityCodegenFile.ts
+++ b/packages/codegen/src/generateEntityCodegenFile.ts
@@ -1212,7 +1212,6 @@ export function getIdType(config: Config) {
   switch (config.idType) {
     case "untagged-string":
     case "tagged-string":
-    case "slug":
     case undefined:
       return "string";
     case "number":

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -12,8 +12,8 @@ import { Config, loadConfig, stripStiPlaceholders, warnInvalidConfigEntries, wri
 import { maybeSetForeignKeyOrdering } from "./foreignKeyOrdering";
 import { generateFiles } from "./generate";
 import { createFlushFunction } from "./generateFlushFunction";
-import { installSkills } from "./installSkills";
 import { applyInheritanceUpdates } from "./inheritance";
+import { installSkills } from "./installSkills";
 import { loadEnumMetadata, loadPgEnumMetadata } from "./loadMetadata";
 import { LOG_LEVELS, loggerMaxWarningLevelHit } from "./logger";
 import { scanEntityFiles } from "./scanEntityFiles";
@@ -64,7 +64,7 @@ export async function joistCodegen() {
 
   // Assign any new tags and write them back to the config file
   assignTags(config, dbMetadata);
-  validateSlugIds(config, entities);
+  validateTagDelimiter(config, entities);
 
   // Scan `*.ts` files after we've expanded `Task` -> `TaskOld.ts`
   await scanEntityFiles(config, dbMetadata);
@@ -165,16 +165,23 @@ export function maybeSetExitCode(): void {
   }
 }
 
-/** Validates that delimiterless slug ids have an unambiguous alpha-plus-digits shape. */
-function validateSlugIds(config: Config, entities: EntityDbMetadata[]): void {
-  if (config.idType !== "slug") return;
+/** Validates that tags can be parsed unambiguously with the configured delimiter. */
+function validateTagDelimiter(config: Config, entities: EntityDbMetadata[]): void {
+  const tagDelimiter = config.tagDelimiter ?? ":";
   for (const entity of entities) {
-    if (!/^[a-z]+$/i.test(entity.tagName)) {
-      throw new Error(`Slug ids require an alphabetic tag, got '${entity.tagName}' for ${entity.name}`);
-    }
-    if (entity.primaryKey.columnType !== "int" && entity.primaryKey.columnType !== "bigint") {
+    if (tagDelimiter !== "" && `${entity.tagName}${tagDelimiter}`.indexOf(tagDelimiter) !== entity.tagName.length) {
       throw new Error(
-        `Slug ids require an int or bigint primary key, got '${entity.primaryKey.columnType}' for ${entity.name}`,
+        `Tagged id delimiter '${tagDelimiter}' cannot occur in or overlap tag '${entity.tagName}' for ${entity.name}`,
+      );
+    } else if (tagDelimiter === "" && !/^[a-z]+$/i.test(entity.tagName)) {
+      throw new Error(`Delimiterless ids require an alphabetic tag, got '${entity.tagName}' for ${entity.name}`);
+    } else if (
+      tagDelimiter === "" &&
+      entity.primaryKey.columnType !== "int" &&
+      entity.primaryKey.columnType !== "bigint"
+    ) {
+      throw new Error(
+        `Delimiterless ids require an int or bigint primary key, got '${entity.primaryKey.columnType}' for ${entity.name}`,
       );
     }
   }

--- a/packages/core/src/EntityMetadata.ts
+++ b/packages/core/src/EntityMetadata.ts
@@ -44,7 +44,7 @@ export interface EntityMetadata<T extends Entity = any> {
   cstr: MaybeAbstractEntityConstructor<T>;
   type: string;
   /** How the domain entity's id is represented. */
-  idType: "tagged-string" | "slug" | "untagged-string" | "number";
+  idType: "tagged-string" | "untagged-string" | "number";
   /** The database column type, i.e. used to do `::type` casts in Postgres. */
   idDbType: "bigint" | "int" | "uuid" | "text";
   tableName: string;

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -18,6 +18,7 @@ import { ReactiveManyToManyImpl, ReactiveReferenceImpl, Reference } from "./rela
 import { AsyncReactiveFieldImpl } from "./relations/AsyncReactiveField";
 import { ReactiveFieldImpl } from "./relations/ReactiveField";
 import { isCannotBeUpdatedRule } from "./rules";
+import { maybeGetRuntimeConfig } from "./runtimeConfig";
 import { KeySerde } from "./serde";
 import { defineLazyGetter, fail } from "./utils";
 
@@ -183,21 +184,11 @@ export function maybeGetConstructorFromReference(
 }
 
 function populateConstructorMaps(metas: EntityMetadata[]): void {
-  const usesSlugIds = metas.some((meta) => meta.idType === "slug");
-  if (usesSlugIds && metas.some((meta) => meta.idType !== "slug")) {
-    throw new Error("Slug ids must be enabled for all entities");
-  }
-  setTaggedIdDelimiter(usesSlugIds ? undefined : ":");
+  const runtimeConfig = maybeGetRuntimeConfig();
+  const tagDelimiter = runtimeConfig && Object.hasOwn(runtimeConfig, "tagDelimiter") ? runtimeConfig.tagDelimiter : ":";
+  setTaggedIdDelimiter(tagDelimiter);
 
   for (const meta of metas) {
-    if (meta.idType === "slug") {
-      if (!/^[a-z]+$/i.test(meta.tagName)) {
-        throw new Error(`Slug ids require an alphabetic tag, got '${meta.tagName}' for ${meta.type}`);
-      }
-      if (meta.idDbType !== "int" && meta.idDbType !== "bigint") {
-        throw new Error(`Slug ids require an int or bigint primary key, got '${meta.idDbType}' for ${meta.type}`);
-      }
-    }
     // Add each (root) constructor into our tag -> constructor map for future lookups
     if (!meta.baseType) {
       const existing = tagToConstructorMap.get(meta.tagName);

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -5,10 +5,10 @@ import { type EntityMetadata, getMetadata } from "./EntityMetadata";
 import { type Reference } from "./relations";
 import { assertNever, fail } from "./utils";
 
-let tagDelimiter: ":" | undefined = ":";
+let tagDelimiter: string | undefined = ":";
 
 /** Sets the process-wide tagged-id format during metadata boot. */
-export function setTaggedIdDelimiter(delimiter: ":" | undefined): void {
+export function setTaggedIdDelimiter(delimiter: string | undefined): void {
   tagDelimiter = delimiter;
 }
 
@@ -27,7 +27,6 @@ export function toIdOf<T extends Entity>(meta: EntityMetadata<T>, id: TaggedId |
     case "number":
       return Number(deTagId(meta, id)) as IdOf<T>;
     case "tagged-string":
-    case "slug":
       return id as IdOf<T>;
     case "untagged-string":
       return deTagId(meta, id) as IdOf<T>;
@@ -57,14 +56,15 @@ export function keyToNumber(meta: HasTagName, value: any): number | undefined {
       const id = value.startsWith(meta.tagName) ? value.slice(meta.tagName.length) : value;
       return maybeNumberUnlessUuid(meta, id);
     }
-    const [tag, id] = value.split(tagDelimiter);
-    if (id === undefined) {
+    const delimiterIndex = value.indexOf(tagDelimiter);
+    if (delimiterIndex === -1) {
       return maybeNumberUnlessUuid(meta, value);
     }
+    const tag = value.slice(0, delimiterIndex);
     if (tag !== meta.tagName) {
       throw new Error(`Invalid tagged id, expected tag ${meta.tagName}, got ${value}`);
     }
-    return maybeNumberUnlessUuid(meta, id);
+    return maybeNumberUnlessUuid(meta, value.slice(delimiterIndex + tagDelimiter.length));
   } else {
     throw new Error(`Invalid key ${value}`);
   }
@@ -98,8 +98,6 @@ export function assertIdsAreTagged(keys: readonly string[]): void {
   }
 }
 
-// Either `tag:int` or `tag:uuid`.
-const validId = /[a-z]+:([0-9a-z\-]+)/;
 const validSlugId = /^([a-z]+)(\d+)$/i;
 const uuidIshId = /[0-9a-z\-]+/i;
 
@@ -113,7 +111,7 @@ export function isTaggedId(metaOrId: string | number | HasTagName, id?: string):
     return false;
   } else if (typeof metaOrId === "string") {
     // string overload
-    return tagDelimiter === undefined ? validSlugId.test(metaOrId) : validId.test(metaOrId);
+    return tagDelimiter === undefined ? validSlugId.test(metaOrId) : hasTagDelimiter(metaOrId);
   } else {
     // meta + string overload
     return isTaggedIdForMeta(metaOrId, id!);
@@ -226,7 +224,12 @@ export function deTagIds(meta: HasTagName, keys: readonly string[]): readonly st
 export function unsafeDeTagIds(keys: readonly string[]): readonly string[] {
   const deTagged = Array(keys.length);
   for (let i = 0; i < keys.length; i++) {
-    deTagged[i] = tagDelimiter === undefined ? validSlugId.exec(keys[i])?.[2] : keys[i].split(tagDelimiter)[1];
+    if (tagDelimiter === undefined) {
+      deTagged[i] = validSlugId.exec(keys[i])?.[2];
+    } else {
+      const delimiterIndex = keys[i].indexOf(tagDelimiter);
+      deTagged[i] = delimiterIndex === -1 ? undefined : keys[i].slice(delimiterIndex + tagDelimiter.length);
+    }
   }
   return deTagged;
 }
@@ -236,8 +239,10 @@ export function tagFromId(id: string): string {
   if (tagDelimiter === undefined) {
     return validSlugId.exec(id)?.[1] ?? fail(`Unknown tagged id format: "${id}"`);
   }
-  const parts = id.split(tagDelimiter);
-  return parts.length === 2 ? parts[0] : fail(`Unknown tagged id format: "${id}"`);
+  const delimiterIndex = id.indexOf(tagDelimiter);
+  return delimiterIndex > 0 && delimiterIndex + tagDelimiter.length < id.length
+    ? id.slice(0, delimiterIndex)
+    : fail(`Unknown tagged id format: "${id}"`);
 }
 
 /** Returns the metadata needed to format an id. */
@@ -250,7 +255,10 @@ function isTaggedIdForMeta(meta: HasTagName, id: string): boolean {
   if (tagDelimiter === undefined) {
     return validSlugId.exec(id)?.[1] === meta.tagName;
   }
-  const [tag, untaggedId] = id.split(tagDelimiter);
+  const delimiterIndex = id.indexOf(tagDelimiter);
+  if (delimiterIndex === -1) return false;
+  const tag = id.slice(0, delimiterIndex);
+  const untaggedId = id.slice(delimiterIndex + tagDelimiter.length);
   if (meta.tagName !== tag) return false;
   switch (meta.idDbType) {
     case "int":
@@ -263,4 +271,11 @@ function isTaggedIdForMeta(meta: HasTagName, id: string): boolean {
     default:
       return assertNever(meta.idDbType);
   }
+}
+
+/** Returns whether `id` has a non-empty tag and value separated by the configured delimiter. */
+function hasTagDelimiter(id: string): boolean {
+  if (tagDelimiter === undefined) return false;
+  const delimiterIndex = id.indexOf(tagDelimiter);
+  return delimiterIndex > 0 && delimiterIndex + tagDelimiter.length < id.length;
 }

--- a/packages/core/src/runtimeConfig.ts
+++ b/packages/core/src/runtimeConfig.ts
@@ -6,10 +6,17 @@ export function getRuntimeConfig(): RuntimeConfig {
   return runtimeConfig ?? fail("setRuntimeConfig in metadata.ts has not been invoked yet");
 }
 
+/** Returns the runtime config if generated metadata has initialized it. */
+export function maybeGetRuntimeConfig(): RuntimeConfig | undefined {
+  return runtimeConfig;
+}
+
 /**
  * Holds any `joist-config.json` values that we want to access at runtime.
  */
 export type RuntimeConfig = {
+  /** The process-wide tagged-id separator; explicit `undefined` means no separator, while omission defaults to `:`. */
+  tagDelimiter?: string | undefined;
   temporal:
     | false
     | {

--- a/packages/tests/integration/src/keys.test.ts
+++ b/packages/tests/integration/src/keys.test.ts
@@ -1,4 +1,4 @@
-import { isTaggedId } from "joist-orm";
+import { isTaggedId, keyToNumber, setTaggedIdDelimiter, tagFromId, tagId, unsafeDeTagIds } from "joist-orm";
 
 describe("keys", () => {
   describe("isTaggedId", () => {
@@ -25,5 +25,19 @@ describe("keys", () => {
       const meta: any = { idType: "uuid" };
       expect(isTaggedId(meta, "a:20000000-0000-0000-0000-00000000000!")).toBe(false);
     });
+  });
+
+  it("supports a custom tag delimiter", () => {
+    const meta: any = { tagName: "author", idDbType: "int" };
+    setTaggedIdDelimiter("_");
+    try {
+      expect(tagId(meta, 1)).toEqual("author_1");
+      expect(keyToNumber(meta, "author_1")).toEqual(1);
+      expect(isTaggedId("author_1")).toEqual(true);
+      expect(tagFromId("author_1")).toEqual("author");
+      expect(unsafeDeTagIds(["author_1"])).toEqual(["1"]);
+    } finally {
+      setTaggedIdDelimiter(":");
+    }
   });
 });

--- a/packages/tests/slug-ids/joist-config.json
+++ b/packages/tests/slug-ids/joist-config.json
@@ -8,5 +8,6 @@
     "Comment": { "relations": { "parent": { "polymorphic": "notNull" } }, "tag": "cm" }
   },
   "entitiesDirectory": "./src/entities",
-  "idType": "slug"
+  "idType": "tagged-string",
+  "tagDelimiter": ""
 }

--- a/packages/tests/slug-ids/src/entities/Author.test.ts
+++ b/packages/tests/slug-ids/src/entities/Author.test.ts
@@ -47,12 +47,12 @@ describe("slug ids", () => {
     expect(tagIds(meta, [1, "2", "a3"])).toEqual(["a1", "a2", "a3"]);
     expect(deTagId(meta, "a1")).toEqual("1");
     expect(unsafeDeTagIds(["a1", "author23"])).toEqual(["1", "23"]);
-    // This fails because this test suite is globally configured to use slug ids.
+    // This fails because this test suite is globally configured to use delimiterless ids.
     expect(unsafeDeTagIds(["a:1"])).toEqual([undefined]);
     expect(isTaggedId(meta, "a1")).toEqual(true);
     expect(isTaggedId(meta, "1")).toEqual(false);
     expect(isTaggedId("a1")).toEqual(true);
-    // This fails because this test suite is globally configured to use slug ids.
+    // This fails because this test suite is globally configured to use delimiterless ids.
     expect(isTaggedId("a:1")).toEqual(false);
     expect(tagFromId("a1")).toEqual("a");
     expect(tagFromId("foo123")).toEqual("foo");

--- a/packages/tests/slug-ids/src/entities/codegen/AuthorCodegen.ts
+++ b/packages/tests/slug-ids/src/entities/codegen/AuthorCodegen.ts
@@ -29,7 +29,6 @@ import {
   setField,
   setOpts,
   type TaggedId,
-  toIdOf,
   toJSON,
   type ToJsonHint,
   updatePartial,
@@ -39,7 +38,6 @@ import {
 import type { Context } from "src/context";
 import {
   type Author,
-  authorMeta,
   type Book,
   type BookId,
   type Comment,
@@ -147,7 +145,7 @@ export abstract class AuthorCodegen extends BaseEntity<EntityManager, string> im
   }
 
   get idMaybe(): AuthorId | undefined {
-    return toIdOf(authorMeta, this.idTaggedMaybe);
+    return this.idTaggedMaybe;
   }
 
   get idTagged(): TaggedId {

--- a/packages/tests/slug-ids/src/entities/codegen/BookCodegen.ts
+++ b/packages/tests/slug-ids/src/entities/codegen/BookCodegen.ts
@@ -31,7 +31,6 @@ import {
   setField,
   setOpts,
   type TaggedId,
-  toIdOf,
   toJSON,
   type ToJsonHint,
   updatePartial,
@@ -44,7 +43,6 @@ import {
   type AuthorId,
   type AuthorOrder,
   type Book,
-  bookMeta,
   type Comment,
   type CommentId,
   type Entity,
@@ -148,7 +146,7 @@ export abstract class BookCodegen extends BaseEntity<EntityManager, string> impl
   }
 
   get idMaybe(): BookId | undefined {
-    return toIdOf(bookMeta, this.idTaggedMaybe);
+    return this.idTaggedMaybe;
   }
 
   get idTagged(): TaggedId {

--- a/packages/tests/slug-ids/src/entities/codegen/CommentCodegen.ts
+++ b/packages/tests/slug-ids/src/entities/codegen/CommentCodegen.ts
@@ -31,7 +31,6 @@ import {
   setField,
   setOpts,
   type TaggedId,
-  toIdOf,
   toJSON,
   type ToJsonHint,
   updatePartial,
@@ -39,7 +38,7 @@ import {
   type ValueGraphQLFilter,
 } from "joist-orm";
 import type { Context } from "src/context";
-import { Author, Book, type Comment, commentMeta, type Entity, EntityManager, newComment } from "../entities";
+import { Author, Book, type Comment, type Entity, EntityManager, newComment } from "../entities";
 
 export type CommentId = Flavor<string, "Comment">;
 
@@ -142,7 +141,7 @@ export abstract class CommentCodegen extends BaseEntity<EntityManager, string> i
   }
 
   get idMaybe(): CommentId | undefined {
-    return toIdOf(commentMeta, this.idTaggedMaybe);
+    return this.idTaggedMaybe;
   }
 
   get idTagged(): TaggedId {

--- a/packages/tests/slug-ids/src/entities/codegen/metadata.ts
+++ b/packages/tests/slug-ids/src/entities/codegen/metadata.ts
@@ -5,7 +5,7 @@ import { Book } from "../Book";
 import { Comment } from "../Comment";
 import { authorConfig, bookConfig, commentConfig, newAuthor, newBook, newComment } from "../entities";
 
-setRuntimeConfig({ temporal: false });
+setRuntimeConfig({ temporal: false, tagDelimiter: undefined });
 
 export class EntityManager extends EntityManager1<Context, Entity, unknown> {}
 
@@ -18,7 +18,7 @@ export const authorMeta: EntityMetadata<Author> = {
   cstr: Author,
   type: "Author",
   baseType: undefined,
-  idType: "slug",
+  idType: "tagged-string",
   idDbType: "int",
   tagName: "a",
   tableName: "authors",
@@ -46,7 +46,7 @@ export const bookMeta: EntityMetadata<Book> = {
   cstr: Book,
   type: "Book",
   baseType: undefined,
-  idType: "slug",
+  idType: "tagged-string",
   idDbType: "bigint",
   tagName: "book",
   tableName: "books",
@@ -73,7 +73,7 @@ export const commentMeta: EntityMetadata<Comment> = {
   cstr: Comment,
   type: "Comment",
   baseType: undefined,
-  idType: "slug",
+  idType: "tagged-string",
   idDbType: "int",
   tagName: "cm",
   tableName: "comments",


### PR DESCRIPTION
Previously `slugId` was considered a new idType, but really they are still `tagged-string` id types, just with a different delimiter.

Kinda fixes #716