### PR TITLE
fix: More GC optimizations.

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -47,6 +47,7 @@ import {
   FindFilter,
   getBaseAndSelfMetas,
   getBaseMeta,
+  getBaseSelfAndSubMetas,
   getConstructorFromTaggedId,
   getMetadata,
   getRelationEntries,
@@ -95,16 +96,26 @@ import { followReverseHint } from "./reactiveHints";
 import { ManyToOneReferenceImpl, OneToOneReferenceImpl, ReactiveReferenceImpl } from "./relations";
 import { AbstractRelationImpl } from "./relations/AbstractRelationImpl";
 import { AsyncPropertyImpl } from "./relations/AsyncProperty";
-import { LazyFieldImpl, lazyColumnLoadOperation } from "./relations/LazyField";
 import { Collection } from "./relations/Collection";
 import { AsyncMethodPopulateSecret } from "./relations/hasAsyncMethod";
+import { lazyColumnLoadOperation, LazyFieldImpl } from "./relations/LazyField";
 import { RecursiveCycleError } from "./relations/RecursiveCollection";
 import { isSelectAllFilter } from "./scopes";
 import { combineJoinRows, createTodos, getTodo, JoinRowTodo, Todo } from "./Todo";
 import { runInTrustedContext } from "./trusted";
 import { OptsOf, OrderOf } from "./typeMap";
 import { upsert } from "./upsert";
-import { assertNever, fail, failIfAnyRejected, getOrSet, groupBy, MaybePromise, partition, toArray } from "./utils";
+import {
+  assertNever,
+  fail,
+  failIfAnyRejected,
+  getOrSet,
+  groupBy,
+  hasAnyKey,
+  MaybePromise,
+  partition,
+  toArray,
+} from "./utils";
 
 // polyfill
 (Symbol as any).asyncDispose ??= Symbol("Symbol.asyncDispose");
@@ -1255,15 +1266,14 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   ): Promise<T[]> {
     const meta = getMetadata(type);
 
-    // Use pre-allocated arrays/for loops instead of `.filter`s since this can be a hot spot
-    const ids = new Array<string>(_ids.length);
+    // Use pre-allocated arrays/for loops instead of `.filter`s since this can be a hot spot;
+    // misses remember their tagged id + position so the all-hit path skips the `ids` copy entirely
     const entities = new Array<T | undefined>(_ids.length);
     let idsToLoad: string[] | undefined;
     let positionsToLoad: number[] | undefined;
 
     for (let i = 0; i < _ids.length; i++) {
       const id = tagId(meta, _ids[i]);
-      ids[i] = id;
       const entity = this.findExistingInstance<T>(id);
       if (entity) {
         entities[i] = entity;
@@ -1273,25 +1283,21 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       }
     }
 
-    if (idsToLoad && idsToLoad.length > 0) {
+    if (idsToLoad) {
       await loadBatchLoader(this, meta)
         .loadAll(idsToLoad.map((id) => ({ taggedId: id, hint })))
         .catch(function loadAll(err) {
           throw appendStack(err, new Error());
         });
-      for (const i of positionsToLoad!) {
-        entities[i] = this.findExistingInstance<T>(ids[i]);
+      let idsNotFound: string[] | undefined;
+      for (let j = 0; j < positionsToLoad!.length; j++) {
+        const entity = this.findExistingInstance<T>(idsToLoad[j]);
+        entities[positionsToLoad![j]] = entity;
+        if (entity === undefined) (idsNotFound ??= []).push(idsToLoad[j]);
       }
-    }
-
-    let idsNotFound: string[] | undefined;
-    for (let i = 0; i < entities.length; i++) {
-      if (entities[i] === undefined) {
-        (idsNotFound ??= []).push(ids[i]);
+      if (idsNotFound) {
+        throw new NotFoundError(`${idsNotFound.join(",")} were not found`);
       }
-    }
-    if (idsNotFound) {
-      throw new NotFoundError(`${idsNotFound.join(",")} were not found`);
     }
     const loadedEntities = entities as T[];
     if (hint) {
@@ -1323,35 +1329,41 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
   ): Promise<T[]> {
     const meta = getMetadata(type);
 
-    // Use pre-allocated arrays/for loops instead of `.filter`s since this can be a hot spot
-    const ids = new Array<string>(_ids.length);
-    const entities: T[] = [];
+    // Use pre-allocated arrays/for loops instead of `.filter`s since this can be a hot spot;
+    // the all-hit path returns the single pre-sized array without any id copies or rebuilds
+    const maybeEntities = new Array<T | undefined>(_ids.length);
     let idsToLoad: string[] | undefined;
+    let positionsToLoad: number[] | undefined;
 
     // Ensure the ids are tagged, and find any not-yet-loaded
     for (let i = 0; i < _ids.length; i++) {
       const id = tagId(meta, _ids[i]);
-      ids[i] = id;
       const entity = this.findExistingInstance<T>(id);
       if (entity) {
-        entities.push(entity);
+        maybeEntities[i] = entity;
       } else {
         (idsToLoad ??= []).push(id);
+        (positionsToLoad ??= []).push(i);
       }
     }
 
-    if (idsToLoad && idsToLoad.length > 0) {
+    let entities: T[];
+    if (idsToLoad) {
       await loadBatchLoader(this, meta)
         .loadAll(idsToLoad.map((id) => ({ taggedId: id, hint })))
         .catch(function loadAllIfExists(err) {
           throw appendStack(err, new Error());
         });
-      // Now that everything is loaded, recalc `entities`
-      entities.length = 0;
-      for (const id of ids) {
-        const entity = this.findExistingInstance<T>(id);
-        if (entity) entities.push(entity);
+      // Fill in whichever missed ids actually exist, then compact out the not-founds
+      for (let j = 0; j < positionsToLoad!.length; j++) {
+        maybeEntities[positionsToLoad![j]] = this.findExistingInstance<T>(idsToLoad[j]);
       }
+      entities = [];
+      for (const entity of maybeEntities) {
+        if (entity !== undefined) entities.push(entity);
+      }
+    } else {
+      entities = maybeEntities as T[];
     }
     if (hint) {
       await this.populate(entities, hint);
@@ -1701,13 +1713,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         // each time, so that for an INSERT-then-UPDATE the triggers don't think the
         // UPDATE forgot to self-bump updatedAt, and then "helpfully" bump it for us.
         if (alreadyRanHooks.size > 0) {
-          maybeBumpUpdatedAt(this.#rm, createTodos([...alreadyRanHooks]), now);
+          maybeBumpUpdatedAt(this.#rm, createTodos(alreadyRanHooks), now);
         }
 
         // Run hooks in a series of loops until things "settle down"
         while (pendingHooks.size > 0) {
           await this.#fl.allowWrites(async () => {
-            let todos = createTodos([...pendingHooks]);
+            let todos = createTodos(pendingHooks);
 
             await setAsyncDefaults(suppressedDefaultTypeErrors, this.ctx, Todo.groupInsertsByTypeAndSubType(todos));
             maybeBumpUpdatedAt(this.#rm, todos, now);
@@ -1819,7 +1831,13 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
           // `isValidating` keeps derived-field reads from creating (now-unflushable) dirty state.
           this.#isValidating = true;
           await validateSimpleRules(entityTodos, (config) => config.commitRules);
-          await validateReactiveRules(this, this.#rm.logger, entityTodos, joinRowTodos, (meta) => meta.reactiveCommitRules!);
+          await validateReactiveRules(
+            this,
+            this.#rm.logger,
+            entityTodos,
+            joinRowTodos,
+            (meta) => meta.reactiveCommitRules!,
+          );
         } finally {
           this.#isValidating = false;
         }
@@ -1939,11 +1957,15 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
 
         // Update the `#orm` field to reflect the new state
         for (const e of allFlushedEntities) {
+          const instanceData = getInstanceData(e);
           if (e.isNewEntity && !e.isDeletedEntity) this.#entitiesById.set(e.idTagged, e);
-          getInstanceData(e).resetAfterFlushed();
+          instanceData.resetAfterFlushed();
           // Reset AsyncQueryProperties & LazyFields since DB state may have changed
-          for (const rel of Object.values(getInstanceData(e).relations)) {
-            if (rel instanceof AsyncPropertyImpl || rel instanceof LazyFieldImpl) rel.resetAfterFlush();
+          const { relations } = instanceData;
+          if (relations) {
+            for (const rel of Object.values(relations)) {
+              if (rel instanceof AsyncPropertyImpl || rel instanceof LazyFieldImpl) rel.resetAfterFlush();
+            }
           }
         }
         // Update the joinRows refs to reflect the new state
@@ -2160,7 +2182,10 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         const meta = findConcreteMeta(maybeBaseMeta, row);
         // Pass id as a hint that we're in hydrate mode
         entity = newEntity(this, asConcreteCstr(meta.cstr), false) as T;
-        getInstanceData(entity).row = row;
+        const instanceData = getInstanceData(entity);
+        instanceData.row = row;
+        // Seed the id to share the identity-map key string and skip the id serde on first read
+        instanceData.data["id"] = taggedId;
         this.#doRegister(entity as any, taggedId, meta, true);
       } else if (overwriteExisting) {
         // Usually if the entity already exists, we don't write over it, but in this case we assume that
@@ -2172,16 +2197,22 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
         // (this keeps us from deserializing data out of rows that we don't need).
         const { data } = instanceData;
         const dataKeys = Object.keys(data);
-        if (dataKeys.length > 0) {
+        // `id` is seeded at hydrate and can never change, so it never needs refreshing
+        if (dataKeys.length > ("id" in data ? 1 : 0)) {
           const allFields = getMetadata(entity).allFields;
-          const changedFields = (entity as any).changes.fieldsWithoutRelations;
+          // For existing entities this is exactly `changes.fieldsWithoutRelations`, minus the proxy allocation
+          const changedFields: string[] = instanceData.isNewEntity
+            ? (entity as any).changes.fieldsWithoutRelations
+            : Object.keys(instanceData.originalData);
           if (changedFields.length === 0) {
             for (const fieldName of dataKeys) {
+              if (fieldName === "id") continue;
               const serde = allFields[fieldName].serde ?? fail(`Missing serde for ${fieldName}`);
               serde.setOnEntity(data, row);
             }
           } else {
             for (const fieldName of dataKeys) {
+              if (fieldName === "id") continue;
               const serde = allFields[fieldName].serde ?? fail(`Missing serde for ${fieldName}`);
               serde.setOnEntity(data, row);
               // Make the field look not-dirty
@@ -2394,17 +2425,17 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
     const entities = (this.#entitiesByTag.get(meta.tagName) as T[]) ?? [];
     // Don't bother filtering if there's no where clause (particularly b/c IndexManager.findMatching
     // really expects there to be at least 1 condition)
-    if (Object.entries(where).length === 0) {
+    if (!hasAnyKey(where)) {
       return entities.filter((e) => e instanceof cstr && !e.isDeletedEntity);
     }
     if (this.#indexManager.shouldIndexType(entities.length)) {
       this.#indexManager.enableIndexingForType(meta, entities, where);
-      return (
-        this.#indexManager
-          .findMatching(meta, entities, where)
-          // Still filter by `instanceof cstr` to handle subtyping
-          .filter((e) => e instanceof cstr && !e.isDeletedEntity)
-      );
+      // Build the final array in one pass, still filtering `instanceof cstr` to handle subtyping
+      const result: T[] = [];
+      for (const e of this.#indexManager.findMatching(meta, entities, where)) {
+        if (e instanceof cstr && !e.isDeletedEntity) result.push(e);
+      }
+      return result;
     } else {
       return (
         entities
@@ -2525,6 +2556,7 @@ export class EntityManager<C = unknown, Entity extends EntityW = EntityW, TX ext
       }
 
       const { relations } = (oldEntity as any).__data as InstanceData;
+      if (!relations) continue;
       for (const [field, relation] of Object.entries(relations)) {
         // With lazyRelation, custom relations are inserted into the `relations` map. Custom relations don't
         // store any data, so we can ignore them by checking if the relation implements `import`
@@ -2868,9 +2900,11 @@ async function validateReactiveRules(
   }
 
   const p1 = Object.values(todos).flatMap((todo) => {
-    const entities = [...todo.inserts, ...todo.updates, ...todo.deletes];
     // Find each statically-declared reactive rule for the given entity type
     const rules = getRules(todo.metadata);
+    // Skip the entities spread for rule-less types
+    if (rules.length === 0) return [];
+    const entities = [...todo.inserts, ...todo.updates, ...todo.deletes];
     return rules.map((rule) => {
       // Of all changed entities of this type, how many specifically trigger this rule?
       const triggered = entities.filter((e) => {
@@ -2878,10 +2912,12 @@ async function validateReactiveRules(
         if (!(e instanceof rule.source)) return false;
         // Any new-or-deleted entity fires every rule (reactiveRules has already filtered out read-only)
         if (e.isNewEntity || e.isDeletedEntity) return true;
-        // Otherwise see if the changed fields overlaps with the rule's fields
-        const changedFields = (e as any).changes.fieldsWithoutRelations as string[];
-        for (const field of changedFields) {
-          if (rule.fields.includes(field)) return true;
+        // Otherwise see if the changed fields overlap with the rule's fields; for existing entities
+        // `changes.fieldsWithoutRelations` is exactly `Object.keys(originalData)`, so probe originalData
+        // directly instead of allocating a proxy + keys array per entity per rule.
+        const { originalData } = getInstanceData(e);
+        for (const field of rule.fields) {
+          if (field in originalData) return true;
         }
         return false;
       });
@@ -2933,20 +2969,34 @@ async function validateSimpleRules(
   // Which config list to pull rules from, i.e. the pre-flush `rules` or the post-flush `commitRules`
   getRules: (config: ConfigData<any, any>) => ValidationRuleInternal<any>[] = (config) => config.rules,
 ): Promise<void> {
-  const p = Object.values(todos).flatMap(({ inserts, updates }) => {
-    return [...inserts, ...updates]
-      .filter((e) => !e.isDeletedEntity)
-      .flatMap((entity) => {
-        const rules = getBaseAndSelfMetas(getMetadata(entity)).flatMap((m) => getRules(m.config.__data));
-        return rules
-          .filter((rule) => rule.hint === undefined)
-          .flatMap(async ({ fn }) => coerceError(entity, await fn(entity)));
-      });
-  });
+  let p: Promise<ValidationError[]>[] | undefined = undefined;
+  for (const todoKey in todos) {
+    const { inserts, updates } = todos[todoKey];
+    for (const entities of [inserts, updates]) {
+      for (const entity of entities) {
+        if (entity.isDeletedEntity) continue;
+        for (const m of getBaseAndSelfMetas(getMetadata(entity))) {
+          for (const rule of getRules(m.config.__data)) {
+            if (rule.hint !== undefined) continue;
+            (p ??= []).push(invokeRule(entity, rule.fn));
+          }
+        }
+      }
+    }
+  }
+  if (!p) return;
   const errors = failIfAnyRejected(await Promise.allSettled(p)).flat();
   if (errors.length > 0) {
     throw new ValidationErrors(errors);
   }
+}
+
+/** Invokes a single validation rule, coercing its result/sync throws into a promise. */
+async function invokeRule(
+  entity: Entity,
+  fn: (entity: any) => MaybePromise<ValidationRuleResult>,
+): Promise<ValidationError[]> {
+  return coerceError(entity, await fn(entity));
 }
 
 export function driverBeforeBegin<TXN>(em: EntityManager<any, any, TXN>, txn: TXN): Promise<unknown> {
@@ -2971,23 +3021,51 @@ async function runHookOnTodos(
   todos: Record<string, Todo>,
   keys: ("inserts" | "deletes" | "updates")[],
 ): Promise<void> {
-  const entities = Object.values(todos).flatMap((todo) => {
-    return keys.flatMap((k) => todo[k].filter((e) => k === "deletes" || !e.isDeletedEntity));
-  });
-  return runHook(ctx, hook, entities);
+  // Only collect entities for todos whose type hierarchy actually has this hook, so that
+  // hook-less bulk flushes skip the per-entity array building entirely.
+  let entities: EntityW[] | undefined = undefined;
+  for (const todoKey in todos) {
+    const todo = todos[todoKey];
+    if (!metaHasHook(todo.metadata, hook)) continue;
+    for (const k of keys) {
+      for (const e of todo[k]) {
+        if (k !== "deletes" && e.isDeletedEntity) continue;
+        (entities ??= []).push(e);
+      }
+    }
+  }
+  if (entities) return runHook(ctx, hook, entities);
+}
+
+/** Returns whether `meta`'s base/self/sub hierarchy has any `hook` functions registered. */
+function metaHasHook(meta: EntityMetadata, hook: EntityHook): boolean {
+  for (const m of getBaseSelfAndSubMetas(meta)) {
+    if (m.config.__data.hooks[hook].length > 0) return true;
+  }
+  return false;
 }
 
 async function runHook(ctx: unknown, hook: EntityHook, entities: EntityW[]): Promise<void> {
-  const p = entities.flatMap((entity) => {
-    const hookFns = getBaseAndSelfMetas(getMetadata(entity)).flatMap((m) => m.config.__data.hooks[hook]);
-    // Use an explicit `async` here to ensure all hooks are promises, i.e. so that a non-promise
-    // hook blowing up doesn't orphan the others .
-    return hookFns.map(async (fn) => fn(entity, ctx as any));
-  });
+  let p: Promise<unknown>[] | undefined = undefined;
+  for (const entity of entities) {
+    for (const m of getBaseAndSelfMetas(getMetadata(entity))) {
+      for (const fn of m.config.__data.hooks[hook]) {
+        // Use an explicit `async` invoke to ensure all hooks are promises, i.e. so that a
+        // non-promise hook blowing up doesn't orphan the others.
+        (p ??= []).push(invokeHook(fn, entity, ctx));
+      }
+    }
+  }
+  if (!p) return;
   // Use `allSettled` so that even if 1 hook blows up, we don't orphan other hooks mid-flush
   // (causes weird errors when/if they try to access the EntityManager that has "moved on")
   const results = await Promise.allSettled(p);
   failIfAnyRejected(results);
+}
+
+/** Invokes a single hook fn, coercing sync throws into rejections. */
+async function invokeHook(fn: (entity: any, ctx: any) => unknown, entity: EntityW, ctx: unknown): Promise<unknown> {
+  return fn(entity, ctx);
 }
 
 function beforeDelete(ctx: unknown, todos: Record<string, Todo>): Promise<unknown> {
@@ -3017,15 +3095,19 @@ function entitiesFromTodos(
 ): readonly Entity[] {
   const entities = new Set<Entity>();
   for (const todo of Object.values(entityTodos)) {
-    [...todo.inserts, ...todo.updates, ...todo.deletes].forEach((entity) => entities.add(entity));
+    for (const list of [todo.inserts, todo.updates, todo.deletes]) {
+      for (const entity of list) entities.add(entity);
+    }
   }
   for (const todo of Object.values(joinRowTodos)) {
-    [...todo.newRows, ...todo.deletedRows].forEach((row) => {
-      // For enum m2ms, a column value is the enum's numeric id rather than an entity.
-      Object.values(row.columns).forEach((value) => {
-        if (isEntity(value)) entities.add(value);
-      });
-    });
+    for (const rows of [todo.newRows, todo.deletedRows]) {
+      for (const row of rows) {
+        // For enum m2ms, a column value is the enum's numeric id rather than an entity.
+        for (const value of Object.values(row.columns)) {
+          if (isEntity(value)) entities.add(value);
+        }
+      }
+    }
   }
   return [...entities];
 }
@@ -3059,26 +3141,18 @@ function coerceError(entity: Entity, maybeError: ValidationRuleResult): Validati
 
 /** Evaluates each (non-async) derived field to see if it's value has changed. */
 function recalcSynchronousDerivedFields(todos: Record<string, Todo>) {
-  const entities = Object.values(todos)
-    .flatMap((todo) => [...todo.inserts, ...todo.updates])
-    .filter((e) => !e.isDeletedEntity);
-  const derivedFieldsByMeta = new Map(
-    [...new Set(entities.map(getMetadata))].map((m) => {
-      return [
-        m,
-        Object.values(m.allFields)
-          .filter((f) => (f.kind === "primitive" || f.kind === "enum") && f.derived === "sync")
-          .map((f) => f.fieldName),
-      ];
-    }),
-  );
-
-  for (const entity of entities) {
-    const derivedFields = derivedFieldsByMeta.get(getMetadata(entity)) || [];
-    derivedFields.forEach((fieldName) => {
-      // setField will intelligently mark/not mark the field as dirty.
-      setField(entity, fieldName as any, (entity as any)[fieldName]);
-    });
+  for (const todoKey in todos) {
+    const todo = todos[todoKey];
+    for (const entities of [todo.inserts, todo.updates]) {
+      for (const entity of entities) {
+        if (entity.isDeletedEntity) continue;
+        // Use the per-meta cached field list instead of rebuilding a map per hook loop
+        for (const fieldName of getMetadata(entity).syncDerivedFields!) {
+          // setField will intelligently mark/not mark the field as dirty.
+          setField(entity, fieldName as any, (entity as any)[fieldName]);
+        }
+      }
+    }
   }
 }
 

--- a/packages/core/src/EntityMetadata.ts
+++ b/packages/core/src/EntityMetadata.ts
@@ -80,6 +80,8 @@ export interface EntityMetadata<T extends Entity = any> {
   hasCommitRules?: boolean;
   /** The lazily-cached set of own `lazy` primitive field names, i.e. columns excluded from the default SELECT. */
   lazyFieldNames?: ReadonlySet<string>;
+  /** The lazily-cached list of sync-derived (`hasReactiveField`-less) field names, recalced during flush. */
+  syncDerivedFields?: string[];
   /** Lazily-cached: whether this entity has any `lazy` columns, i.e. so the default SELECT lists columns explicitly. */
   hasLazyColumns?: boolean;
   orderBy: string | undefined;
@@ -92,6 +94,10 @@ export interface EntityMetadata<T extends Entity = any> {
   baseTypes: EntityMetadata[];
   /** The list of subtypes for this base type, e.g. for Animal it'd be `[Mammal, Dog]`. */
   subTypes: EntityMetadata[];
+  /** Cached `[...baseTypes, this]` set up by `configureMetadata`, so hot paths avoid re-allocating it. */
+  baseSelfMetas?: EntityMetadata[];
+  /** Cached `[...baseTypes, this, ...subTypes]` set up by `configureMetadata`, so hot paths avoid re-allocating it. */
+  baseSelfAndSubMetas?: EntityMetadata[];
   /** The lazy lookup of subtypes by type name, i.e. `Animal.metadata.subTypesByType.get("Dog")`. */
   subTypesByType?: ReadonlyMap<string, EntityMetadata>;
   /** The lazy lookup of STI subtypes by discriminator value, i.e. `Task.metadata.subTypesByStiValue.get(1)`. */
@@ -303,11 +309,13 @@ export function isCollectionField(ormField: Field): ormField is OneToManyField |
 export function getBaseAndSelfMetas(meta: EntityMetadata): EntityMetadata[];
 export function getBaseAndSelfMetas(entity: Entity): EntityMetadata[];
 export function getBaseAndSelfMetas(param: Entity | EntityMetadata): EntityMetadata[] {
-  return isEntity(param) ? getBaseSelfAndSubMetas(getMetadata(param)) : [...param.baseTypes, param];
+  return isEntity(param)
+    ? getBaseSelfAndSubMetas(getMetadata(param))
+    : (param.baseSelfMetas ?? [...param.baseTypes, param]);
 }
 
 export function getBaseSelfAndSubMetas(meta: EntityMetadata): EntityMetadata[] {
-  return [...meta.baseTypes, meta, ...meta.subTypes];
+  return meta.baseSelfAndSubMetas ?? [...meta.baseTypes, meta, ...meta.subTypes];
 }
 
 export function getSubMetas(meta: EntityMetadata): EntityMetadata[] {

--- a/packages/core/src/IndexManager.ts
+++ b/packages/core/src/IndexManager.ts
@@ -78,9 +78,11 @@ export class IndexManager {
 
   /**
    * Finds entities matching the given where clause using indexes.
-   * Returns null if the type is not indexed (fallback to linear search).
+   *
+   * Returns the raw candidate set (possibly a live internal index set, so do not mutate it);
+   * the caller applies its own subtype/deleted filtering while building the final array.
    */
-  findMatching<T extends Entity>(meta: EntityMetadata<T>, entities: T[], where: any): T[] {
+  findMatching<T extends Entity>(meta: EntityMetadata<T>, entities: T[], where: any): ReadonlySet<T> {
     const { tagName } = meta;
     if (!this.#indexes.has(tagName)) {
       throw new Error(`${meta.type} is not indexed`);
@@ -102,7 +104,7 @@ export class IndexManager {
     if (candidates === undefined) {
       throw new Error(`Expected where clause with at least one condition`);
     }
-    return [...candidates] as T[];
+    return candidates as unknown as ReadonlySet<T>;
   }
 
   // `entities` should all be of the exact same subtype

--- a/packages/core/src/InstanceData.ts
+++ b/packages/core/src/InstanceData.ts
@@ -1,6 +1,7 @@
 import { Entity } from "./Entity";
 import { EntityManager, getEmInternalApi } from "./EntityManager";
 import { EntityMetadata } from "./EntityMetadata";
+import { hasAnyKey } from "./utils";
 
 /** The `#orm` metadata field we track on each instance. */
 export class InstanceData {
@@ -10,18 +11,35 @@ export class InstanceData {
   readonly em: EntityManager;
   /** A pointer to our entity type's metadata. */
   readonly metadata: EntityMetadata;
-  /** A bag for our lazy-initialized relations. */
-  relations: Record<any, any> = {};
+  /** A bag for our lazy-initialized relations, allocated on first relation access. */
+  relations: Record<any, any> | undefined = undefined;
   /** The database-value of columns, as-is returned from the driver. */
   row!: Record<string, any>;
   /** The domain-value of fields, lazily converted (if needed) on read from the database columns. */
   data: Record<string, any>;
-  /** A bag to keep the original values, lazily populated as fields are mutated. */
-  originalData: Record<any, any> = {};
-  /** Reference values that were set through during this unit of work and may need reverse-walking. */
-  readonly referenceHistory: Record<string, any[]> = {};
+  /** A bag to keep the original values, allocated on first mutation (most entities are never mutated). */
+  #originalData: Record<any, any> | undefined = undefined;
+  /** Reference values that were set during this unit of work, allocated on first m2o/poly change. */
+  #referenceHistory: Record<string, any[]> | undefined = undefined;
   /** A bag to keep the flushed-to-database values, only for AsyncReactiveField reactivity. */
   flushedData: Record<any, any> | undefined;
+  /** Packs the new/deleted `Operation`s + isTouched into one slot; see the accessors below. */
+  #flags: number = 0;
+  /** The `a#1`, `a#2` index if we're an em.create-d entity. We never unset this, to keep ids stable across flushes. */
+  createId: string | undefined;
+  /** The zero-based order this entity was registered with its EntityManager. */
+  entityIndex: number = -1;
+
+  /** Whether our entity is new or not. */
+  get #new(): Operation | undefined {
+    const value = this.#flags & 0b11;
+    return value === 0 ? undefined : value;
+  }
+
+  set #new(op: Operation | undefined) {
+    this.#flags = (this.#flags & ~0b11) | (op ?? 0);
+  }
+
   /**
    * Whether our entity has been deleted or not.
    *
@@ -29,15 +47,23 @@ export class InstanceData {
    * - `flushed` means we've flushed a `DELETE` but `em.flush` hasn't fully completed yet, likely due to AsyncReactiveField calcs
    * - `deleted` means we've been flushed and `em.flush` has completed
    */
-  #deleted?: Operation;
-  /** Whether our entity is new or not. */
-  #new?: Operation;
-  /** The `a#1`, `a#2` index if we're an em.create-d entity. We never unset this, to keep ids stable across flushes. */
-  createId: string | undefined;
-  /** The zero-based order this entity was registered with its EntityManager. */
-  entityIndex: number = -1;
+  get #deleted(): Operation | undefined {
+    const value = (this.#flags >> 2) & 0b11;
+    return value === 0 ? undefined : value;
+  }
+
+  set #deleted(op: Operation | undefined) {
+    this.#flags = (this.#flags & ~0b1100) | ((op ?? 0) << 2);
+  }
+
   /** Whether our entity should flush regardless of any other changes. */
-  isTouched: boolean = false;
+  get isTouched(): boolean {
+    return (this.#flags & 0b10000) !== 0;
+  }
+
+  set isTouched(value: boolean) {
+    this.#flags = value ? this.#flags | 0b10000 : this.#flags & ~0b10000;
+  }
 
   /** Creates the `#orm` field. */
   constructor(em: EntityManager, entity: Entity, metadata: EntityMetadata, isNew: boolean) {
@@ -65,8 +91,8 @@ export class InstanceData {
   }
 
   resetAfterFlushed() {
-    this.originalData = {};
-    for (const fieldName of Object.keys(this.referenceHistory)) delete this.referenceHistory[fieldName];
+    this.#originalData = undefined;
+    this.#referenceHistory = undefined;
     this.flushedData = undefined;
     this.isTouched = false;
     if (this.#new === Operation.Pending || this.#new === Operation.Flushed) {
@@ -88,9 +114,14 @@ export class InstanceData {
     return this.#deleted !== undefined;
   }
 
+  /** The original values of mutated fields; a shared empty object until the entity is actually mutated. */
+  get originalData(): Record<any, any> {
+    return this.#originalData ?? emptyObject;
+  }
+
   /** Our public-facing `isDirtyEntity`. */
   get isDirtyEntity(): boolean {
-    return Object.keys(this.originalData).length > 0;
+    return hasAnyKey(this.#originalData);
   }
 
   /** This is our internal "is pending flush", which is aware of RQF micro-flush loops. */
@@ -109,14 +140,19 @@ export class InstanceData {
       // Per ^, if `#new === flushed`, we fall through to check if micro-flush UPDATEs are required
       return "insert";
     } else if (this.flushedData) {
-      return Object.keys(this.flushedData).length > 0 ? "update" : "none";
+      return hasAnyKey(this.flushedData) ? "update" : "none";
     } else {
-      return this.isTouched || Object.keys(this.originalData).length > 0 ? "update" : "none";
+      return this.isTouched || hasAnyKey(this.#originalData) ? "update" : "none";
     }
   }
 
   get changedFields(): string[] {
-    return this.flushedData ? Object.keys(this.flushedData) : Object.keys(this.originalData);
+    return Object.keys(this.changedData);
+  }
+
+  /** The changed-fields bag (flushedData during RQF loops, else originalData) without allocating a keys array. */
+  get changedData(): Record<any, any> {
+    return this.flushedData ?? this.#originalData ?? emptyObject;
   }
 
   /** Called when an `em.load` tries to find the entity and it's just gone from the db. */
@@ -166,13 +202,13 @@ export class InstanceData {
 
   /** Marks a field as dirty with its pre-mutation value. */
   markFieldDirty(fieldName: string, value: any): void {
-    this.originalData[fieldName] = value;
+    (this.#originalData ??= {})[fieldName] = value;
     this.markMaybePending();
   }
 
   /** Marks a reverted field as clean again. */
   markFieldClean(fieldName: string): void {
-    delete this.originalData[fieldName];
+    if (this.#originalData) delete this.#originalData[fieldName];
     this.markMaybePending();
   }
 
@@ -189,13 +225,13 @@ export class InstanceData {
   /** Remembers a reference value that may need to be reverse-walked later. */
   rememberReferenceValue(fieldName: string, value: any): void {
     if (value === undefined) return;
-    const values = (this.referenceHistory[fieldName] ??= []);
+    const values = ((this.#referenceHistory ??= {})[fieldName] ??= []);
     if (!values.includes(value)) values.push(value);
   }
 
   /** Returns reference values that may need to be reverse-walked later. */
   getReferenceHistory(fieldName: string): readonly any[] {
-    return this.referenceHistory[fieldName] ?? [];
+    return this.#referenceHistory?.[fieldName] ?? emptyArray;
   }
 
   get isDeletedAndFlushed(): boolean {
@@ -226,3 +262,9 @@ enum Operation {
   Flushed = 2,
   Complete = 3,
 }
+
+/** A shared frozen bag for un-mutated entities; strict mode makes accidental writes throw. */
+const emptyObject: Record<any, any> = Object.freeze({});
+
+/** A shared frozen array for fields with no remembered reference values. */
+const emptyArray: readonly any[] = Object.freeze([]);

--- a/packages/core/src/ReactionsManager.ts
+++ b/packages/core/src/ReactionsManager.ts
@@ -59,7 +59,6 @@ export class ReactionsManager {
       //   its `.load()` called again so that it's `setField` marks `initials` as
       //   dirty, otherwise it will be left out of any INSERTs/UPDATEs.
       this.getPending(r).todo.add(entity);
-      this.getDirtyFields(getMetadata(r.cstr)).add(r.name);
       this.#needsRecalc[r.kind] = true;
       this.logger.logQueued(entity, fieldName, r);
     }
@@ -94,7 +93,6 @@ export class ReactionsManager {
   queueAllDownstreamFields(entity: Entity, reason: "created" | "deleted"): void {
     for (const r of this.getReactables(entity)) {
       this.getPending(r).todo.add(entity);
-      this.getDirtyFields(getMetadata(r.cstr)).add(r.name);
       this.#needsRecalc[r.kind] = true;
       this.logger.logQueuedAll(entity, reason, r);
     }
@@ -296,6 +294,9 @@ export class ReactionsManager {
     if (!pending) {
       pending = { todo: new Set(), done: new Set() };
       this.pendingReactables.set(r, pending);
+      // The dirty field name is constant per reactable, so mark it once on the first
+      // queue instead of paying the `getMetadata` + map lookup on every queued entity.
+      this.getDirtyFields(getMetadata(r.cstr)).add(r.name);
     }
     return pending;
   }
@@ -316,14 +317,18 @@ export class ReactionsManager {
     return getEmInternalApi(this.em).isMerging(entity) ? meta.reactablesIncludingReadOnly! : meta.reactables!;
   }
 
-  private getReactablesByField(entity: Entity, fieldName: string): Reactable[] {
+  private getReactablesByField(entity: Entity, fieldName: string): readonly Reactable[] {
     const meta = getMetadata(entity);
     const byField = getEmInternalApi(this.em).isMerging(entity)
       ? meta.reactablesIncludingReadOnlyByField!
       : meta.reactablesByField!;
-    return byField.get(fieldName) ?? [];
+    // Most fields have no reactables, so return a shared empty array instead of allocating one per set
+    return byField.get(fieldName) ?? noReactables;
   }
 }
+
+/** A shared frozen array for fields with no downstream reactables. */
+const noReactables: readonly Reactable[] = Object.freeze([]);
 
 /** Returns a stable dedupe key for retry/runOnce reaction bookkeeping. */
 function makeActionKey(entity: Entity, r: Reactable): string {

--- a/packages/core/src/Todo.ts
+++ b/packages/core/src/Todo.ts
@@ -9,13 +9,20 @@ import { groupBy } from "./utils";
 export class Todo {
   /** Groups `todos` by their base/subtype, currently only inserts. */
   static groupInsertsByTypeAndSubType(todos: Record<string, Todo>): Map<EntityMetadata, Entity[]> {
-    return new Map(
-      Object.values(todos).flatMap((todo) => {
-        return todo.metadata.inheritanceType
-          ? [...groupBy(todo.inserts, (e) => getMetadata(e)).entries()]
-          : ([[todo.metadata, todo.inserts]] as const);
-      }),
-    );
+    const map = new Map<EntityMetadata, Entity[]>();
+    for (const todoKey in todos) {
+      const todo = todos[todoKey];
+      // Skip update/delete-only todos so hook loops don't allocate entries for empty insert lists
+      if (todo.inserts.length === 0) continue;
+      if (todo.metadata.inheritanceType) {
+        for (const [meta, inserts] of groupBy(todo.inserts, (e) => getMetadata(e))) {
+          map.set(meta, inserts);
+        }
+      } else {
+        map.set(todo.metadata, todo.inserts);
+      }
+    }
+    return map;
   }
 
   inserts: Entity[] = [];
@@ -31,7 +38,7 @@ export class Todo {
 /**
  * Scans `entities` for new/updated entities and groups them by type (by base type if applicable).
  */
-export function createTodos(entities: readonly Entity[]): Record<string, Todo> {
+export function createTodos(entities: Iterable<Entity>): Record<string, Todo> {
   const todos: Record<string, Todo> = {};
   for (const entity of entities) {
     const op = getInstanceData(entity).pendingOperation;

--- a/packages/core/src/batchloaders/populateBatchLoader.ts
+++ b/packages/core/src/batchloaders/populateBatchLoader.ts
@@ -99,6 +99,8 @@ export function populateBatchLoader(
 
       for (const [key, tree] of Object.entries(layerNode.hints)) {
         const field = layerMeta?.allFields[key];
+        // Hoist the poly-key parsing out of the per-entity loop; most keys are not poly
+        const isPoly = isPolyHint(key);
         let oneToManyLoader: ReturnType<typeof oneToManyBatchLoader> | undefined;
         let oneToManyPromise: Promise<void> | undefined;
         let manyToManyLoader: ReturnType<typeof manyToManyBatchLoader> | undefined;
@@ -108,12 +110,12 @@ export function populateBatchLoader(
         let manyToOneLoader: ReturnType<typeof loadBatchLoader> | undefined;
         let manyToOnePromise: Promise<void> | undefined;
         for (const entity of tree.entities) {
-          const relation = getRelationFromMaybePolyKey(entity, key);
+          const relation = isPoly ? getRelationFromMaybePolyKey(entity, key) : (entity as any)[key];
           // This happens to let through non-relation hints like 'name' on user, which wasn't intentional,
           // but currently doesn't blow up (somehow), and is depended on by internal tests.
           if (!relation || typeof relation.load !== "function") {
             // We don't want to throw on poly hints, because they're not actually loaded on the entity
-            if (isPolyHint(key)) continue;
+            if (isPoly) continue;
             throw new Error(`Invalid load hint '${key}' on ${entity}`);
           }
 

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -83,6 +83,11 @@ function installMetadataGetters(metas: EntityMetadata[]): void {
     defineLazyGetter(meta, "hasLazyColumns", function buildHasLazyColumns() {
       return meta.lazyFieldNames!.size > 0;
     });
+    defineLazyGetter(meta, "syncDerivedFields", function buildSyncDerivedFields() {
+      return Object.values(meta.allFields)
+        .filter((f) => (f.kind === "primitive" || f.kind === "enum") && f.derived === "sync")
+        .map((f) => f.fieldName);
+    });
   }
 }
 
@@ -277,6 +282,12 @@ function hookUpBaseTypeAndSubTypes(metas: EntityMetadata[]): void {
         }
       });
     }
+  }
+  // Now that base/sub links are complete, cache the hot-path meta arrays that
+  // `getBaseAndSelfMetas`/`getBaseSelfAndSubMetas` would otherwise re-allocate per call.
+  for (const m of metas) {
+    m.baseSelfMetas = [...m.baseTypes, m];
+    m.baseSelfAndSubMetas = [...m.baseTypes, m, ...m.subTypes];
   }
 }
 

--- a/packages/core/src/dataloaders/findDataLoader.ts
+++ b/packages/core/src/dataloaders/findDataLoader.ts
@@ -378,17 +378,6 @@ function findSelectedAliases(expression: string): string[] {
   return [...aliases];
 }
 
-/** Replaces all values with `*` so we can see the generic structure of the query. */
-function stripValues(query: ParsedFindQuery): void {
-  visitConditions(query, {
-    visitCond(c: ColumnCondition) {
-      if ("value" in c.cond) {
-        c.cond.value = "*";
-      }
-    },
-  });
-}
-
 /** Returns [operator, argsTaken, negate], i.e. `["=", 1, false]`. */
 function makeOp(cond: ParsedValueFilter<any>, argsIndex: ArgCounter): [string, boolean] {
   switch (cond.kind) {
@@ -494,13 +483,22 @@ function argsEqual(a: any, b: any): boolean {
 }
 
 export function getBatchKeyFromGenericStructure(meta: EntityMetadata, query: ParsedFindQuery): string {
-  // Clone b/c parseFindQuery does not deep copy complex conditions, i.e. `a.firstName.eq(...)`
-  const clone = structuredClone(query);
-  stripValues(clone);
-  if (meta.stiDiscriminatorValue) {
-    // Include the meta b/c STI queries for different subtypes will look identical
-    (clone as any).meta = meta.type;
-  }
-  // We could use `whereFilterHash` too if it's faster?
-  return JSON.stringify(clone);
+  // Temporarily swap condition values for `*` so we can see the generic structure of the query,
+  // then restore them; this avoids deep-cloning the entire parsed query on every em.find call.
+  // Track values per condition object b/c parseFindQuery does not deep copy complex conditions,
+  // i.e. `a.firstName.eq(...)`, so the same condition instance could appear twice.
+  const saved = new Map<any, any>();
+  visitConditions(query, {
+    visitCond(c: ColumnCondition) {
+      const { cond } = c;
+      if ("value" in cond && !saved.has(cond)) {
+        saved.set(cond, cond.value);
+        cond.value = "*";
+      }
+    },
+  });
+  const structure = JSON.stringify(query);
+  for (const [cond, value] of saved) cond.value = value;
+  // Include the meta b/c STI queries for different subtypes will look identical
+  return meta.stiDiscriminatorValue ? `${structure}|${meta.type}` : structure;
 }

--- a/packages/core/src/drivers/EntityWriter.ts
+++ b/packages/core/src/drivers/EntityWriter.ts
@@ -164,7 +164,7 @@ function addLazyUpdates(ops: Ops, meta: EntityMetadata, entities: Entity[]): voi
   for (const fieldName of meta.lazyFieldNames!) {
     const field = meta.fields[fieldName];
     if (!hasSerde(field)) continue;
-    const changed = entities.filter((e) => getInstanceData(e).changedFields.includes(fieldName));
+    const changed = entities.filter((e) => fieldName in getInstanceData(e).changedData);
     if (changed.length === 0) continue;
     const columns: BindingColumn[] = [idColumn, ...field.serde.columns];
     const columnValues = collectBindings(changed, meta.tableName, columns, undefined);
@@ -177,7 +177,7 @@ function newUpdateOp(meta: EntityMetadata, entities: Entity[]): UpdateOp | undef
   // to always use the same fields, to take advantage of Prepared Statements.
   const changedFields = new Set<string>();
   for (const entity of entities) {
-    for (const fieldName of getInstanceData(entity).changedFields) changedFields.add(fieldName);
+    for (const fieldName in getInstanceData(entity).changedData) changedFields.add(fieldName);
   }
   // Sometimes with derived fields, an instance will be marked as an update, but if the derived field hasn't
   // actually changed, it'll be a noop, so just short-circuit if it looks like that happened. Unless touched.
@@ -295,7 +295,8 @@ function collectBindings(
     const column = columns[columnIndex];
     const columnValues: any[] = new Array(entityCount);
     for (let entityIndex = 0; entityIndex < entityCount; entityIndex++) {
-      columnValues[entityIndex] = column.dbValue(entityData[entityIndex], entities[entityIndex], tableName, fixups) ?? null;
+      columnValues[entityIndex] =
+        column.dbValue(entityData[entityIndex], entities[entityIndex], tableName, fixups) ?? null;
     }
     bindings[columnIndex] = columnValues;
   }

--- a/packages/core/src/newEntity.ts
+++ b/packages/core/src/newEntity.ts
@@ -3,7 +3,7 @@ import { Entity } from "./Entity";
 import { EntityConstructor, EntityManager } from "./EntityManager";
 import { EntityMetadata, getMetadata } from "./EntityMetadata";
 import { getLazyFields } from "./getProperties";
-import { fail } from "./utils";
+import { fail, hasAnyKey } from "./utils";
 
 // Marks a constructor like Author has having had our relation getters installed
 const lazySymbol = Symbol("lazy");
@@ -38,7 +38,7 @@ function moveRelationsToGetters(cstr: EntityConstructor<any>): void {
     if (value instanceof LazyRelation) {
       Object.defineProperty(cstr.prototype, fieldName, {
         get(this: any) {
-          return (this.__data.relations[fieldName] ??= value.create(this, fieldName));
+          return ((this.__data.relations ??= {})[fieldName] ??= value.create(this, fieldName));
         },
       });
     } else if (fieldName === "transientFields") {
@@ -46,6 +46,8 @@ function moveRelationsToGetters(cstr: EntityConstructor<any>): void {
       transientFieldsValue = value;
     }
   }
+  // Most entities have no transientFields, so skip the structuredClone for the empty default
+  const needsClone = hasAnyKey(transientFieldsValue);
   Object.defineProperty(cstr.prototype, "transientFields", {
     get(this: any) {
       // This prototype-level `get` will only ever be called once per instance, b/c when we're
@@ -54,7 +56,7 @@ function moveRelationsToGetters(cstr: EntityConstructor<any>): void {
       //
       // This has the pleasant upshot of making the instance-level `transientFields` lazy, and
       // they will not be created on an instance until they're actually asked for.
-      const copy = structuredClone(transientFieldsValue);
+      const copy = needsClone ? structuredClone(transientFieldsValue) : {};
       Object.defineProperty(this, "transientFields", { value: copy });
       return copy;
     },

--- a/packages/core/src/relations/ReactiveManyToMany.ts
+++ b/packages/core/src/relations/ReactiveManyToMany.ts
@@ -65,7 +65,7 @@ export class ReactiveManyToManyImpl<T extends Entity, U extends Entity, H extend
   ) {
     super(entity);
     this.#field = field;
-    getInstanceData(entity).relations[this.fieldName] = this;
+    (getInstanceData(entity).relations ??= {})[this.fieldName] = this;
   }
 
   async load(opts?: { withDeleted?: boolean; forceReload?: boolean }): Promise<ReadonlyArray<U>> {

--- a/packages/core/src/relations/ReactiveManyToManyOtherSide.ts
+++ b/packages/core/src/relations/ReactiveManyToManyOtherSide.ts
@@ -51,7 +51,7 @@ export class ReactiveManyToManyOtherSideImpl<T extends Entity, U extends Entity>
   constructor(entity: T, field: ManyToManyField) {
     super(entity);
     this.#field = field;
-    getInstanceData(entity).relations[field.fieldName] = this;
+    (getInstanceData(entity).relations ??= {})[field.fieldName] = this;
   }
 
   async load(opts?: { withDeleted?: boolean; forceReload?: boolean }): Promise<readonly U[]> {

--- a/packages/core/src/relations/ReactiveReference.ts
+++ b/packages/core/src/relations/ReactiveReference.ts
@@ -134,7 +134,7 @@ export class ReactiveReferenceImpl<
     }
     // If the property transformer is not enabled, then the RR will not be in the relations map because they are
     // defined in the implementation file and not the codegen file.  So we should insert ourselves regardless.
-    getInstanceData(entity).relations[field.fieldName] = this;
+    (getInstanceData(entity).relations ??= {})[field.fieldName] = this;
   }
 
   async load(opts?: { withDeleted?: boolean; forceReload?: true }): Promise<U | N> {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -67,6 +67,12 @@ export function tryResolve<T>(fn: () => T): Promise<T> {
   }
 }
 
+/** Returns whether `obj` has at least one key, without allocating a keys array. */
+export function hasAnyKey(obj: Record<any, any> | undefined): boolean {
+  for (const _ in obj) return true;
+  return false;
+}
+
 export function fail(message?: string): never {
   throw new Error(message || "Failed");
 }

--- a/packages/tests/integration/BENCHMARK-PLAN.md
+++ b/packages/tests/integration/BENCHMARK-PLAN.md
@@ -513,3 +513,141 @@ PLUGINS= BENCH_SIZES=1000 BENCH_ITERATIONS=5 BENCH_WARMUPS=1 BENCH_REPEAT=100 NO
 - Follow-up benchmark commands used the same integration harness shape as Appendix A, with `BENCH_SIZES=100000` and Node `v25.9.0`.
 - After resetting and migrating the integration DB, `PLUGINS= yarn jest --runInBand -- src/IndexManager.test.ts src/relations/ReactiveField.test.ts src/ReactionLogging.test.ts` passed.
 - The retained follow-ups intentionally avoid changing SQL shape, public API behavior, or reactive scheduling semantics.
+
+## Appendix C: Heap-Allocation / GC-Pressure Pass (2026-07-21)
+
+This pass targeted transient allocations and per-entity retained memory, with the twin goals of
+overall throughput (+10-20%) and making ~1M-entity EntityManagers viable. All numbers are from
+Node `v26.3.1` with `--expose-gc`; fresh baselines were captured first (the Appendix A/B numbers
+were from Node `v25.9.0` and are not comparable). Each comparison below is baseline vs the full
+pass (3 runs per side unless noted), via direct `node --import tsx` invocations.
+
+### Motivating evidence
+
+CPU profiles of the baseline benchmarks showed GC itself was the dominant or co-dominant cost:
+38.8% of `benchmark-flush-entity-scanning`, 24.3% of `benchmark-field-mutation`, 19.2% of
+`benchmark-hydration-registration`, and 15.7% of `benchmark-reactive-recalc` total time was
+`(garbage collector)`. The top non-GC frames were `queueAllDownstreamFields` (43.8% self in the
+reactive benchmark), `queueDownstreamReactables` (28.7% self in field-mutation), and
+`structuredClone` (2.6-9.7% across flush/reactive), which drove the change list below.
+
+Note: `--heap-prof` was tried first and is not usable for this work — V8's sampling heap profile
+only reports objects still live at process exit, so transient garbage never appears in it.
+
+### Changes kept
+
+Per-entity retained memory (the 1M-entity goal):
+
+1. `InstanceData` no longer eagerly allocates its three bags: `relations`, `originalData`, and
+   `referenceHistory` are now `undefined` until first relation access / first mutation / first
+   m2o change, with shared frozen empties behind the public `originalData`/`getReferenceHistory`
+   reads. Clean read-only entities allocate zero bags.
+2. `InstanceData`'s `#new`/`#deleted` operations and `isTouched` are packed into one `#flags`
+   bitfield (private accessors), dropping two slots per entity.
+3. `hydrate` seeds `data.id` with the same tagged-id string used as the identity-map key, so the
+   id serde never runs and the second `"a:1"` string is never allocated; the overwrite/refresh
+   path skips the immutable `id` key and, for existing entities, reads changed fields from
+   `originalData` directly instead of allocating a `changes` proxy per row.
+
+Transient-allocation cuts on the write path:
+
+4. `ReactionsManager.getReactablesByField` returns a shared frozen empty array (was: fresh `[]`
+   per `setField` on any field with no reactables), and the constant-per-reactable
+   `getDirtyFields(getMetadata(r.cstr)).add(r.name)` moved from per-queued-entity into
+   `getPending`'s create-once branch.
+5. `getBaseAndSelfMetas`/`getBaseSelfAndSubMetas` return arrays cached on the metadata by
+   `configureMetadata` (after base/sub linking), instead of `[...baseTypes, meta, ...subTypes]`
+   per call.
+6. Hook dispatch: `runHookOnTodos` skips todos whose base/self/sub hierarchy has no functions for
+   the hook (`metaHasHook`), and `runHook` builds one flat promise list imperatively with no
+   per-entity flatMap arrays, skipping `Promise.allSettled` entirely when nothing runs.
+7. `validateReactiveRules` probes `field in originalData` per rule field instead of allocating a
+   `changes` proxy + keys array per updated entity per rule, and skips the todo's entity spread
+   for rule-less types; `validateSimpleRules` is imperative with the same early-exit;
+   `recalcSynchronousDerivedFields` uses a `meta.syncDerivedFields` list cached in `configure.ts`
+   instead of rebuilding a map every hook loop; `entitiesFromTodos` drops its array spreads.
+8. `Todo.groupInsertsByTypeAndSubType` skips update/delete-only todos and builds its map without
+   flatMap tuples; `createTodos` accepts `Iterable<Entity>` so the flush loop passes its
+   `pendingHooks`/`alreadyRanHooks` sets without `[...set]` copies.
+9. `EntityWriter` iterates a new non-allocating `InstanceData.changedData` bag (`for..in`)
+   instead of materializing `changedFields` arrays per update entity; `newEntity` skips the
+   `structuredClone` for the common empty `transientFields`.
+
+Read-path cuts:
+
+10. `loadAll`/`loadAllIfExists` drop the N-length tagged-ids copy; misses remember their id +
+    position, so the all-hit path allocates exactly one pre-sized result array.
+11. `IndexManager.findMatching` returns the raw candidate set and `filterEntities` builds the
+    final array in one pass (was: `[...candidates]` then a second `.filter` array).
+12. `findDataLoader.getBatchKeyFromGenericStructure` no longer `structuredClone`s the parsed
+    query per `em.find`; it strips condition values in place (tracking shared condition objects),
+    stringifies, and restores.
+13. `populateBatchLoader` hoists the per-key `isPolyHint` check out of the per-entity loop.
+
+### Results (baseline vs full pass, `BENCH_SIZES=100000`)
+
+| Benchmark | Scenario | Before (ms) | After (ms) | Delta | Notes |
+| --- | --- | ---: | ---: | ---: | --- |
+| hydration | `author_fresh_register` | 67.6 | 53.9 | +20.3% | retained 42.0 -> 27.4 MB (-35%) |
+| hydration | `author_fresh_register_scalar_reads` | 134.2 | 112.8 | +15.9% | retained 47.3 -> 30.6 MB |
+| hydration | `author_existing_no_overwrite` | 89.9 | 83.4 | +7.2% | |
+| hydration | `author_existing_overwrite_warm_data` | 203.2 | 170.0 | +16.3% | |
+| hydration | `task_sti_fresh_register` | 74.1 | 61.6 | +16.8% | retained 42.7 -> 28.1 MB |
+| loadall | `load_all_hits_tagged` | 13.7 | 12.3 | +10.4% | untagged +7.7% |
+| loadall | `load_all_if_exists_hits_untagged` | 21.5 | 19.5 | +9.5% | tagged +8.7% |
+| flush | `flush_dirty_100_validation` | 5.48 | 5.05 | +7.8% | skip_validation +7.8% |
+| flush | `flush_dirty_10000_validation` | 404.3 | 387.1 | +4.2% | skip_validation +2.6% |
+| field-mutation | `field_primitive_actual_change` | 116.7 | 88.5 | +24.1% | |
+| field-mutation | `field_primitive_indexed_change` | 203.4 | 166.9 | +17.9% | |
+| field-mutation | `field_m2o_entity_change` | 321.7 | 255.7 | +20.5% | id variant +21.4% |
+| reactive | `reactive_queue_created_all_downstream` | 1059.7 | 587.2 | +44.6% | |
+| reactive | `reactive_queue_deleted_all_downstream` | 1048.5 | 595.8 | +43.2% | |
+| reactive | `reactive_recalc_one_reaction` | 369.2 | 353.7 | +4.2% | multiple_downstream +1.6% |
+| find-indexing | `find_index_relation_value_steady_state` | 11.7 | 8.8 | +25.0% | first_build +7.7% |
+| find-query-prep | `find_query_prep_one_field` (1000) | 16.7 | 11.2 | +33.0% | all sizes +13-33% |
+| populate (direct) | `populate_books_reviews` | 214.1 | 204.2 | +4.7% | queries unchanged |
+| populate (preload) | `populate_books_reviews_already_loaded` | 17.0 | 13.5 | +20.7% | queries unchanged |
+| todo | all scenarios | - | - | ~0% | neutral, within noise |
+
+Known trade-off: `reactive_queue_no_reactables` (mutate a reactable-less field on 100k clean
+entities) reads ~40% slower in isolation because the lazy `originalData` bag is now allocated in
+the measured mutation loop instead of during (unmeasured) hydration setup. End-to-end the work
+went down: hydration of the same 100k entities got ~14ms faster while the first-mutation pass got
+~8ms slower, and read-only entities never pay the allocation at all. The sub-millisecond
+`find_index_*_steady_state` scenarios showed -12-18% readings at RSD 20-30%, i.e. noise.
+
+### 1M-entity scale (`benchmark-em-million.ts`, new)
+
+The new `benchmark-em-million.ts` hydrates 1M Author rows into a single EntityManager and reports
+wall/cpu time, GC pause counts/totals (via a `PerformanceObserver`), and retained bytes/entity
+after a forced GC. With the pass applied (Node `--max-old-space-size=8192`):
+
+| Scenario | Size | Mean (ms) | GC pauses (ms) | Retained (MB) | Retained B/entity |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `million_hydrate` | 1,000,000 | 832 | 189 | 285.5 | 299 |
+| `million_hydrate_scalar_reads` | 1,000,000 | 987 | 189 | 285.5 | 299 |
+| `million_hydrate_mutate` | 1,000,000 | 2,630 | 255 | 568.3 | 596 |
+
+I.e. hydrating 1M entities into one EntityManager runs at ~1.2M entities/sec with under 200ms of
+total GC pauses, and the identity map holds them in ~285 MB.
+
+Per the hydration benchmark's 3-run averages, per-entity retained cost dropped from ~440 B to
+~290 B (-35%), i.e. a 1M-entity identity map went from ~440 MB to ~290 MB of entity-side heap
+(excluding the driver rows themselves).
+
+Harness note: measuring retained heap inside the async timing loop double-counts nothing but can
+*under*-count to ~0, because dead-but-uncleared V8 frame registers pin the previous iteration's
+result across `await`s; `benchmark-em-million.ts` measures retained heap in a dedicated
+synchronous function so any such pin is constant on both sides of the delta.
+
+### Verification
+
+- `yarn build` (tsc) clean; `packages/core` unit tests pass.
+- Full integration suite passes under both plugins configs: `PLUGINS=` and
+  `PLUGINS=join-preloading`, each 161 suites / 1902 tests passed (7 suites skipped).
+- Populate/find benchmark query counts are unchanged in every scenario.
+- `benchmark-entity-writer.ts` was also repaired in this pass: the synthetic metadata predated
+  the lazy-fields feature (`meta.lazyFieldNames` undefined crashed all update scenarios), and its
+  fake `InstanceData` now shadows the new `originalData`/`changedData`/`changedFields`/`isTouched`
+  prototype accessors, since `Object.create(InstanceData.prototype)` instances have no private
+  fields.

--- a/packages/tests/integration/benchmark-em-million.ts
+++ b/packages/tests/integration/benchmark-em-million.ts
@@ -1,0 +1,270 @@
+import { setDefaultEntityLimit, type Entity } from "joist-orm";
+import { performance, PerformanceObserver } from "node:perf_hooks";
+import { Author, type EntityManager } from "./src/entities";
+import { newEntityManager, testDriver } from "./src/testEm";
+
+type Row = Record<string, unknown>;
+
+interface ScenarioResult {
+  checksum: number;
+  em: EntityManager;
+  entities: Entity[];
+}
+
+interface Scenario {
+  name: string;
+  run(rows: readonly Row[]): ScenarioResult;
+}
+
+interface Sample {
+  cpuMs: number;
+  gcCount: number;
+  gcPauseMs: number;
+  wallMs: number;
+}
+
+interface BenchmarkConfig {
+  iterations: number;
+  size: number;
+  warmups: number;
+}
+
+let blackhole = 0;
+let heldResult: ScenarioResult | undefined;
+let gcCount = 0;
+let gcPauseMs = 0;
+const graduated = new Date("2020-01-01T00:00:00.000Z");
+const createdAt = new Date("2020-01-01T00:00:00.000Z");
+const updatedAt = new Date("2020-01-02T00:00:00.000Z");
+
+/**
+ * Benchmarks EntityManager viability at ~1M entities.
+ *
+ * Reports wall/cpu time plus GC pause totals during each run and the retained
+ * heap per entity after a forced GC, i.e. the long-term cost of holding a huge
+ * identity map. Run with NODE_OPTIONS="--expose-gc --max-old-space-size=8192".
+ */
+async function main(): Promise<void> {
+  const sizes = readSizes();
+  setDefaultEntityLimit(Math.max(...sizes) + 1_000);
+  observeGc();
+  console.log(`node=${process.version} exposeGc=${typeof global.gc === "function"}`);
+  console.log(
+    "scenario,size,iterations,mean_ms,min_ms,max_ms,rsd,cpu_mean_ms,gc_count,gc_pause_ms,retained_mb,retained_bytes_per_entity",
+  );
+
+  for (const size of sizes) {
+    const rows = makeAuthorRows(size);
+    const config = configForSize(size);
+    await runScenario(hydrate(), rows, config);
+    await runScenario(hydrateWithScalarReads(), rows, config);
+    await runScenario(hydrateThenMutate(), rows, config);
+  }
+
+  // Prevent overly-aggressive dead-code elimination in alternate JS runtimes.
+  if (blackhole === Number.MIN_SAFE_INTEGER) console.log(blackhole);
+  await testDriver.destroy();
+}
+
+/** Returns the sizes to benchmark, allowing BENCH_SIZES=250000,1000000 overrides. */
+function readSizes(): number[] {
+  const input = process.env.BENCH_SIZES;
+  if (!input) return [1_000_000];
+  return input.split(",").map((value) => Number(value.trim()));
+}
+
+/** Returns iteration counts that keep 1M-entity runs practical. */
+function configForSize(size: number): BenchmarkConfig {
+  if (size >= 500_000) return { iterations: 4, size, warmups: 1 };
+  return { iterations: 6, size, warmups: 2 };
+}
+
+/** Measures one scenario after warmup and prints a CSV row with GC and retained-heap stats. */
+async function runScenario(scenario: Scenario, rows: readonly Row[], config: BenchmarkConfig): Promise<void> {
+  for (let i = 0; i < config.warmups; i++) {
+    consume(scenario.run(rows));
+    forceGc();
+  }
+
+  const samples: Sample[] = [];
+  for (let i = 0; i < config.iterations; i++) {
+    forceGc();
+    await drainGcObserver();
+    const gcCountBefore = gcCount;
+    const gcPauseBefore = gcPauseMs;
+    const cpuBefore = process.cpuUsage();
+    const start = performance.now();
+    heldResult = scenario.run(rows);
+    const wallMs = performance.now() - start;
+    const cpu = process.cpuUsage(cpuBefore);
+    await drainGcObserver();
+    const sampleGcCount = gcCount - gcCountBefore;
+    const sampleGcPauseMs = gcPauseMs - gcPauseBefore;
+    consume(heldResult);
+    heldResult = undefined;
+    samples.push({
+      cpuMs: (cpu.user + cpu.system) / 1_000,
+      gcCount: sampleGcCount,
+      gcPauseMs: sampleGcPauseMs,
+      wallMs,
+    });
+    forceGc();
+  }
+
+  // Measure retained heap in its own synchronous frame: dead-but-uncleared V8 frame registers
+  // in this async fn can pin the previous iteration's result, which corrupts before/after deltas
+  // taken here; inside a fresh frame any such pin is constant on both sides of the measurement.
+  const retainedMb = measureRetainedMb(scenario, rows);
+
+  const wall = samples.map((sample) => sample.wallMs).sort((a, b) => a - b);
+  const meanMs = mean(wall);
+  console.log(
+    [
+      scenario.name,
+      config.size,
+      config.iterations,
+      fmt(meanMs),
+      fmt(wall[0]),
+      fmt(wall[wall.length - 1]),
+      fmt(standardDeviation(wall, meanMs) / meanMs),
+      fmt(mean(samples.map((sample) => sample.cpuMs))),
+      fmt(mean(samples.map((sample) => sample.gcCount))),
+      fmt(mean(samples.map((sample) => sample.gcPauseMs))),
+      fmt(retainedMb),
+      fmt((retainedMb * 1024 * 1024) / config.size),
+    ].join(","),
+  );
+}
+
+/** Hydrates Authors into a fresh EntityManager without touching scalar fields. */
+function hydrate(): Scenario {
+  return {
+    name: "million_hydrate",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      const entities = em.hydrate(Author, rows);
+      return { checksum: entities.length, em, entities };
+    },
+  };
+}
+
+/** Hydrates Authors and reads common scalars, forcing lazy serde into InstanceData.data. */
+function hydrateWithScalarReads(): Scenario {
+  return {
+    name: "million_hydrate_scalar_reads",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      const entities = em.hydrate(Author, rows);
+      let checksum = 0;
+      for (const author of entities) {
+        checksum += author.firstName.length;
+        checksum += author.age ?? 0;
+        checksum += author.isFunny ? 1 : 0;
+      }
+      return { checksum, em, entities };
+    },
+  };
+}
+
+/** Hydrates Authors then mutates one field on every entity, exercising dirty tracking at scale. */
+function hydrateThenMutate(): Scenario {
+  return {
+    name: "million_hydrate_mutate",
+    run(rows: readonly Row[]): ScenarioResult {
+      const em = newEntityManager();
+      const entities = em.hydrate(Author, rows);
+      for (const author of entities) author.firstName = `changed${author.age}`;
+      return { checksum: entities.length, em, entities };
+    },
+  };
+}
+
+/** Creates Author rows with the same shape as the hydration benchmark. */
+function makeAuthorRows(size: number): Row[] {
+  const rows = new Array<Row>(size);
+  for (let i = 0; i < size; i++) {
+    rows[i] = {
+      id: i + 1,
+      first_name: `first${i}`,
+      last_name: `last${i}`,
+      ssn: `ssn${i}`,
+      initials: "fl",
+      number_of_books: i % 17,
+      is_popular: i % 2 === 0,
+      age: 20 + (i % 60),
+      graduated,
+      nick_names: [`nick${i}`],
+      is_funny: i % 3 === 0,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    };
+  }
+  return rows;
+}
+
+/** Runs `scenario` once and returns the post-GC heap growth while holding its result. */
+function measureRetainedMb(scenario: Scenario, rows: readonly Row[]): number {
+  forceGc();
+  const heapBefore = process.memoryUsage().heapUsed;
+  let result: ScenarioResult | undefined = scenario.run(rows);
+  forceGc();
+  const heapAfter = process.memoryUsage().heapUsed;
+  consume(result);
+  result = undefined;
+  forceGc();
+  return (heapAfter - heapBefore) / 1024 / 1024;
+}
+
+/** Accumulates GC pause counts/durations reported by the performance observer. */
+function observeGc(): void {
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      gcCount += 1;
+      gcPauseMs += entry.duration;
+    }
+  });
+  observer.observe({ entryTypes: ["gc"] });
+}
+
+/** Waits for pending GC performance entries to be delivered to the observer. */
+async function drainGcObserver(): Promise<void> {
+  await new Promise<void>(resolveImmediate);
+  await new Promise<void>(resolveImmediate);
+}
+
+/** Returns the arithmetic mean. */
+function mean(values: readonly number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+/** Returns the population standard deviation. */
+function standardDeviation(values: readonly number[], meanValue: number): number {
+  const variance = mean(values.map((value) => (value - meanValue) ** 2));
+  return Math.sqrt(variance);
+}
+
+/** Keeps benchmark results observable until after retained heap is measured. */
+function consume(result: ScenarioResult): void {
+  blackhole += result.checksum + result.em.numberOfEntities + result.entities.length;
+}
+
+/** Runs a full GC when node was started with --expose-gc. */
+function forceGc(): void {
+  global.gc?.();
+}
+
+/** Resolves on the next immediate tick. */
+function resolveImmediate(resolve: () => void): void {
+  setImmediate(resolve);
+}
+
+/** Formats numeric CSV fields. */
+function fmt(value: number): string {
+  return value.toFixed(3);
+}
+
+main().catch(async (error: unknown) => {
+  console.error(error);
+  await testDriver.destroy();
+  process.exitCode = 1;
+});

--- a/packages/tests/integration/benchmark-entity-writer.ts
+++ b/packages/tests/integration/benchmark-entity-writer.ts
@@ -65,7 +65,9 @@ let heldResult: ScenarioResult | undefined;
 async function main(): Promise<void> {
   const sizes = readSizes();
   console.log(`node=${process.version} exposeGc=${typeof global.gc === "function"}`);
-  console.log("scenario,size,columns,iterations,mean_ms,p50_ms,p90_ms,p99_ms,min_ms,max_ms,rsd,cpu_mean_ms,heap_delta_mb");
+  console.log(
+    "scenario,size,columns,iterations,mean_ms,p50_ms,p90_ms,p99_ms,min_ms,max_ms,rsd,cpu_mean_ms,heap_delta_mb",
+  );
 
   for (const size of sizes) {
     const config = configForSize(size);
@@ -218,6 +220,7 @@ function makeMetadata(columnCount: number): SyntheticEntityMetadata {
     baseTypes: [],
     fields,
     inheritanceType: undefined,
+    lazyFieldNames: new Set<string>(),
     nonDeferredFkOrder: 0,
     subTypes: [],
     tableName: "synthetic_entities",
@@ -283,10 +286,13 @@ function changedFieldsFor(
 function makeEntity(meta: EntityMetadata, data: Record<string, number>, changedFields: string[]): Entity {
   const instanceData = Object.create(InstanceData.prototype) as SyntheticData;
   instanceData.data = data;
-  instanceData.originalData = {};
-  instanceData.isTouched = false;
-  for (const fieldName of changedFields) instanceData.originalData[fieldName] = data[fieldName] - 1;
+  const originalData: Record<string, number> = {};
+  for (const fieldName of changedFields) originalData[fieldName] = data[fieldName] - 1;
+  // Shadow the prototype getters, since this fake instance skips the constructor (and its private fields)
+  Object.defineProperty(instanceData, "originalData", { value: originalData });
+  Object.defineProperty(instanceData, "changedData", { value: originalData });
   Object.defineProperty(instanceData, "changedFields", { get: readChangedFields });
+  Object.defineProperty(instanceData, "isTouched", { value: false });
   Object.defineProperty(instanceData, "metadata", { value: meta });
 
   const entity = {} as SyntheticEntity;
@@ -370,7 +376,8 @@ function fmt(value: number): string {
 
 /** Keeps benchmark results observable across samples. */
 function consume(result: ScenarioResult): void {
-  blackhole += result.checksum + getInstanceData(result.context.todo.inserts[0] ?? result.context.todo.updates[0]).data.id;
+  blackhole +=
+    result.checksum + getInstanceData(result.context.todo.inserts[0] ?? result.context.todo.updates[0]).data.id;
 }
 
 /** Forces GC when the benchmark was launched with node --expose-gc. */

--- a/packages/tests/integration/src/toMatchEntity.test.ts
+++ b/packages/tests/integration/src/toMatchEntity.test.ts
@@ -340,7 +340,7 @@ describe("toMatchEntity", () => {
     await em.flush();
     // This test assumes that no Author rules loaded `comments` during
     // flush, and so this is the 1st time comments is being accessed
-    expect(Object.keys(getInstanceData(a1).relations)).toEqual(expect.arrayContaining(["comments"]));
+    expect(Object.keys(getInstanceData(a1).relations ?? {})).toEqual(expect.arrayContaining(["comments"]));
     expect(a1).toMatchEntity({ comments: [] });
   });
 


### PR DESCRIPTION
From AI:

<img width="2490" height="940" alt="image" src="https://github.com/user-attachments/assets/f5dc954f-0a4a-4e3a-adef-bc98b6e9b6bc" />


The CPU profiles justified the premise: GC was 19–39% of total time in the baseline benchmarks. The fixes fall into three groups:

Per-entity retained memory:
- InstanceData no longer eagerly allocates its relations/originalData/referenceHistory bags (clean read-only entities allocate zero of them)
- #new/#deleted/isTouched packed into one bitfield
- hydrate seeds data.id with the identity-map's tagged-id string so the id serde and a duplicate string never happen.

Write path:

- shared empty array for no-reactable setFields
- per-reactable dirty-marking hoisted out of the per-entity queue loop (that's the 44% created/deleted win)
- cached getBaseAndSelfMetas arrays
- hook dispatch skips types with no hooks
- reactive-rule triggering probes originalData instead of allocating a changes proxy per entity per rule
- cached sync-derived-field lists
- createTodos(Iterable)
- EntityWriter iterates a non-allocating changedData bag

Read path:

- loadAll/loadAllIfExists all-hit paths allocate a single pre-sized array
- filterEntities builds indexed results in one pass
- getBatchKeyFromGenericStructure no longer structuredClones the whole parsed query per em.find (strip-in-place → stringify → restore).