### PR TITLE
fix: Align em.find soft-delete with relations behavior.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/joist-admin" vcs="Git" />
   </component>
 </project>

--- a/packages/core/src/QueryParser.ts
+++ b/packages/core/src/QueryParser.ts
@@ -250,6 +250,7 @@ export function parseFindQuery(
     return i === 0 ? abbrev : `${abbrev}${i}`;
   }
 
+  /** Adds a `deleted_at IS NULL` condition for `alias`, i.e. for the primary table or a collection join. */
   function addSoftDeleteCondition(meta: EntityMetadata, alias: string, targetCb: ConditionBuilder): void {
     if (filterSoftDeletes(meta, softDeletes)) {
       const column = meta.allFields[getBaseMeta(meta).timestampFields!.deletedAt!].serde?.columns[0]!;
@@ -273,6 +274,8 @@ export function parseFindQuery(
     filter: any,
     fieldName?: string,
     targetCb: ConditionBuilder = cb,
+    /** Whether this table is the "other side" of a collection, i.e. `books` in `em.find(Author, { books: ... })`. */
+    isCollection: boolean = false,
   ): void {
     // look at filter, is it `{ book: "b2" }` or `{ book: { ... } }`
     const scopeFilter = isScope(filter);
@@ -319,7 +322,13 @@ export function parseFindQuery(
       addStiSubtypeFilter(targetCb, meta, alias);
     }
 
-    addSoftDeleteCondition(meta, alias, targetCb);
+    // Only the primary table & collection joins filter soft-deletes, to match the in-memory relation
+    // semantics of "o2m/m2m collections filter out soft-deletes, but m2o/o2o references still return
+    // them". I.e. `book.author.get` returns a soft-deleted author, so `em.find(Book, { author: ... })`
+    // should still match the book, as long as the book itself is not soft-deleted.
+    if (join === "primary" || isCollection) {
+      addSoftDeleteCondition(meta, alias, targetCb);
+    }
 
     // The user's locally declared aliases, i.e. `const [a, b] = aliases(Author, Book)`,
     // aren't guaranteed to line up with the aliases we've assigned internally, like `a`
@@ -419,10 +428,11 @@ export function parseFindQuery(
           );
         }
         const f = parseEntityFilter(field.otherMetadata(), sub);
-        // Probe the filter and see if it's just an id (...and not soft deleted), if so we can avoid the join
+        // Probe the filter and see if it's just an id, if so we can avoid the join; m2os don't need
+        // a join for soft-delete filtering because references don't filter out soft-deletes.
         if (!f) {
           // skip
-        } else if (f.kind === "join" || filterSoftDeletes(field.otherMetadata(), softDeletes)) {
+        } else if (f.kind === "join") {
           const a = getAlias(field.otherMetadata().tableName);
           addTable(
             field.otherMetadata(),
@@ -555,6 +565,7 @@ export function parseFindQuery(
           (subFilter as any)[key],
           field.otherFieldName,
           targetCb,
+          true,
         );
         if (!isCtiBaseFk) {
           const table = tables.find((t) => t.alias === a);
@@ -588,6 +599,7 @@ export function parseFindQuery(
             sub,
             undefined,
             targetCb,
+            true,
           );
           const table = tables.find((t) => t.alias === a);
           if (table && (table.join === "inner" || table.join === "outer")) {

--- a/packages/tests/integration/src/EntityManager.queries.test.ts
+++ b/packages/tests/integration/src/EntityManager.queries.test.ts
@@ -2072,10 +2072,7 @@ describe("EntityManager.queries", () => {
       ],
       condition: {
         op: "and",
-        conditions: [
-          { alias: "b", column: "deleted_at" },
-          { alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "t" } },
-        ],
+        conditions: [{ alias: "b", column: "title", dbType: "character varying", cond: { kind: "eq", value: "t" } }],
       },
       orderBys: [expect.anything()],
     });

--- a/packages/tests/integration/src/EntityManager.softDeletes.test.ts
+++ b/packages/tests/integration/src/EntityManager.softDeletes.test.ts
@@ -146,20 +146,41 @@ describe("EntityManager.softDeletes", () => {
     expect(authors.length).toBe(0);
   });
 
-  it("find ignores soft-deleted entities at end of m2o join", async () => {
+  it("find includes soft-deleted entities at end of m2o join", async () => {
     await insertAuthor({ first_name: "a1", deleted_at: jan1 });
     await insertBook({ author_id: 1, title: "b1" });
     const em = newEntityManager();
+    // The book itself is not soft-deleted, and `book.author.get` would return the soft-deleted
+    // author, so the m2o join should not filter the book out
     const books = await em.find(Book, { author: { firstName: "a1" } });
-    expect(books.length).toBe(0);
+    expect(books).toMatchEntity([{ title: "b1" }]);
   });
 
-  it("find ignores soft-deleted entities at end of m2o without join", async () => {
+  it("find includes soft-deleted entities at end of m2o without join", async () => {
     await insertAuthor({ first_name: "a1", deleted_at: jan1 });
     await insertBook({ author_id: 1, title: "b1" });
     const em = newEntityManager();
     const books = await em.find(Book, { author: "a:1" });
-    expect(books.length).toBe(0);
+    expect(books).toMatchEntity([{ title: "b1" }]);
+  });
+
+  it("find includes soft-deleted entities at end of o2o join", async () => {
+    await insertAuthor({ first_name: "a1", deleted_at: jan1 });
+    await insertBook({ author_id: 1, title: "b1" });
+    await update("authors", { id: 1, favorite_book_id: 1 });
+    const em = newEntityManager();
+    const books = await em.find(Book, { favoriteAuthor: { firstName: "a1" } });
+    expect(books).toMatchEntity([{ title: "b1" }]);
+  });
+
+  it("find ignores soft-deleted entities at end of m2m join", async () => {
+    await insertAuthor({ first_name: "a1" });
+    await insertBook({ title: "b1", author_id: 1, deleted_at: jan1 });
+    await insertTag({ name: "t1" });
+    await insertBookToTag({ book_id: 1, tag_id: 1 });
+    const em = newEntityManager();
+    const tags = await em.find(Tag, { books: { title: "b1" } });
+    expect(tags).toMatchEntity([]);
   });
 
   it("find can return soft-deleted entities", async () => {

--- a/packages/tests/integration/src/QueryParser.quotes.test.ts
+++ b/packages/tests/integration/src/QueryParser.quotes.test.ts
@@ -12,7 +12,6 @@ describe("QueryParser", () => {
         " from books as b",
         " inner join authors as a on b.author_id = a.id",
         " where b.deleted_at IS NULL",
-        " AND a.deleted_at IS NULL",
         " AND a.first_name = ?",
         ' AND EXISTS (select 1 from author_schedules as "as" where a.id = "as".author_id AND "as".id = ?)',
         " order by b.title ASC, b.id ASC",

--- a/packages/tests/integration/src/relations/AsyncReactiveField.test.ts
+++ b/packages/tests/integration/src/relations/AsyncReactiveField.test.ts
@@ -24,7 +24,7 @@ describe("AsyncReactiveField", () => {
        "WITH data AS (SELECT unnest($1::int[]) as id, unnest($2::text[]) as shared_column, unnest($3::text[]) as country) INSERT INTO large_publishers (id, shared_column, country) SELECT * FROM data",
        "WITH data AS (SELECT unnest($1::int[]) as id, unnest($2::character varying[]) as first_name, unnest($3::character varying[]) as last_name, unnest($4::character varying[]) as ssn, unnest($5::character varying[]) as initials, unnest($6::int[]) as number_of_books, unnest($7::text[]) as book_comments, unnest($8::boolean[]) as is_popular, unnest($9::int[]) as age, unnest($10::date[]) as graduated, unnest_arrays($11::character varying[][], true) as nick_names, unnest_arrays($12::character varying[][], true) as nick_names_upper, unnest($13::boolean[]) as was_ever_popular, unnest($14::boolean[]) as is_funny, unnest($15::text[]) as mentor_names, unnest($16::text[]) as mentee_names, unnest($17::jsonb[]) as address, unnest($18::jsonb[]) as business_address, unnest($19::jsonb[]) as quotes, unnest($20::bigint[]) as number_of_atoms, unnest($21::timestamp with time zone[]) as deleted_at, unnest($22::int[]) as number_of_public_reviews, unnest($23::int[]) as "numberOfPublicReviews2", unnest($24::character varying[]) as tags_of_all_books, unnest($25::text[]) as search, unnest($26::text[]) as image_file_name, unnest($27::bytea[]) as certificate, unnest($28::timestamp with time zone[]) as created_at, unnest($29::timestamp with time zone[]) as updated_at, unnest($30::favorite_shape[]) as favorite_shape, unnest($31::int[]) as range_of_books, unnest_arrays($32::int[][], true) as favorite_colors, unnest($33::int[]) as mentor_id, unnest($34::int[]) as root_mentor_id, unnest($35::int[]) as current_draft_book_id, unnest($36::int[]) as favorite_book_id, unnest($37::int[]) as publisher_id) INSERT INTO authors (id, first_name, last_name, ssn, initials, number_of_books, book_comments, is_popular, age, graduated, nick_names, nick_names_upper, was_ever_popular, is_funny, mentor_names, mentee_names, address, business_address, quotes, number_of_atoms, deleted_at, number_of_public_reviews, "numberOfPublicReviews2", tags_of_all_books, search, image_file_name, certificate, created_at, updated_at, favorite_shape, range_of_books, favorite_colors, mentor_id, root_mentor_id, current_draft_book_id, favorite_book_id, publisher_id) SELECT * FROM data",
        "WITH data AS (SELECT unnest($1::int[]) as mentor_id, unnest($2::int[]) as mentee_id) INSERT INTO author_to_mentees_closure (mentor_id, mentee_id) SELECT * FROM data ON CONFLICT (mentor_id, mentee_id) DO UPDATE SET id = author_to_mentees_closure.id RETURNING id;",
-       "SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
+       "SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id WHERE a.publisher_id = $1 LIMIT $2",
        "COMMIT;",
      ]
     `);
@@ -52,7 +52,7 @@ describe("AsyncReactiveField", () => {
        "WITH data AS (SELECT unnest($1::int[]) as id, unnest($2::character varying[]) as title, unnest($3::int[]) as "order", unnest($4::text[]) as notes, unnest($5::text[]) as acknowledgements, unnest($6::text[]) as authors_nick_names, unnest($7::text[]) as search, unnest($8::timestamp with time zone[]) as deleted_at, unnest($9::timestamp with time zone[]) as created_at, unnest($10::timestamp with time zone[]) as updated_at, unnest($11::int[]) as prequel_id, unnest($12::int[]) as author_id, unnest($13::int[]) as reviewer_id, unnest($14::int[]) as random_comment_id) INSERT INTO books (id, title, "order", notes, acknowledgements, authors_nick_names, search, deleted_at, created_at, updated_at, prequel_id, author_id, reviewer_id, random_comment_id) SELECT * FROM data",
        "WITH data AS (SELECT unnest($1::int[]) as id, unnest($2::int[]) as rating, unnest($3::boolean[]) as is_public, unnest($4::boolean[]) as is_test, unnest($5::boolean[]) as is_test_chain, unnest($6::timestamp with time zone[]) as created_at, unnest($7::timestamp with time zone[]) as updated_at, unnest($8::int[]) as book_id, unnest($9::int[]) as critic_id) INSERT INTO book_reviews (id, rating, is_public, is_test, is_test_chain, created_at, updated_at, book_id, critic_id) SELECT * FROM data",
        "WITH data AS (SELECT unnest($1::int[]) as mentor_id, unnest($2::int[]) as mentee_id) INSERT INTO author_to_mentees_closure (mentor_id, mentee_id) SELECT * FROM data ON CONFLICT (mentor_id, mentee_id) DO UPDATE SET id = author_to_mentees_closure.id RETURNING id;",
-       "SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2",
+       "SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id WHERE a.publisher_id = $1 LIMIT $2",
        "WITH data AS (SELECT unnest($1::int[]) as id, unnest($2::int[]) as number_of_book_reviews, unnest($3::timestamp with time zone[]) as updated_at, unnest($4::timestamptz[]) as __original_updated_at) UPDATE publishers SET number_of_book_reviews = data.number_of_book_reviews, updated_at = data.updated_at FROM data WHERE publishers.id = data.id AND date_trunc('milliseconds', publishers.updated_at) = data.__original_updated_at RETURNING publishers.id",
        "COMMIT;",
        "select * from "publishers" order by "id" asc",
@@ -114,9 +114,12 @@ describe("AsyncReactiveField", () => {
       id: 1,
       number_of_book_reviews: 1,
     });
-    expect(queries).toContain(
-      `SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id LEFT OUTER JOIN publishers AS p ON a.publisher_id = p.id WHERE b.deleted_at IS NULL AND a.deleted_at IS NULL AND p.deleted_at IS NULL AND p.id = $1 LIMIT $2`,
-    );
+    // Isolate the RF's count query, b/c the surrounding populate queries differ by preloading plugin
+    expect(queries.filter((q) => q.startsWith("SELECT count"))).toMatchInlineSnapshot(`
+     [
+       "SELECT count(distinct br.id) as count FROM book_reviews AS br JOIN books AS b ON br.book_id = b.id JOIN authors AS a ON b.author_id = a.id WHERE a.publisher_id = $1 LIMIT $2",
+     ]
+    `);
   });
 
   it("can recalc dependent reactive fields", async () => {


### PR DESCRIPTION
One of Joist's soft-delete tenants is that "references _directly to_ a soft-deleted entity" should still be considered valid; the rationale is that, if you _didn't_ want this, you'd probably be hard-deleting the entity and setting the column to null.

So just the fact that you're keeping "a soft-deleted author around _for folks to point at_" means we should allow these pointers to still resolve.

This is what m2o.gets have done for awhile, but the em.find filtering did not match this; if a _live_ Book still pointed to a soft-deleted Author, then filters for that book that said "...and your author is..." would not return.

This caused a production bug where "a live entity but pointing at a soft-deleted entity" em.find didn't hit, which made it look like the live entity itself was not there.

This PR aligns the relation/em.find behavior.